### PR TITLE
Inline wasm memory ops via unsafe.Pointer to fit Go's 65536-PC cap

### DIFF
--- a/internal/codegen/emit_memops.go
+++ b/internal/codegen/emit_memops.go
@@ -1,0 +1,238 @@
+package codegen
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// emit_memops.go renders wasm linear-memory load/store ops as an
+// inline `unsafe.Pointer` expression instead of a per-access helper
+// CALL.
+//
+// Background: the Go wasm linker rejects any function whose internal
+// PC counter reaches 65536 with "function too big: %s exceeds 65536
+// blocks" (cmd/internal/obj/wasm/wasmobj.go). On the wasm backend
+// each emitted CALL increments PC, so a function with N memory
+// accesses pays at least N PC if every access goes through a helper
+// call. Helpers cannot be relied on to be inlined either: Go's mid-
+// stack inliner declines to inline them inside very large callers
+// (caller-size budget), so once a transpiled function gets big enough
+// the helper-call form alone is enough to blow the PC cap.
+//
+// The inline form collapses an access to a single expression:
+//
+//	*(*T)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(m.Memory)), uintptr(uint32(base)+offset)))
+//
+// Every step is a Go compiler intrinsic — no CALL, no PC++. The
+// shared slice header (m.Memory) is read fresh on every access so
+// memory.grow reallocations between calls are picked up without any
+// stale-pointer hazard.
+//
+// Bounds check
+//
+// The wasm spec traps on out-of-bounds memory access. We deliberately
+// drop the runtime bounds check: by the time we reach Go-level
+// codegen, the input wasm has already been validated and the source
+// language has done its own bounds enforcement. An out-of-range
+// address indicates a bug in the input wasm, not a normal trap path.
+// With the check kept, even a per-function shared-panic-block form
+// still leaves a non-trivial PC contribution per access; without it,
+// access cost is zero.
+//
+// Entry points
+//
+// emitMemLoadExpr returns an ast.Expr suitable for both inline use
+// and as the RHS of a hoisted `vN = ...` assignment (computeHoist
+// already force-hoists every OpLoad*, so loads always come out as
+// assignments at their definition site).
+//
+// emitMemStoreStmt returns a single ast.Stmt — the RHS cast for
+// narrowing stores (i32.store8 / i32.store16 / i64.store32 / ...)
+// relies on computeHoist having force-hoisted args[1] so the cast
+// is a runtime conversion and Go's constant evaluator never sees
+// the out-of-range literal.
+
+// emitMemLoadExpr renders the read expression for an OpLoad* value.
+//
+//	full-width:        *(*T)(unsafe.Add(..., uintptr(uint32(base)+offset)))
+//	with outer cast:   <outerCast>(*(*T)(unsafe.Add(...)))
+//
+// The outer cast handles wasm's sub-word sign- or zero-extension
+// (i32.load8_u reads `uint8` and widens to `int32`, etc.).
+func (em *ssaEmitter) emitMemLoadExpr(v *ssa.Value, emitExpr func(*ssa.Value) (ast.Expr, error)) (ast.Expr, error) {
+	spec, ok := loadSpec(v)
+	if !ok {
+		return nil, fmt.Errorf("emitMemLoadExpr: not a load op: %v", v.Op)
+	}
+	baseExpr, err := emitExpr(v.Args[0])
+	if err != nil {
+		return nil, err
+	}
+	expr := em.unsafeDerefExpr(spec, baseExpr, uint64(v.AuxInt))
+	if spec.outerCast != "" {
+		expr = &ast.CallExpr{Fun: newID(spec.outerCast), Args: []ast.Expr{expr}}
+	}
+	return expr, nil
+}
+
+// emitMemStoreStmt renders an OpStore* as one assignment statement:
+//
+//	*(*T)(unsafe.Add(...)) = val               // no cast (i32.store, i64.store, fN.store)
+//	*(*T)(unsafe.Add(...)) = T(val)            // narrowing (i32.store8, i32.store16,
+//	                                           //            i64.store32, i64.store16, i64.store8)
+//
+// Narrowing stores pick UNSIGNED elemTypes (uint8 / uint16 / uint32)
+// to match the wasm spec's "store the low N bits" semantics, and
+// rely on computeHoist having force-hoisted args[1] so the cast
+// operand is always a typed local variable. The constant-evaluator
+// quirk `uint8(int32(255))` produces "constant 255 overflows int8" /
+// "constant -1 overflows uint8" depending on choice of signedness;
+// using a typed-variable operand sidesteps the check entirely.
+func (em *ssaEmitter) emitMemStoreStmt(v *ssa.Value, emitExpr func(*ssa.Value) (ast.Expr, error)) (ast.Stmt, error) {
+	spec, ok := storeSpec(v)
+	if !ok {
+		return nil, fmt.Errorf("emitMemStoreStmt: not a store op: %v", v.Op)
+	}
+	baseExpr, err := emitExpr(v.Args[0])
+	if err != nil {
+		return nil, err
+	}
+	valExpr, err := emitExpr(v.Args[1])
+	if err != nil {
+		return nil, err
+	}
+	dst := em.unsafeDerefExpr(spec, baseExpr, uint64(v.AuxInt))
+	rhs := valExpr
+	if spec.elemType != spec.valSrcType {
+		rhs = &ast.CallExpr{Fun: newID(spec.elemType), Args: []ast.Expr{valExpr}}
+	}
+	return &ast.AssignStmt{
+		Tok: token.ASSIGN,
+		Lhs: []ast.Expr{dst},
+		Rhs: []ast.Expr{rhs},
+	}, nil
+}
+
+// unsafeDerefExpr builds the typed-pointer dereference used as both
+// the load source and the store destination:
+//
+//	*(*<elemType>)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(m.Memory)),
+//	                          uintptr(uint32(base)[+offset])))
+//
+// Registers "unsafe" with the translator so the generated file picks
+// up the import.
+func (em *ssaEmitter) unsafeDerefExpr(spec memOpSpec, baseExpr ast.Expr, offset uint64) ast.Expr {
+	em.useImport("unsafe")
+	addr := ast.Expr(&ast.CallExpr{Fun: newID("uint32"), Args: []ast.Expr{baseExpr}})
+	if offset != 0 {
+		addr = &ast.BinaryExpr{X: addr, Op: token.ADD, Y: uintLit(offset)}
+	}
+	addrUptr := &ast.CallExpr{Fun: newID("uintptr"), Args: []ast.Expr{addr}}
+	sliceData := &ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("unsafe"), Sel: newID("SliceData")},
+		Args: []ast.Expr{em.fieldRef("memory")},
+	}
+	asPtr := &ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("unsafe"), Sel: newID("Pointer")},
+		Args: []ast.Expr{sliceData},
+	}
+	added := &ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("unsafe"), Sel: newID("Add")},
+		Args: []ast.Expr{asPtr, addrUptr},
+	}
+	castFn := &ast.ParenExpr{X: &ast.StarExpr{X: newID(spec.elemType)}}
+	cast := &ast.CallExpr{Fun: castFn, Args: []ast.Expr{added}}
+	return &ast.StarExpr{X: cast}
+}
+
+// memOpSpec describes one memory op's in-memory shape.
+//
+//   - elemType:   Go type used as the deref target.
+//   - outerCast:  optional cast wrapping the load result (sub-word
+//     sign/zero extension); empty when elemType already
+//     matches the SSA result type.
+//   - valSrcType: only used for stores — the Go type of the SSA value
+//     being stored. When valSrcType != elemType the
+//     emitter wraps `vN` in `elemType(vN)`.
+type memOpSpec struct {
+	elemType   string
+	outerCast  string
+	valSrcType string
+}
+
+// loadSpec returns the access spec for an OpLoad* value.
+func loadSpec(v *ssa.Value) (memOpSpec, bool) {
+	intCast := "int32"
+	if v.Type == ssa.TypeI64 {
+		intCast = "int64"
+	}
+	switch v.Op {
+	case ssa.OpLoad8U:
+		return memOpSpec{elemType: "uint8", outerCast: intCast}, true
+	case ssa.OpLoad8S:
+		return memOpSpec{elemType: "int8", outerCast: intCast}, true
+	case ssa.OpLoad16U:
+		return memOpSpec{elemType: "uint16", outerCast: intCast}, true
+	case ssa.OpLoad16S:
+		return memOpSpec{elemType: "int16", outerCast: intCast}, true
+	case ssa.OpLoad32:
+		// i32.load: full-width 32-bit load, no extension.
+		return memOpSpec{elemType: "int32"}, true
+	case ssa.OpLoad32U:
+		// i64.load32_u: read uint32, zero-extend to int64.
+		return memOpSpec{elemType: "uint32", outerCast: "int64"}, true
+	case ssa.OpLoad32S:
+		// i64.load32_s: read int32, sign-extend to int64.
+		return memOpSpec{elemType: "int32", outerCast: "int64"}, true
+	case ssa.OpLoad64:
+		return memOpSpec{elemType: "int64"}, true
+	case ssa.OpLoadF32:
+		return memOpSpec{elemType: "float32"}, true
+	case ssa.OpLoadF64:
+		return memOpSpec{elemType: "float64"}, true
+	}
+	return memOpSpec{}, false
+}
+
+// storeSpec returns the access spec for an OpStore* value.
+//
+// Sub-word stores use UNSIGNED elemTypes (uint8 / uint16 / uint32) to
+// match the wasm spec ("store the low N bits as the unsigned
+// representation"); a signed elemType would semantically misrepresent
+// the operation (i32.store8 of 255 must write 0xFF, not "out of int8
+// range"). The cast in emitMemStoreStmt is a runtime conversion
+// because args[1] is force-hoisted by computeHoist.
+//
+// For non-narrowing stores (i32.store, i64.store, fN.store) elemType
+// equals valSrcType and no cast is emitted.
+func storeSpec(v *ssa.Value) (memOpSpec, bool) {
+	if len(v.Args) < 2 || v.Args[1] == nil {
+		return memOpSpec{}, false
+	}
+	valSrc := "int32"
+	if v.Args[1].Type == ssa.TypeI64 {
+		valSrc = "int64"
+	}
+	switch v.Op {
+	case ssa.OpStore8:
+		return memOpSpec{elemType: "uint8", valSrcType: valSrc}, true
+	case ssa.OpStore16:
+		return memOpSpec{elemType: "uint16", valSrcType: valSrc}, true
+	case ssa.OpStore32:
+		// i32.store: identity. i64.store32: low 32 bits as unsigned.
+		if valSrc == "int64" {
+			return memOpSpec{elemType: "uint32", valSrcType: "int64"}, true
+		}
+		return memOpSpec{elemType: "int32", valSrcType: "int32"}, true
+	case ssa.OpStore64:
+		return memOpSpec{elemType: "int64", valSrcType: "int64"}, true
+	case ssa.OpStoreF32:
+		return memOpSpec{elemType: "float32", valSrcType: "float32"}, true
+	case ssa.OpStoreF64:
+		return memOpSpec{elemType: "float64", valSrcType: "float64"}, true
+	}
+	return memOpSpec{}, false
+}

--- a/internal/codegen/emit_memops_test.go
+++ b/internal/codegen/emit_memops_test.go
@@ -1,0 +1,304 @@
+package codegen
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// formatExpr / formatStmt render an AST node through go/format so the
+// tests can assert on the canonical Go source representation rather
+// than chase ast.Node pointer chains.
+func formatExpr(t *testing.T, e ast.Expr) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, e); err != nil {
+		t.Fatalf("format expr: %v", err)
+	}
+	return buf.String()
+}
+
+func formatStmt(t *testing.T, s ast.Stmt) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, s); err != nil {
+		t.Fatalf("format stmt: %v", err)
+	}
+	return buf.String()
+}
+
+// TestLoadSpec covers every wasm load shape and asserts elemType /
+// outerCast pick.
+func TestLoadSpec(t *testing.T) {
+	// (op, type, elemType, outerCast) — the i64 variants of sub-word
+	// loads pick the int64 outer cast while still reading the narrow
+	// sub-word elem.
+	type tc struct {
+		op   ssa.Op
+		typ  ssa.Type
+		elem string
+		cast string
+	}
+	cases := []tc{
+		{ssa.OpLoad8U, ssa.TypeI32, "uint8", "int32"},
+		{ssa.OpLoad8S, ssa.TypeI32, "int8", "int32"},
+		{ssa.OpLoad8U, ssa.TypeI64, "uint8", "int64"},
+		{ssa.OpLoad16U, ssa.TypeI32, "uint16", "int32"},
+		{ssa.OpLoad16S, ssa.TypeI32, "int16", "int32"},
+		{ssa.OpLoad32, ssa.TypeI32, "int32", ""},
+		{ssa.OpLoad32U, ssa.TypeI64, "uint32", "int64"},
+		{ssa.OpLoad32S, ssa.TypeI64, "int32", "int64"},
+		{ssa.OpLoad64, ssa.TypeI64, "int64", ""},
+		{ssa.OpLoadF32, ssa.TypeF32, "float32", ""},
+		{ssa.OpLoadF64, ssa.TypeF64, "float64", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.op.String(), func(t *testing.T) {
+			b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+			entry := b.NewBlock(ssa.BlockRet)
+			b.SetEntry(entry)
+			b.SetCurrent(entry)
+			v := b.NewValueAuxInt(c.op, c.typ, 0, b.Const32(0))
+			spec, ok := loadSpec(v)
+			if !ok {
+				t.Fatalf("loadSpec returned !ok for %v", c.op)
+			}
+			if spec.elemType != c.elem {
+				t.Errorf("elemType = %q, want %q", spec.elemType, c.elem)
+			}
+			if spec.outerCast != c.cast {
+				t.Errorf("outerCast = %q, want %q", spec.outerCast, c.cast)
+			}
+		})
+	}
+}
+
+// TestStoreSpec covers every wasm store shape. Sub-word stores must
+// pick UNSIGNED elemTypes (uint8/uint16/uint32) to honour the wasm
+// "store low N bits unsigned" semantics; non-narrowing stores set
+// valSrcType == elemType so the emitter skips the cast.
+func TestStoreSpec(t *testing.T) {
+	type tc struct {
+		op     ssa.Op
+		valTyp ssa.Type
+		elem   string
+		valSrc string
+	}
+	cases := []tc{
+		{ssa.OpStore8, ssa.TypeI32, "uint8", "int32"},
+		{ssa.OpStore8, ssa.TypeI64, "uint8", "int64"},
+		{ssa.OpStore16, ssa.TypeI32, "uint16", "int32"},
+		{ssa.OpStore16, ssa.TypeI64, "uint16", "int64"},
+		{ssa.OpStore32, ssa.TypeI32, "int32", "int32"},  // i32.store: no cast
+		{ssa.OpStore32, ssa.TypeI64, "uint32", "int64"}, // i64.store32: narrowing
+		{ssa.OpStore64, ssa.TypeI64, "int64", "int64"},
+		{ssa.OpStoreF32, ssa.TypeF32, "float32", "float32"},
+		{ssa.OpStoreF64, ssa.TypeF64, "float64", "float64"},
+	}
+	for _, c := range cases {
+		t.Run(c.op.String()+"/"+c.valTyp.String(), func(t *testing.T) {
+			b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+			entry := b.NewBlock(ssa.BlockRet)
+			b.SetEntry(entry)
+			b.SetCurrent(entry)
+			var val *ssa.Value
+			switch c.valTyp {
+			case ssa.TypeI32:
+				val = b.Const32(0)
+			case ssa.TypeI64:
+				val = b.Const64(0)
+			default:
+				// Use a constant 0 of the right type via a CallDirect stub.
+				// Simpler: just synthesise with NewValue and a placeholder.
+				val = b.NewValueAuxInt(ssa.OpCallDirect, c.valTyp, 0)
+			}
+			v := b.NewValueAuxInt(c.op, ssa.TypeMem, 0, b.Const32(0), val)
+			spec, ok := storeSpec(v)
+			if !ok {
+				t.Fatalf("storeSpec returned !ok for %v", c.op)
+			}
+			if spec.elemType != c.elem {
+				t.Errorf("elemType = %q, want %q", spec.elemType, c.elem)
+			}
+			if spec.valSrcType != c.valSrc {
+				t.Errorf("valSrcType = %q, want %q", spec.valSrcType, c.valSrc)
+			}
+		})
+	}
+}
+
+// TestEmitMemLoadExpr_Load32 renders the OpLoad32 inline form and
+// asserts it matches the documented one-liner shape. Catches any
+// regression in unsafeDerefExpr's pointer-arithmetic chain.
+func TestEmitMemLoadExpr_Load32(t *testing.T) {
+	b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+	entry := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	addr := b.Const32(0)
+	v := b.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 8, addr)
+
+	em := newSSAEmitter(nil)
+	emit := func(arg *ssa.Value) (ast.Expr, error) { return constArgExpr(arg), nil }
+	expr, err := em.emitMemLoadExpr(v, emit)
+	if err != nil {
+		t.Fatalf("emitMemLoadExpr: %v", err)
+	}
+	got := formatExpr(t, expr)
+	want := "*(*int32)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(m.memory)), uintptr(uint32(int32(0))+8)))"
+	if got != want {
+		t.Errorf("Load32 inline form:\n got:  %s\n want: %s", got, want)
+	}
+}
+
+// TestEmitMemLoadExpr_Load8U checks the outer cast wraps the inner
+// unsafe deref when sign/zero extension is needed.
+func TestEmitMemLoadExpr_Load8U(t *testing.T) {
+	b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+	entry := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	addr := b.Const32(0)
+	v := b.NewValueAuxInt(ssa.OpLoad8U, ssa.TypeI32, 0, addr)
+
+	em := newSSAEmitter(nil)
+	emit := func(arg *ssa.Value) (ast.Expr, error) { return constArgExpr(arg), nil }
+	expr, err := em.emitMemLoadExpr(v, emit)
+	if err != nil {
+		t.Fatalf("emitMemLoadExpr: %v", err)
+	}
+	got := formatExpr(t, expr)
+	if !strings.HasPrefix(got, "int32(*(*uint8)") {
+		t.Errorf("Load8U should be int32-cast over *(*uint8)(...); got: %s", got)
+	}
+	if !strings.Contains(got, "unsafe.SliceData(m.memory)") {
+		t.Errorf("Load8U missing unsafe.SliceData(m.memory); got: %s", got)
+	}
+}
+
+// TestEmitMemStoreStmt_Store32 — non-narrowing store renders as a
+// plain `*(*int32)(...) = val` one-liner; no cast around the RHS.
+func TestEmitMemStoreStmt_Store32(t *testing.T) {
+	b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+	entry := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	addr := b.Const32(0)
+	val := b.Const32(7)
+	v := b.NewValueAuxInt(ssa.OpStore32, ssa.TypeMem, 0, addr, val)
+
+	em := newSSAEmitter(nil)
+	emit := func(arg *ssa.Value) (ast.Expr, error) { return constArgExpr(arg), nil }
+	stmt, err := em.emitMemStoreStmt(v, emit)
+	if err != nil {
+		t.Fatalf("emitMemStoreStmt: %v", err)
+	}
+	got := formatStmt(t, stmt)
+	want := "*(*int32)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(m.memory)), uintptr(uint32(int32(0))))) = int32(7)"
+	if got != want {
+		t.Errorf("Store32 inline form:\n got:  %s\n want: %s", got, want)
+	}
+	// RHS must be the bare valExpr, NOT wrapped in `int32(int32(7))`.
+	// (Non-narrowing stores skip the cast entirely — see emitMemStoreStmt.)
+	if strings.Count(got, "= int32(int32(") > 0 {
+		t.Errorf("Store32 must NOT wrap RHS in a no-op int32 cast; got: %s", got)
+	}
+}
+
+// TestEmitMemStoreStmt_Store8 — narrowing store renders the uint8
+// cast on the RHS (the value side is force-hoisted by computeHoist
+// so the emit form is a runtime conversion).
+func TestEmitMemStoreStmt_Store8(t *testing.T) {
+	b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+	entry := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	addr := b.Const32(0)
+	val := b.Const32(255) // out of int8 range — must NOT be inlined into the cast
+	v := b.NewValueAuxInt(ssa.OpStore8, ssa.TypeMem, 0, addr, val)
+
+	em := newSSAEmitter(nil)
+	// Simulate the post-hoist state by emitting val as the bare `vN`
+	// identifier the real emitter would substitute.
+	emit := func(arg *ssa.Value) (ast.Expr, error) {
+		if arg == val {
+			return newID("v9"), nil
+		}
+		return constArgExpr(arg), nil
+	}
+	stmt, err := em.emitMemStoreStmt(v, emit)
+	if err != nil {
+		t.Fatalf("emitMemStoreStmt: %v", err)
+	}
+	got := formatStmt(t, stmt)
+	want := "*(*uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(m.memory)), uintptr(uint32(int32(0))))) = uint8(v9)"
+	if got != want {
+		t.Errorf("Store8 narrowing form:\n got:  %s\n want: %s", got, want)
+	}
+}
+
+// TestComputeHoistForceHoistsNarrowingStoreValue: when args[1] of a
+// narrowing store is a constant-producing op (OpConst32), computeHoist
+// must mark it for hoisting so emitMemStoreStmt's runtime cast lands
+// on a variable instead of a literal.
+func TestComputeHoistForceHoistsNarrowingStoreValue(t *testing.T) {
+	b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+	entry := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	addr := b.Const32(0)
+	// val has usage = 1 (only the store), so without force-hoist it
+	// would be folded inline.
+	val := b.Const32(255)
+	b.NewValueAuxInt(ssa.OpStore8, ssa.TypeMem, 0, addr, val)
+	f := b.Func()
+
+	usage := computeValueUsage(f)
+	hoist := computeHoist(f, usage)
+
+	if !hoist[val.ID] {
+		t.Errorf("computeHoist did not force-hoist OpStore8 value arg (usage=%d, hoist=%v)",
+			usage[val.ID], hoist[val.ID])
+	}
+}
+
+// TestComputeHoistSkipsNonNarrowingStore: when elemType == valSrcType
+// the cast is absent, so we don't need the force-hoist either.
+// (Without this guard we'd needlessly bloat hoisted-var declarations
+// on every i32.store and i64.store.)
+func TestComputeHoistSkipsNonNarrowingStore(t *testing.T) {
+	b := ssa.NewFuncBuilder("t", ssa.FuncSig{})
+	entry := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	addr := b.Const32(0)
+	val := b.Const32(7)
+	b.NewValueAuxInt(ssa.OpStore32, ssa.TypeMem, 0, addr, val)
+	f := b.Func()
+
+	usage := computeValueUsage(f)
+	hoist := computeHoist(f, usage)
+
+	if hoist[val.ID] {
+		t.Errorf("computeHoist wrongly force-hoisted OpStore32 value arg (no narrowing cast needed)")
+	}
+}
+
+// constArgExpr renders a constant arg for the test fixtures' emit
+// closure. Matches what emitOp would return for OpConst32 / OpConst64.
+func constArgExpr(v *ssa.Value) ast.Expr {
+	switch v.Op {
+	case ssa.OpConst32:
+		return goConstI32(int32(v.AuxInt))
+	case ssa.OpConst64:
+		return goConstI64(v.AuxInt)
+	}
+	return newID("?")
+}

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -541,6 +541,24 @@ func computeHoist(f *ssa.Func, usage map[ssa.ValueID]int) map[ssa.ValueID]bool {
 			}
 		}
 	}
+	// Force-hoist the VALUE side of every narrowing store
+	// (i32.store8 / i32.store16 / i64.store32 / i64.store16 / i64.store8).
+	// The inline emitter renders these as `*(*uint8)(...) = uint8(vN)`,
+	// and the truncating cast must be a runtime conversion — an inlined
+	// constant operand like `uint8(int32(255))` would trip Go's
+	// compile-time constant-overflow check. Hoisting args[1] guarantees
+	// the operand is always a typed local variable.
+	for _, blk := range f.Blocks {
+		for _, v := range blk.Values {
+			spec, ok := storeSpec(v)
+			if !ok || spec.elemType == spec.valSrcType {
+				continue
+			}
+			if len(v.Args) >= 2 && v.Args[1] != nil {
+				hoist[v.Args[1].ID] = true
+			}
+		}
+	}
 	return hoist
 }
 
@@ -648,20 +666,13 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 		}
 		return &ast.CallExpr{Fun: em.helperRef("memoryGrow"), Args: []ast.Expr{newID("m"), delta}}, nil
 	}
-	// Bulk-memory ops have a Mem result type; they're emitted as
-	// statements via emitSideEffectStmt, but if emitOp is reached we
-	// still need a placeholder expression. emitSideEffectStmt handles
-	// the real emission below.
-	if helper, isLoad, ok := memoryHelperTyped(v); ok && isLoad {
-		base, err := emit(v.Args[0])
-		if err != nil {
-			return nil, err
-		}
-		em.useHelper(helper)
-		return &ast.CallExpr{
-			Fun:  em.helperRef(helper),
-			Args: []ast.Expr{newID("m"), base, uintLit(uint64(v.AuxInt))},
-		}, nil
+	// Inline memory loads: emit the unsafe deref expression directly
+	// rather than calling a helper. See emit_memops.go for the per-
+	// function PC-budget rationale. Both structured and goto-form
+	// paths reach here through emitOp, so the inline form is uniform
+	// across the whole transpiler output.
+	if _, ok := loadSpec(v); ok {
+		return em.emitMemLoadExpr(v, emit)
 	}
 	if tok, mode, ok := binarySSAOp(v.Op); ok {
 		lhs, err := emit(v.Args[0])
@@ -689,10 +700,14 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 }
 
 // emitSideEffectStmt dispatches a side-effecting SSA value to its
-// statement form: store helper, global assignment, or call statement.
+// statement form: inline memory store, global assignment, or call
+// statement.
 func (em *ssaEmitter) emitSideEffectStmt(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, error)) (ast.Stmt, error) {
-	if _, isLoad, ok := memoryHelper(v.Op); ok && !isLoad {
-		return em.emitStoreStmt(v, emit)
+	if _, ok := storeSpec(v); ok {
+		// Inline store, one-liner: `*(*T)(unsafe.Add(...)) = T(vN)`.
+		// computeHoist guarantees narrowing-store values are hoisted
+		// so the cast is always runtime-safe. See emit_memops.go.
+		return em.emitMemStoreStmt(v, emit)
 	}
 	switch v.Op {
 	case ssa.OpGlobalSet:
@@ -869,29 +884,6 @@ func (em *ssaEmitter) emitCallIndirect(v *ssa.Value, emit func(*ssa.Value) (ast.
 	return &ast.CallExpr{Fun: asserted, Args: args}, nil
 }
 
-// emitStoreStmt produces the Go-statement form of a memory store. Stores
-// are side-effecting and never have users, so they are emitted as
-// expression statements in their defining block.
-func (em *ssaEmitter) emitStoreStmt(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, error)) (ast.Stmt, error) {
-	helper, isLoad, ok := memoryHelperTyped(v)
-	if !ok || isLoad {
-		return nil, fmt.Errorf("emitStoreStmt: not a store op: %v", v.Op)
-	}
-	base, err := emit(v.Args[0])
-	if err != nil {
-		return nil, err
-	}
-	value, err := emit(v.Args[1])
-	if err != nil {
-		return nil, err
-	}
-	em.useHelper(helper)
-	return &ast.ExprStmt{X: &ast.CallExpr{
-		Fun:  em.helperRef(helper),
-		Args: []ast.Expr{newID("m"), base, uintLit(uint64(v.AuxInt)), value},
-	}}, nil
-}
-
 // useHelper registers a helper name with the translator (if bound) so
 // the helper's source is included in the output's helpers section.
 // nil translator (unit tests) silently no-ops.
@@ -902,6 +894,15 @@ func (em *ssaEmitter) useHelper(name string) {
 	em.t.useHelper(name)
 }
 
+// useImport registers a Go import package with the translator (if
+// bound). nil translator (unit tests) silently no-ops.
+func (em *ssaEmitter) useImport(pkg string) {
+	if em.t == nil {
+		return
+	}
+	em.t.use(pkg)
+}
+
 // helperRef returns the AST expression naming the helper, qualified for
 // multi-package mode (base.Mload32) or bare for single-package mode.
 // Falls back to bare identifier when translator is nil (tests).
@@ -910,92 +911,6 @@ func (em *ssaEmitter) helperRef(name string) ast.Expr {
 		return newID(name)
 	}
 	return em.t.helperRef(name)
-}
-
-// memoryHelper maps an SSA load/store op to the helper-function name
-// emitted at the call site. Both the SSA op AND the value type matter
-// because wasm has distinct ops for i32.store8 (4→1 byte truncating
-// store of an i32 value) and i64.store8 (8→1 byte truncating store of
-// an i64 value); they use different Go helpers because the value
-// argument type differs.
-//
-// For loads, the result type drives helper choice. For stores, the
-// type of the value argument (args[1]) drives it.
-func memoryHelper(op ssa.Op) (name string, isLoad bool, ok bool) {
-	// Default mapping based on op alone; callers that need value-type
-	// distinction should use memoryHelperTyped.
-	switch op {
-	case ssa.OpLoad8U, ssa.OpLoad8S, ssa.OpLoad16U, ssa.OpLoad16S,
-		ssa.OpLoad32, ssa.OpLoad32U, ssa.OpLoad32S, ssa.OpLoad64,
-		ssa.OpLoadF32, ssa.OpLoadF64:
-		return "", true, true
-	case ssa.OpStore8, ssa.OpStore16, ssa.OpStore32, ssa.OpStore64,
-		ssa.OpStoreF32, ssa.OpStoreF64:
-		return "", false, true
-	}
-	return "", false, false
-}
-
-// memoryHelperTyped is the type-aware variant. It returns the helper
-// name that matches the value's bit-width / signedness — picking
-// e.g. mload8u (i32 result) vs mload64_8u (i64 result).
-func memoryHelperTyped(v *ssa.Value) (name string, isLoad bool, ok bool) {
-	switch v.Op {
-	case ssa.OpLoad8U:
-		if v.Type == ssa.TypeI64 {
-			return "mload64_8u", true, true
-		}
-		return "mload8u", true, true
-	case ssa.OpLoad8S:
-		if v.Type == ssa.TypeI64 {
-			return "mload64_8s", true, true
-		}
-		return "mload8s", true, true
-	case ssa.OpLoad16U:
-		if v.Type == ssa.TypeI64 {
-			return "mload64_16u", true, true
-		}
-		return "mload16u", true, true
-	case ssa.OpLoad16S:
-		if v.Type == ssa.TypeI64 {
-			return "mload64_16s", true, true
-		}
-		return "mload16s", true, true
-	case ssa.OpLoad32:
-		return "mload32", true, true
-	case ssa.OpLoad32U:
-		return "mload64_32u", true, true
-	case ssa.OpLoad32S:
-		return "mload64_32s", true, true
-	case ssa.OpLoad64:
-		return "mload64", true, true
-	case ssa.OpLoadF32:
-		return "mloadF32", true, true
-	case ssa.OpLoadF64:
-		return "mloadF64", true, true
-	case ssa.OpStore8:
-		if len(v.Args) >= 2 && v.Args[1].Type == ssa.TypeI64 {
-			return "mstore8_64", false, true
-		}
-		return "mstore8", false, true
-	case ssa.OpStore16:
-		if len(v.Args) >= 2 && v.Args[1].Type == ssa.TypeI64 {
-			return "mstore16_64", false, true
-		}
-		return "mstore16", false, true
-	case ssa.OpStore32:
-		if len(v.Args) >= 2 && v.Args[1].Type == ssa.TypeI64 {
-			return "mstore32_64", false, true
-		}
-		return "mstore32", false, true
-	case ssa.OpStore64:
-		return "mstore64", false, true
-	case ssa.OpStoreF32:
-		return "mstoreF32", false, true
-	case ssa.OpStoreF64:
-		return "mstoreF64", false, true
-	}
-	return "", false, false
 }
 
 func goConstI32(n int32) ast.Expr {


### PR DESCRIPTION
## Summary

Replace the per-access helper-call form of every wasm load/store with an inline `unsafe.Pointer` dereference so functions with many memory accesses no longer trip Go's wasm linker cap (`function too big: %s exceeds 65536 blocks`).

## Motivation

When the transpiled output contains a very large function (tens of thousands of memory accesses + thousands of direct calls), `GOOS=js GOARCH=wasm go build` rejects it with:

```
function too big: <FuncName> exceeds 65536 blocks
```

The "blocks" in that diagnostic are PC slots in the wasm resume-point dispatch table — one per CALL after RESUMEPOINT insertion (`cmd/internal/obj/wasm/wasmobj.go`), not Go SSA basic blocks. The dominant PC source in `wasm2go`-generated code is the per-access ACALL into the memory-op helpers. Go's mid-stack inliner declines to absorb those helpers inside very large callers (caller-size budget) — verifiable with `go build -gcflags='all=-m=2'` — so each access stays a real call and contributes +1 PC.

## Approach

Inline every memory access as a single expression:

```go
*(*T)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(m.Memory)), uintptr(uint32(base)+offset)))
```

Every step is a Go compiler intrinsic on the wasm backend, so per-access PC cost is zero. The dispatch is wired through `emitOp` + `emitSideEffectStmt` so the structured AND goto codegen paths both reach it — every generated package picks up the new form uniformly. The legacy `memoryHelper` / `memoryHelperTyped` / `emitStoreStmt` dispatch becomes unreachable and is removed.

Sub-word stores (`i32.store8` / `i32.store16` / `i64.store32`) pick UNSIGNED `elemType`s (`uint8` / `uint16` / `uint32`) to match the wasm spec's "store low N bits unsigned" semantics. `computeHoist` force-hoists the value side of every narrowing store so the truncating cast is a runtime conversion (Go's constant evaluator would otherwise reject `uint8(int32(255))` and its inverse).

## Trade-off — bounds check dropped

The wasm spec's runtime bounds-check trap is intentionally not emitted. The input wasm has already been validated and the source toolchain (typically clang/wasm-ld) is expected to enforce its own bounds; an out-of-range address indicates a bug in the input wasm, not a normal trap path.

## Tests

Unit tests added in `internal/codegen/emit_memops_test.go`:

- `TestLoadSpec` / `TestStoreSpec` cover every wasm load/store op shape.
- `TestEmitMemLoadExpr_Load32` / `TestEmitMemLoadExpr_Load8U` golden-string-assert the emitted load expression (including the outer cast for sub-word loads).
- `TestEmitMemStoreStmt_Store32` / `TestEmitMemStoreStmt_Store8` do the same for stores (including the narrowing-cast path).
- `TestComputeHoistForceHoistsNarrowingStoreValue` / `TestComputeHoistSkipsNonNarrowingStore` verify the hoist rule is scoped to narrowing stores only.

`go test ./...` and `make lint` pass.

## Test plan

- [ ] CI is green
- [ ] Reviewer agrees the bounds-check trade-off is acceptable for the project's wasm-input trust model (or asks for an opt-in flag to put it back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
