### PR TITLE
Fix CodeQL int32 narrowing alerts in parseBulkExportName

### DIFF
--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -1483,11 +1483,11 @@ func parseBulkExportName(name, prefix string) (int32, int32, bool) {
 			return 0, 0, false
 		}
 	}
-	svc, err := strconv.Atoi(svcStr)
+	svc, err := strconv.ParseInt(svcStr, 10, 32)
 	if err != nil || svc < 0 {
 		return 0, 0, false
 	}
-	mt, err := strconv.Atoi(mtStr)
+	mt, err := strconv.ParseInt(mtStr, 10, 32)
 	if err != nil || mt < 0 {
 		return 0, 0, false
 	}


### PR DESCRIPTION
## Summary

- Resolves the two open CodeQL alerts (`go/incorrect-integer-conversion`, severity: high) reported at https://github.com/goccy/wasm2go/security/code-scanning, both pointing at `internal/codegen/translate.go:1494`.
- Switches `parseBulkExportName` from `strconv.Atoi` to `strconv.ParseInt(s, 10, 32)` so values that overflow `int32` are rejected at parse time instead of silently wrapping during the `int32(svc)` / `int32(mt)` narrowing.
- Pre-existing `svc < 0` / `mt < 0` guards and the digit-only character check are preserved, so well-formed inputs behave identically.

## Notes on Dependabot alerts

The 12 Dependabot alerts on the Security tab all point to `tools/go.mod` and are stale: every flagged dependency is already pinned to its first-patched version at `HEAD` (e.g. `go-git/v5 v5.19.1`, `go-billy/v5 v5.9.0`, `slack-go v0.23.1`, `in-toto-golang v0.11.0`, `modelcontextprotocol/registry v1.7.9`). `go mod tidy` produces no changes. They should auto-close on the next Dependabot rescan, so no manifest change is included here.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/codegen/...` (passes, ~52s)
- [ ] Full e2e chain (`googlesql-wasm` → `googlesqlite-wasm2go`) — not run; this change only tightens integer parsing in a defensive helper and the behaviour is unchanged for any input within `int32` range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)