### PR TITLE
asmgen: loop-carry register allocation (own-register phis, inline-helper barriers, arm64 port)

### DIFF
--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -167,6 +167,17 @@ type arch interface {
 	// side; the rest still need a slot. Returning false here makes
 	// the regalloc skip the value so its slot store survives.
 	RegHomeEligibleOp(op ssa.Op) bool
+	// HelperIsInline reports whether the arch emits the named
+	// OpHelperCall helper as inline asm with NO returning CALL. The
+	// CALL-barrier analyses (block-local regalloc lifetimes, the
+	// loop-carry coalesce's call-free check, the m-cache refresh)
+	// treat such values as ordinary ALU ops instead of register-
+	// clobbering calls. Trap CALLs on never-returning branches
+	// (divide-by-zero panics) do not count as "returning". amd64
+	// consults inlineHelperNamesAMD64; arm64 conservatively returns
+	// false for everything until its inline set is audited the same
+	// way.
+	HelperIsInline(name string) bool
 	// GPRegPool returns the GP register pool the block-local regalloc
 	// hands out to int / pointer SSA values. The order matters only
 	// for determinism — first-fit during linear scan. Each entry
@@ -272,6 +283,7 @@ func emitFunc(name string, sig wasm.FuncType, f *ssa.Func, opts FuncOptions, a a
 	plan.sseRegPool = a.SSERegPool()
 	plan.regHomeEligibleOpFn = a.RegHomeEligibleOp
 	plan.supportsCoalesce = a.SupportsLoopCarryCoalesce()
+	plan.helperInlineFn = a.HelperIsInline
 
 	// m-pointer caching: stage `m` into a function-wide register
 	// so every memop / global access / call-site arg-staging that
@@ -1553,7 +1565,12 @@ func emitBlock(b *strings.Builder, blk *ssa.Block, f *ssa.Func, plan *funcPlan, 
 		// the source site (the BlockIf terminator inlines the
 		// compare). Without these guards every inlined access would
 		// cost the refresh pair it was supposed to save.
-		if plan.mCacheReg != "" && opEmitsCall(v.Op) && !plan.branchFused[v.ID] {
+		// Inline-emitted helpers (extends, rotates, div/rem, float
+		// arith — see HelperIsInline) produce no returning CALL
+		// either: their scratch usage never touches mCacheReg, so
+		// the cache stays valid and the refresh pair would be pure
+		// waste in exactly the hot loops the inlining serves.
+		if plan.mCacheReg != "" && opEmitsCall(v.Op) && !plan.branchFused[v.ID] && !helperCallIsInline(plan, v) {
 			if _, inline := plan.globalInline[v.ID]; !inline {
 				a.EmitMCachePrime(b, plan.mCacheReg)
 			}
@@ -1740,6 +1757,21 @@ func emitPhiEdgeCopies(b *strings.Builder, pred, succ *ssa.Block, predIdx int, p
 }
 
 func labelFor(b *ssa.Block) string { return fmt.Sprintf("L%d", b.ID) }
+
+// helperCallIsInline reports whether v is an OpHelperCall the arch
+// emits inline with no returning CALL — i.e. a false positive of
+// opEmitsCall. The CALL-barrier analyses (block-local regalloc
+// lifetimes, the loop-carry coalesce's call-free check) and the
+// m-cache refresh subtract these the same way they subtract
+// branchFused and globalInline values. Conservative false when the
+// plan has no arch hook (hand-built test fixtures) or the helper
+// name is unknown.
+func helperCallIsInline(plan *funcPlan, v *ssa.Value) bool {
+	if v.Op != ssa.OpHelperCall || plan.helperInlineFn == nil {
+		return false
+	}
+	return plan.helperInlineFn(plan.helperRefs[v.ID])
+}
 
 // opEmitsCall reports whether emitting v results in a runtime
 // CALL instruction (helper, direct, indirect, import, global
@@ -1974,6 +2006,11 @@ type funcPlan struct {
 	// regHome-eligible carry, etc.), this stays nil and the per-
 	// block scan runs unchanged.
 	reservedRegs map[ssa.BlockID]map[string]bool
+	// helperInlineFn is the arch's HelperIsInline hook (nil when the
+	// plan was built without an arch — hand-built test fixtures). An
+	// OpHelperCall whose name this reports inline is NOT a CALL
+	// barrier: see helperCallIsInline.
+	helperInlineFn func(name string) bool
 	// coalescedPhi records loop-carry phi destinations
 	// that have been merged with their back-edge args into a
 	// shared register. When emitPhiCopyValue sees a phi-edge-copy

--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -1570,7 +1570,8 @@ func emitBlock(b *strings.Builder, blk *ssa.Block, f *ssa.Func, plan *funcPlan, 
 		// either: their scratch usage never touches mCacheReg, so
 		// the cache stays valid and the refresh pair would be pure
 		// waste in exactly the hot loops the inlining serves.
-		if plan.mCacheReg != "" && opEmitsCall(v.Op) && !plan.branchFused[v.ID] && !helperCallIsInline(plan, v) {
+		if plan.mCacheReg != "" && opEmitsCall(v.Op) && !plan.branchFused[v.ID] &&
+			!(os.Getenv("WASM2GO_HELPER_BARRIER_REFRESH") == "" && helperCallIsInline(plan, v)) {
 			if _, inline := plan.globalInline[v.ID]; !inline {
 				a.EmitMCachePrime(b, plan.mCacheReg)
 			}

--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -159,6 +159,13 @@ type arch interface {
 	// pinned across a loop is not reliably maintained). When false the
 	// coalesce pass is skipped and carries stay slot-resident.
 	SupportsLoopCarryCoalesce() bool
+	// CoalesceRegPool is the dedicated register set the loop-carry
+	// coalesce pass draws from when reserving a register across a
+	// loop body (and the carry's out-of-body live region). Entries
+	// must never be used as per-op emit scratches and are excluded
+	// from the block-local scan in every reserved block. Only
+	// consulted when SupportsLoopCarryCoalesce() is true.
+	CoalesceRegPool() []string
 	// RegHomeEligibleOp narrows the regalloc eligibility list per
 	// arch. The default for amd64 is "every op whose producer can
 	// write directly to a register" — that's the existing
@@ -283,6 +290,7 @@ func emitFunc(name string, sig wasm.FuncType, f *ssa.Func, opts FuncOptions, a a
 	plan.sseRegPool = a.SSERegPool()
 	plan.regHomeEligibleOpFn = a.RegHomeEligibleOp
 	plan.supportsCoalesce = a.SupportsLoopCarryCoalesce()
+	plan.coalescePool = a.CoalesceRegPool()
 	plan.helperInlineFn = a.HelperIsInline
 
 	// m-pointer caching: stage `m` into a function-wide register
@@ -2012,6 +2020,10 @@ type funcPlan struct {
 	// OpHelperCall whose name this reports inline is NOT a CALL
 	// barrier: see helperCallIsInline.
 	helperInlineFn func(name string) bool
+	// coalescePool is the arch's CoalesceRegPool (nil when the plan
+	// was built without an arch — hand-built test fixtures fall back
+	// to the amd64 coalesceReservedPool var).
+	coalescePool []string
 	// coalescedPhi records loop-carry phi destinations
 	// that have been merged with their back-edge args into a
 	// shared register. When emitPhiCopyValue sees a phi-edge-copy

--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -132,10 +132,11 @@ type arch interface {
 	EmitPhiCopySlot(b *strings.Builder, srcOff, dstOff int, t ssa.Type) error
 	// EmitPhiCopyValueToReg copies an SSA value into a register that
 	// the loop-carry coalesce pass reserved. Called instead of
-	// EmitPhiCopyValue on the forward (entry) edge of a coalesced
-	// loop, so the loop body sees the right initial value in the
-	// reserved register. arm64 returns an error — the coalesce pass
-	// only fires behind SupportsRegHome().
+	// EmitPhiCopyValue on every edge of an own-register phi and on
+	// the forward (entry) edge of a shared coalesce, so the loop
+	// body sees the right value in the reserved register. Both
+	// archs implement it (the coalesce pass fires behind
+	// SupportsLoopCarryCoalesce()).
 	EmitPhiCopyValueToReg(b *strings.Builder, src *ssa.Value, dstReg string, t ssa.Type, plan *funcPlan, frame argFrame) error
 	// SkipValue reports whether the arch's operandSrc helpers handle
 	// v inline at every consumer, so the materialise instruction in
@@ -1578,8 +1579,7 @@ func emitBlock(b *strings.Builder, blk *ssa.Block, f *ssa.Func, plan *funcPlan, 
 		// either: their scratch usage never touches mCacheReg, so
 		// the cache stays valid and the refresh pair would be pure
 		// waste in exactly the hot loops the inlining serves.
-		if plan.mCacheReg != "" && opEmitsCall(v.Op) && !plan.branchFused[v.ID] &&
-			!(os.Getenv("WASM2GO_HELPER_BARRIER_REFRESH") == "" && helperCallIsInline(plan, v)) {
+		if plan.mCacheReg != "" && opEmitsCall(v.Op) && !plan.branchFused[v.ID] && !helperCallIsInline(plan, v) {
 			if _, inline := plan.globalInline[v.ID]; !inline {
 				a.EmitMCachePrime(b, plan.mCacheReg)
 			}

--- a/internal/asmgen/buildpkg.go
+++ b/internal/asmgen/buildpkg.go
@@ -569,6 +569,16 @@ func BuildPackageFiles(mod *wasm.Module, opts BuildPackageOptions) (map[string]s
 							"i64_rem_s", "i64_rem_u", "i64_rem_u_s":
 							helpersUsed["wasm_trap_div_zero"] = true
 						}
+						// The arm64 inline div_s emit additionally traps
+						// INT_MIN / −1 with an explicit
+						// `CALL ·wasm_trap_int_overflow(SB)` (arm64 SDIV
+						// wraps silently where amd64 IDIV raises #DE), so
+						// the signed divisions also need that stub in the
+						// per-chunk trampoline set.
+						switch name {
+						case "i32_div_s", "i64_div_s":
+							helpersUsed["wasm_trap_int_overflow"] = true
+						}
 					}
 				}
 			}

--- a/internal/asmgen/emit_archs.go
+++ b/internal/asmgen/emit_archs.go
@@ -190,6 +190,13 @@ func (archAMD64) RegHomeEligibleOp(op ssa.Op) bool {
 	return regHomeEligibleOp(op)
 }
 
+// CoalesceRegPool — amd64 draws loop-carry registers from the
+// unallocated tail of its block-local pool (see coalesceReservedPool
+// for the rationale).
+func (archAMD64) CoalesceRegPool() []string {
+	return coalesceReservedPool
+}
+
 // GPRegPool — amd64's block-local regalloc set. AX/CX/DX/BX/SI are
 // scratch in emitBin/emitLoad/emitStore; BP is the Go frame
 // pointer; R14 is the goroutine pointer. R11 is in the pool but

--- a/internal/asmgen/emit_archs.go
+++ b/internal/asmgen/emit_archs.go
@@ -1288,6 +1288,59 @@ func emitHelperCall(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argF
 	return nil
 }
 
+// inlineHelperNamesAMD64 is the set of helper names emitInlineHelper
+// handles WITHOUT a returning CALL. It must stay in sync with the
+// switch in emitInlineHelper — TestInlineHelperPredicateMatchesEmit
+// pins the correspondence by dry-running the emitter for every
+// registered helper name.
+//
+// Names in this set are transparent to the CALL-barrier analyses
+// (block-local regalloc, loop-carry coalesce, m-cache refresh): their
+// emit clobbers only the fixed scratches (AX/CX/DX/X0/X1), never a
+// pool or reserved register. The inline div/rem bodies DO contain a
+// conditional `CALL ·wasm_trap_*(SB)` on the divide-by-zero branch,
+// but those helpers panic and never return — execution never rejoins
+// the function with clobbered registers, so they are not a barrier.
+var inlineHelperNamesAMD64 = map[string]bool{
+	"i32_eqz": true, "i32_clz": true, "i32_ctz": true, "i32_popcnt": true,
+	"i32_rotl": true, "i32_rotr": true,
+	"i64_eqz": true, "i64_clz": true, "i64_ctz": true, "i64_popcnt": true,
+	"i64_rotl": true, "i64_rotr": true,
+	"i32_div_s": true, "i32_div_u_s": true,
+	"i32_rem_s": true, "i32_rem_u_s": true,
+	"i64_div_s": true, "i64_div_u_s": true,
+	"i64_rem_s": true, "i64_rem_u_s": true,
+	"i32_wrap_i64": true, "i64_extend_i32_s": true, "i64_extend_i32_u": true,
+	"i32_extend8_s": true, "i32_extend16_s": true,
+	"i64_extend8_s": true, "i64_extend16_s": true, "i64_extend32_s": true,
+	"i32_reinterpret_f32": true, "f32_reinterpret_i32": true,
+	"i64_reinterpret_f64": true, "f64_reinterpret_i64": true,
+	"f32_add": true, "f32_sub": true, "f32_mul": true, "f32_div": true,
+	"f64_add": true, "f64_sub": true, "f64_mul": true, "f64_div": true,
+	"f32_sqrt": true, "f64_sqrt": true,
+	"f32_abs": true, "f64_abs": true, "f32_neg": true, "f64_neg": true,
+	"f32_eq": true, "f32_ne": true, "f32_lt": true, "f32_le": true, "f32_gt": true, "f32_ge": true,
+	"f64_eq": true, "f64_ne": true, "f64_lt": true, "f64_le": true, "f64_gt": true, "f64_ge": true,
+	"f32_ceil": true, "f32_floor": true, "f32_trunc": true, "f32_nearest": true,
+	"f64_ceil": true, "f64_floor": true, "f64_trunc": true, "f64_nearest": true,
+	"f32_min": true, "f32_max": true, "f64_min": true, "f64_max": true,
+	"f32_copysign": true, "f64_copysign": true,
+	"f32_demote_f64": true, "f64_promote_f32": true,
+	"f32_convert_i32_s": true, "f32_convert_i64_s": true,
+	"f64_convert_i32_s": true, "f64_convert_i64_s": true,
+	"f32_convert_i32_u": true, "f64_convert_i32_u": true,
+	"f32_convert_i64_u": true, "f64_convert_i64_u": true,
+	"i32_trunc_sat_f32_s": true, "i32_trunc_sat_f64_s": true,
+	"i64_trunc_sat_f32_s": true, "i64_trunc_sat_f64_s": true,
+}
+
+// HelperIsInline — amd64 emits the helpers in inlineHelperNamesAMD64
+// without a returning CALL; everything else stages args and CALLs the
+// Go-side helper.
+func (archAMD64) HelperIsInline(name string) bool {
+	return inlineHelperNamesAMD64[name]
+}
+
 // emitInlineHelper emits the inline asm body for a known helper —
 // no CALL to a Go-side helper function. The asm-to-Go boundary is
 // reserved for user-registered callbacks (env imports and indirect

--- a/internal/asmgen/emitarm64.go
+++ b/internal/asmgen/emitarm64.go
@@ -298,13 +298,9 @@ func (a archARM64) EmitPhiCopySlot(b *strings.Builder, srcOff, dstOff int, t ssa
 	return a.emitPhiCopyARM64(b, fmt.Sprintf("%d(RSP)", srcOff), dstOff, t)
 }
 
-// EmitPhiCopyValueToReg is the arm64 entry-edge copy for the loop-carry
-// coalesce path. arm64 reports SupportsLoopCarryCoalesce() == false, so
-// the coalesce pass never runs and plan.coalescedPhi stays empty — this
-// method is therefore not reached in practice. The implementation is
-// kept (and correct) so that flipping the gate to true is the only
-// change required once the arm64 write-side regHome contract is
-// validated end-to-end.
+// EmitPhiCopyValueToReg is the arm64 edge copy for the loop-carry
+// coalesce path: every edge of an own-register phi and the forward
+// (entry) edge of a shared coalesce route through here.
 func (archARM64) EmitPhiCopyValueToReg(b *strings.Builder, src *ssa.Value, dstReg string, t ssa.Type, plan *funcPlan, frame argFrame) error {
 	// Same shape as archAMD64: read the source operand and MOV it
 	// straight into the coalesced register. arm64's `MOVW src, Rn`

--- a/internal/asmgen/emitarm64.go
+++ b/internal/asmgen/emitarm64.go
@@ -89,23 +89,31 @@ func emitCondBranchARM64(b *strings.Builder, branchOp, branchOpInv, thenLabel, e
 // carry is reloaded from its slot each iteration — always correct.
 func (archARM64) SupportsRegHome() bool { return true }
 
-// SupportsLoopCarryCoalesce — arm64 does NOT opt into the cross-block
-// loop-carry coalesce pass. That pass keeps a carry ONLY in a reserved
-// register across the whole loop body (no per-iteration slot reload),
-// which requires every per-op emit that can produce the carry to honour
-// plan.regHome on the write side. arm64 honours regHome for only a
-// subset of ops today, so a coalesced carry is not reliably maintained
-// across the loop — leaving it false keeps carries slot-resident, which
-// is correct. Flip to true only once the arm64 emit path is validated
-// end-to-end (and a matching reserved-register pool is chosen).
-func (archARM64) SupportsLoopCarryCoalesce() bool { return false }
+// SupportsLoopCarryCoalesce — arm64 opts into the cross-block
+// loop-carry coalesce pass. The SHARED mode is safe because the
+// candidate filter only accepts carries whose producer op passes
+// archARM64.RegHomeEligibleOp — exactly the ops whose write side
+// honours plan.regHome — and the OWN-REGISTER mode never requires a
+// producer write at all (the edge copies go through
+// EmitPhiCopyValueToReg). Reservation bookkeeping (loop body +
+// out-of-body live region) is arch-independent.
+func (archARM64) SupportsLoopCarryCoalesce() bool { return true }
 
-// HelperIsInline — conservative false for every helper until the
-// arm64 inline-helper set is audited for scratch-register discipline
-// the way inlineHelperNamesAMD64 was. Returning false keeps every
-// OpHelperCall a CALL barrier on arm64, exactly the pre-existing
-// behaviour.
-func (archARM64) HelperIsInline(string) bool { return false }
+// CoalesceRegPool — the unallocated tail of arm64's block-local pool
+// (R5..R15). R13/R14/R15 are not used as scratches by any arm64
+// per-op emit (R0-R3 / F0-F1 only), are not the m-cache (R4), and are
+// not Go-reserved (R18 platform, R27 assembler temp, R28 g, R29/R30
+// FP/LR).
+func (archARM64) CoalesceRegPool() []string {
+	return []string{"R13", "R14", "R15"}
+}
+
+// HelperIsInline — arm64 emits the helpers in inlineHelperNamesARM64
+// without a returning CALL (see emitInlineHelperARM64); everything
+// else stages args and CALLs the Go-side helper.
+func (archARM64) HelperIsInline(name string) bool {
+	return inlineHelperNamesARM64[name]
+}
 
 // RegHomeEligibleOp — arm64 honours regHome on the set of ops
 // where both the consumer-side reader (operandSrc{32,64}ARM64 /
@@ -940,6 +948,14 @@ func emitHelperCallARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame
 	if len(v.Args) != len(spec.params) {
 		return fmt.Errorf("helper %q wants %d args, got %d", name, len(spec.params), len(v.Args))
 	}
+	// Prefer inline asm — same policy as amd64's emitHelperCall. The
+	// helpers arm64 does not natively implement fall through to the
+	// staged CALL below.
+	if done, err := emitInlineHelperARM64(b, v, plan, frame, name); err != nil {
+		return err
+	} else if done {
+		return nil
+	}
 	// Same +8 bias as emitCallDirectARM64 — see CallArgBias() comment.
 	const bias = 8 // archARM64.CallArgBias()
 	off := 0
@@ -1178,4 +1194,628 @@ func emitCallDirectARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame
 		return fmt.Errorf("%v v%d: result type %v unsupported", v.Op, v.ID, d.sig.Results[0])
 	}
 	return nil
+}
+
+// inlineHelperNamesARM64 is the set of helper names
+// emitInlineHelperARM64 handles WITHOUT a returning CALL. It must
+// stay in sync with that function's switch —
+// TestInlineHelperPredicateMatchesEmitARM64 pins the correspondence
+// by dry-running the emitter for every registered helper name.
+//
+// Names in this set are transparent to the CALL-barrier analyses
+// (block-local regalloc, loop-carry coalesce, m-cache refresh): their
+// emit clobbers only the fixed scratches (R0-R3 / F0-F1), never a
+// pool or reserved register. The inline div/rem bodies contain
+// conditional `CALL ·wasm_trap_*(SB)` branches, but those helpers
+// panic and never return — execution never rejoins the function with
+// clobbered registers, so they are not a barrier.
+//
+// Differences from the amd64 set: popcnt stays a CALL (no scalar
+// arm64 popcount instruction), while ALL FOUR trunc_sat unsigned
+// variants join the inline set (FCVTZU saturates natively; amd64
+// only inlines the signed pair).
+var inlineHelperNamesARM64 = map[string]bool{
+	"i32_eqz": true, "i64_eqz": true,
+	"i32_clz": true, "i32_ctz": true, "i64_clz": true, "i64_ctz": true,
+	"i32_rotl": true, "i32_rotr": true, "i64_rotl": true, "i64_rotr": true,
+	"i32_div_s": true, "i32_div_u_s": true,
+	"i32_rem_s": true, "i32_rem_u_s": true,
+	"i64_div_s": true, "i64_div_u_s": true,
+	"i64_rem_s": true, "i64_rem_u_s": true,
+	"i32_wrap_i64": true, "i64_extend_i32_s": true, "i64_extend_i32_u": true,
+	"i32_extend8_s": true, "i32_extend16_s": true,
+	"i64_extend8_s": true, "i64_extend16_s": true, "i64_extend32_s": true,
+	"i32_reinterpret_f32": true, "f32_reinterpret_i32": true,
+	"i64_reinterpret_f64": true, "f64_reinterpret_i64": true,
+	"f32_add": true, "f32_sub": true, "f32_mul": true, "f32_div": true,
+	"f64_add": true, "f64_sub": true, "f64_mul": true, "f64_div": true,
+	"f32_sqrt": true, "f64_sqrt": true,
+	"f32_abs": true, "f64_abs": true, "f32_neg": true, "f64_neg": true,
+	"f32_eq": true, "f32_ne": true, "f32_lt": true, "f32_le": true, "f32_gt": true, "f32_ge": true,
+	"f64_eq": true, "f64_ne": true, "f64_lt": true, "f64_le": true, "f64_gt": true, "f64_ge": true,
+	"f32_ceil": true, "f32_floor": true, "f32_trunc": true, "f32_nearest": true,
+	"f64_ceil": true, "f64_floor": true, "f64_trunc": true, "f64_nearest": true,
+	"f32_min": true, "f32_max": true, "f64_min": true, "f64_max": true,
+	"f32_copysign": true, "f64_copysign": true,
+	"f32_demote_f64": true, "f64_promote_f32": true,
+	"f32_convert_i32_s": true, "f32_convert_i64_s": true,
+	"f64_convert_i32_s": true, "f64_convert_i64_s": true,
+	"f32_convert_i32_u": true, "f32_convert_i64_u": true,
+	"f64_convert_i32_u": true, "f64_convert_i64_u": true,
+	"i32_trunc_sat_f32_s": true, "i32_trunc_sat_f32_u": true,
+	"i32_trunc_sat_f64_s": true, "i32_trunc_sat_f64_u": true,
+	"i64_trunc_sat_f32_s": true, "i64_trunc_sat_f32_u": true,
+	"i64_trunc_sat_f64_s": true, "i64_trunc_sat_f64_u": true,
+}
+
+// isFloatRegARM64 reports whether s names an arm64 FP register (the
+// SSERegPool entries F2..F7 plus the F0/F1 scratches).
+func isFloatRegARM64(s string) bool {
+	return len(s) >= 2 && s[0] == 'F' && s[1] >= '0' && s[1] <= '9'
+}
+
+// emitInlineHelperARM64 emits the inline arm64 body for a known
+// helper — no CALL to a Go-side helper function. Returns true when
+// the helper was handled inline; emitHelperCallARM64 falls back to
+// the staged CALL otherwise.
+//
+// Scratch discipline: bodies read operands via
+// operandSrc{32,64}ARM64 / operandSrcFloat into R0/R1/R2/R3 and
+// F0/F1 only, and write the result to plan.regHome[v.ID] when the
+// regalloc assigned one (OpHelperCall is regHome-eligible on arm64)
+// or to the value's slot otherwise. Pool registers (R5..R15,
+// F2..F7) are never used as intermediates, so the CALL-barrier
+// subtraction in the regalloc/coalesce analyses stays sound. The
+// result register is only written AFTER every operand has been
+// read — an operand may itself live in the home register's pool
+// neighbourhood, but never in the result's own home (the linear
+// scan keeps an operand's register live through its last use).
+//
+// Instruction-selection notes (all verified by native execution on
+// darwin/arm64 before this landed):
+//   - SDIVW/UDIVW Rm, Rn, Rd computes Rd = Rn / Rm; MSUBW Rm, Rn,
+//     Ra, Rd computes Rd = Rn − Ra×Rm — together they form wasm's
+//     div/rem. arm64 division does NOT fault: div-by-zero returns 0
+//     and INT_MIN/−1 wraps, so the wasm traps are explicit compare+
+//     branch to the never-returning wasm_trap_* helpers (amd64 gets
+//     the same traps from the hardware #DE).
+//   - RORW/ROR $imm|Rm rotates right; rotl is ROR of the negated
+//     count (NEGW/NEG), which the hardware masks mod width.
+//   - FCMPS/FCMPD Fm, Fn sets flags from Fn ? Fm with unordered
+//     mapping such that CSET MI/LS/GT/GE/EQ are exactly wasm's
+//     lt/le/gt/ge/eq (false on NaN) and NE is wasm ne (true on NaN).
+//   - FCVTZS/FCVTZU saturate to the destination range and map NaN
+//     to 0 — precisely wasm's trunc_sat semantics, one instruction.
+//   - FMIN/FMAX propagate NaN and order ±0 the way wasm requires.
+//   - CLZ handles a zero input (returns the width) with no branch,
+//     so clz/ctz have no labels at all (ctz = CLZ ∘ RBIT).
+func emitInlineHelperARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFrame, name string) (bool, error) {
+	dst := plan.offsets[v.ID]
+	home := plan.regHome[v.ID]
+	// Integer result target: the value's home register when it has
+	// one, else the R0 scratch followed by a slot store.
+	iTgt, iStore := "R0", true
+	if home != "" && !isFloatRegARM64(home) {
+		iTgt, iStore = home, false
+	}
+	fTgt, fStore := "F0", true
+	if home != "" && isFloatRegARM64(home) {
+		fTgt, fStore = home, false
+	}
+	storeI32 := func() {
+		if iStore {
+			fmt.Fprintf(b, "\tMOVW %s, %d(RSP)\n", iTgt, dst)
+		}
+	}
+	storeI64 := func() {
+		if iStore {
+			fmt.Fprintf(b, "\tMOVD %s, %d(RSP)\n", iTgt, dst)
+		}
+	}
+	storeF32 := func() {
+		if fStore {
+			fmt.Fprintf(b, "\tFMOVS %s, %d(RSP)\n", fTgt, dst)
+		}
+	}
+	storeF64 := func() {
+		if fStore {
+			fmt.Fprintf(b, "\tFMOVD %s, %d(RSP)\n", fTgt, dst)
+		}
+	}
+	src32 := func(i int) string { return operandSrc32ARM64(v.Args[i], plan, frame) }
+	src64 := func(i int) string { return operandSrc64ARM64(v.Args[i], plan, frame) }
+	srcF := func(i int) string { return operandSrcFloat(v.Args[i], plan, frame, "RSP") }
+
+	// floatBin/floatUn/floatCmp factor the fully regular float
+	// families; the switch below routes each name with its mnemonic.
+	floatBin := func(mnem string, is64 bool) (bool, error) {
+		mov := "FMOVS"
+		if is64 {
+			mov = "FMOVD"
+		}
+		fmt.Fprintf(b, "\t%s %s, F0\n", mov, srcF(0))
+		fmt.Fprintf(b, "\t%s %s, F1\n", mov, srcF(1))
+		fmt.Fprintf(b, "\t%s F1, F0\n", mnem) // F0 = F0 <op> F1
+		if fTgt != "F0" {
+			fmt.Fprintf(b, "\t%s F0, %s\n", mov, fTgt)
+		}
+		if is64 {
+			storeF64()
+		} else {
+			storeF32()
+		}
+		return true, nil
+	}
+	floatBin3 := func(mnem string, is64 bool) (bool, error) {
+		// FMIN/FMAX use the 3-operand form so the result can land in
+		// the home register directly.
+		mov := "FMOVS"
+		if is64 {
+			mov = "FMOVD"
+		}
+		fmt.Fprintf(b, "\t%s %s, F0\n", mov, srcF(0))
+		fmt.Fprintf(b, "\t%s %s, F1\n", mov, srcF(1))
+		fmt.Fprintf(b, "\t%s F1, F0, %s\n", mnem, fTgt) // fTgt = min/max(F0, F1)
+		if is64 {
+			storeF64()
+		} else {
+			storeF32()
+		}
+		return true, nil
+	}
+	floatUn := func(mnem string, is64 bool) (bool, error) {
+		mov := "FMOVS"
+		if is64 {
+			mov = "FMOVD"
+		}
+		fmt.Fprintf(b, "\t%s %s, F0\n", mov, srcF(0))
+		fmt.Fprintf(b, "\t%s F0, %s\n", mnem, fTgt)
+		if is64 {
+			storeF64()
+		} else {
+			storeF32()
+		}
+		return true, nil
+	}
+	floatCmp := func(cond string, is64 bool) (bool, error) {
+		mov, cmp := "FMOVS", "FCMPS"
+		if is64 {
+			mov, cmp = "FMOVD", "FCMPD"
+		}
+		fmt.Fprintf(b, "\t%s %s, F0\n", mov, srcF(0))
+		fmt.Fprintf(b, "\t%s %s, F1\n", mov, srcF(1))
+		fmt.Fprintf(b, "\t%s F1, F0\n", cmp) // flags from F0 ? F1
+		fmt.Fprintf(b, "\tCSET %s, %s\n", cond, iTgt)
+		storeI32()
+		return true, nil
+	}
+	convert := func(cvt string, srcIs64 bool, dstIs64 bool) (bool, error) {
+		if srcIs64 {
+			fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		} else {
+			fmt.Fprintf(b, "\tMOVWU %s, R1\n", src32(0))
+		}
+		fmt.Fprintf(b, "\t%s R1, %s\n", cvt, fTgt)
+		if dstIs64 {
+			storeF64()
+		} else {
+			storeF32()
+		}
+		return true, nil
+	}
+	truncSat := func(cvt string, srcIs64 bool, dstIs64 bool) (bool, error) {
+		mov := "FMOVS"
+		if srcIs64 {
+			mov = "FMOVD"
+		}
+		fmt.Fprintf(b, "\t%s %s, F0\n", mov, srcF(0))
+		fmt.Fprintf(b, "\t%s F0, %s\n", cvt, iTgt)
+		if dstIs64 {
+			storeI64()
+		} else {
+			storeI32()
+		}
+		return true, nil
+	}
+	// divRem emits the shared div/rem skeleton: explicit div-by-zero
+	// trap, optional signed-overflow trap (div_s only — rem_s of
+	// INT_MIN/−1 is 0 by MSUB wraparound, which is what wasm wants),
+	// then SDIV/UDIV (+ MSUB for rem).
+	divRem := func(is64, signed, rem bool) (bool, error) {
+		movLoad := "MOVWU"
+		if signed {
+			movLoad = "MOVW"
+		}
+		cmp, div, msub, minConst := "CMPW", "UDIVW", "MSUBW", ""
+		if signed {
+			div = "SDIVW"
+			minConst = "$-2147483648"
+		}
+		if is64 {
+			cmp, div, msub = "CMP", "UDIV", "MSUB"
+			if signed {
+				div = "SDIV"
+				minConst = "$-9223372036854775808"
+			}
+			movLoad = "MOVD"
+		}
+		var s0, s1 string
+		if is64 {
+			s0, s1 = src64(0), src64(1)
+		} else {
+			s0, s1 = src32(0), src32(1)
+		}
+		zeroLbl := fmt.Sprintf("DIVZ_%d", v.ID)
+		doneLbl := fmt.Sprintf("DIVD_%d", v.ID)
+		okLbl := fmt.Sprintf("DIVOK_%d", v.ID)
+		fmt.Fprintf(b, "\t%s %s, R1\n", movLoad, s0)
+		fmt.Fprintf(b, "\t%s %s, R2\n", movLoad, s1)
+		fmt.Fprintf(b, "\t%s $0, R2\n", cmp)
+		fmt.Fprintf(b, "\tBEQ %s\n", zeroLbl)
+		if signed && !rem {
+			// wasm div_s traps on INT_MIN / −1; arm64 SDIV wraps
+			// silently, so the trap is explicit.
+			fmt.Fprintf(b, "\t%s $-1, R2\n", cmp)
+			fmt.Fprintf(b, "\tBNE %s\n", okLbl)
+			fmt.Fprintf(b, "\tMOVD %s, R3\n", minConst)
+			fmt.Fprintf(b, "\t%s R3, R1\n", cmp)
+			fmt.Fprintf(b, "\tBNE %s\n", okLbl)
+			fmt.Fprintf(b, "\tCALL %s\n", goCallSymbol(plan.helperPfx, "wasm_trap_int_overflow"))
+			fmt.Fprintf(b, "%s:\n", okLbl)
+		}
+		if rem {
+			fmt.Fprintf(b, "\t%s R2, R1, R3\n", div)
+			fmt.Fprintf(b, "\t%s R2, R1, R3, %s\n", msub, iTgt) // iTgt = R1 − R3×R2
+		} else {
+			fmt.Fprintf(b, "\t%s R2, R1, %s\n", div, iTgt)
+		}
+		if is64 {
+			storeI64()
+		} else {
+			storeI32()
+		}
+		fmt.Fprintf(b, "\tJMP %s\n", doneLbl)
+		fmt.Fprintf(b, "%s:\n", zeroLbl)
+		fmt.Fprintf(b, "\tCALL %s\n", goCallSymbol(plan.helperPfx, "wasm_trap_div_zero"))
+		fmt.Fprintf(b, "%s:\n", doneLbl)
+		return true, nil
+	}
+	rotate := func(is64, left bool) (bool, error) {
+		width := 32
+		movLoad, ror, neg := "MOVWU", "RORW", "NEGW"
+		if is64 {
+			width = 64
+			movLoad, ror, neg = "MOVD", "ROR", "NEG"
+		}
+		var s0 string
+		var imm int64
+		var immOK bool
+		if is64 {
+			s0 = src64(0)
+			imm, immOK = inlineableI64(v.Args[1])
+		} else {
+			s0 = src32(0)
+			var imm32 int32
+			imm32, immOK = inlineableI32(v.Args[1])
+			imm = int64(imm32)
+		}
+		fmt.Fprintf(b, "\t%s %s, R1\n", movLoad, s0)
+		if immOK {
+			n := uint64(imm) & uint64(width-1)
+			if left {
+				n = uint64(width) - n
+				n &= uint64(width - 1)
+			}
+			fmt.Fprintf(b, "\t%s $%d, R1, %s\n", ror, n, iTgt)
+		} else {
+			var s1 string
+			if is64 {
+				s1 = src64(1)
+			} else {
+				s1 = src32(1)
+			}
+			fmt.Fprintf(b, "\t%s %s, R2\n", movLoad, s1)
+			if left {
+				// rotl(x, n) == rotr(x, −n); the hardware masks the
+				// count mod width, which also makes n == 0 exact.
+				fmt.Fprintf(b, "\t%s R2, R2\n", neg)
+			}
+			fmt.Fprintf(b, "\t%s R2, R1, %s\n", ror, iTgt)
+		}
+		if is64 {
+			storeI64()
+		} else {
+			storeI32()
+		}
+		return true, nil
+	}
+
+	switch name {
+	// --- integer predicates / bit scans ---
+	case "i32_eqz":
+		fmt.Fprintf(b, "\tMOVWU %s, R1\n", src32(0))
+		fmt.Fprintf(b, "\tCMPW $0, R1\n")
+		fmt.Fprintf(b, "\tCSET EQ, %s\n", iTgt)
+		storeI32()
+		return true, nil
+	case "i64_eqz":
+		fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		fmt.Fprintf(b, "\tCMP $0, R1\n")
+		fmt.Fprintf(b, "\tCSET EQ, %s\n", iTgt)
+		storeI32()
+		return true, nil
+	case "i32_clz":
+		fmt.Fprintf(b, "\tMOVWU %s, R1\n", src32(0))
+		fmt.Fprintf(b, "\tCLZW R1, %s\n", iTgt)
+		storeI32()
+		return true, nil
+	case "i32_ctz":
+		fmt.Fprintf(b, "\tMOVWU %s, R1\n", src32(0))
+		fmt.Fprintf(b, "\tRBITW R1, R1\n")
+		fmt.Fprintf(b, "\tCLZW R1, %s\n", iTgt)
+		storeI32()
+		return true, nil
+	case "i64_clz":
+		fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		fmt.Fprintf(b, "\tCLZ R1, %s\n", iTgt)
+		storeI64()
+		return true, nil
+	case "i64_ctz":
+		fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		fmt.Fprintf(b, "\tRBIT R1, R1\n")
+		fmt.Fprintf(b, "\tCLZ R1, %s\n", iTgt)
+		storeI64()
+		return true, nil
+
+	// --- rotates ---
+	case "i32_rotl":
+		return rotate(false, true)
+	case "i32_rotr":
+		return rotate(false, false)
+	case "i64_rotl":
+		return rotate(true, true)
+	case "i64_rotr":
+		return rotate(true, false)
+
+	// --- division / remainder ---
+	case "i32_div_s":
+		return divRem(false, true, false)
+	case "i32_div_u_s":
+		return divRem(false, false, false)
+	case "i32_rem_s":
+		return divRem(false, true, true)
+	case "i32_rem_u_s":
+		return divRem(false, false, true)
+	case "i64_div_s":
+		return divRem(true, true, false)
+	case "i64_div_u_s":
+		return divRem(true, false, false)
+	case "i64_rem_s":
+		return divRem(true, true, true)
+	case "i64_rem_u_s":
+		return divRem(true, false, true)
+
+	// --- width changes ---
+	case "i32_wrap_i64":
+		fmt.Fprintf(b, "\tMOVWU %s, %s\n", src64(0), iTgt)
+		storeI32()
+		return true, nil
+	case "i64_extend_i32_s":
+		fmt.Fprintf(b, "\tMOVW %s, %s\n", src32(0), iTgt)
+		storeI64()
+		return true, nil
+	case "i64_extend_i32_u":
+		fmt.Fprintf(b, "\tMOVWU %s, %s\n", src32(0), iTgt)
+		storeI64()
+		return true, nil
+	case "i32_extend8_s":
+		fmt.Fprintf(b, "\tMOVB %s, %s\n", src32(0), iTgt)
+		storeI32()
+		return true, nil
+	case "i32_extend16_s":
+		fmt.Fprintf(b, "\tMOVH %s, %s\n", src32(0), iTgt)
+		storeI32()
+		return true, nil
+	case "i64_extend8_s":
+		fmt.Fprintf(b, "\tMOVB %s, %s\n", src64(0), iTgt)
+		storeI64()
+		return true, nil
+	case "i64_extend16_s":
+		fmt.Fprintf(b, "\tMOVH %s, %s\n", src64(0), iTgt)
+		storeI64()
+		return true, nil
+	case "i64_extend32_s":
+		fmt.Fprintf(b, "\tMOVW %s, %s\n", src64(0), iTgt)
+		storeI64()
+		return true, nil
+
+	// --- reinterpret ---
+	case "i32_reinterpret_f32":
+		fmt.Fprintf(b, "\tFMOVS %s, F0\n", srcF(0))
+		fmt.Fprintf(b, "\tFMOVS F0, %s\n", iTgt)
+		storeI32()
+		return true, nil
+	case "f32_reinterpret_i32":
+		fmt.Fprintf(b, "\tMOVWU %s, R1\n", src32(0))
+		fmt.Fprintf(b, "\tFMOVS R1, %s\n", fTgt)
+		storeF32()
+		return true, nil
+	case "i64_reinterpret_f64":
+		fmt.Fprintf(b, "\tFMOVD %s, F0\n", srcF(0))
+		fmt.Fprintf(b, "\tFMOVD F0, %s\n", iTgt)
+		storeI64()
+		return true, nil
+	case "f64_reinterpret_i64":
+		fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		fmt.Fprintf(b, "\tFMOVD R1, %s\n", fTgt)
+		storeF64()
+		return true, nil
+
+	// --- float arithmetic ---
+	case "f32_add":
+		return floatBin("FADDS", false)
+	case "f32_sub":
+		return floatBin("FSUBS", false)
+	case "f32_mul":
+		return floatBin("FMULS", false)
+	case "f32_div":
+		return floatBin("FDIVS", false)
+	case "f64_add":
+		return floatBin("FADDD", true)
+	case "f64_sub":
+		return floatBin("FSUBD", true)
+	case "f64_mul":
+		return floatBin("FMULD", true)
+	case "f64_div":
+		return floatBin("FDIVD", true)
+	case "f32_sqrt":
+		return floatUn("FSQRTS", false)
+	case "f64_sqrt":
+		return floatUn("FSQRTD", true)
+	case "f32_abs":
+		return floatUn("FABSS", false)
+	case "f64_abs":
+		return floatUn("FABSD", true)
+	case "f32_neg":
+		return floatUn("FNEGS", false)
+	case "f64_neg":
+		return floatUn("FNEGD", true)
+	case "f32_min":
+		return floatBin3("FMINS", false)
+	case "f32_max":
+		return floatBin3("FMAXS", false)
+	case "f64_min":
+		return floatBin3("FMIND", true)
+	case "f64_max":
+		return floatBin3("FMAXD", true)
+
+	// --- float compares (flags false on NaN except NE) ---
+	case "f32_eq":
+		return floatCmp("EQ", false)
+	case "f32_ne":
+		return floatCmp("NE", false)
+	case "f32_lt":
+		return floatCmp("MI", false)
+	case "f32_le":
+		return floatCmp("LS", false)
+	case "f32_gt":
+		return floatCmp("GT", false)
+	case "f32_ge":
+		return floatCmp("GE", false)
+	case "f64_eq":
+		return floatCmp("EQ", true)
+	case "f64_ne":
+		return floatCmp("NE", true)
+	case "f64_lt":
+		return floatCmp("MI", true)
+	case "f64_le":
+		return floatCmp("LS", true)
+	case "f64_gt":
+		return floatCmp("GT", true)
+	case "f64_ge":
+		return floatCmp("GE", true)
+
+	// --- float rounding ---
+	case "f32_ceil":
+		return floatUn("FRINTPS", false)
+	case "f32_floor":
+		return floatUn("FRINTMS", false)
+	case "f32_trunc":
+		return floatUn("FRINTZS", false)
+	case "f32_nearest":
+		return floatUn("FRINTNS", false)
+	case "f64_ceil":
+		return floatUn("FRINTPD", true)
+	case "f64_floor":
+		return floatUn("FRINTMD", true)
+	case "f64_trunc":
+		return floatUn("FRINTZD", true)
+	case "f64_nearest":
+		return floatUn("FRINTND", true)
+
+	// --- copysign (bit surgery through the GP side) ---
+	case "f32_copysign":
+		fmt.Fprintf(b, "\tFMOVS %s, F0\n", srcF(0))
+		fmt.Fprintf(b, "\tFMOVS %s, F1\n", srcF(1))
+		fmt.Fprintf(b, "\tFMOVS F0, R1\n")
+		fmt.Fprintf(b, "\tFMOVS F1, R2\n")
+		fmt.Fprintf(b, "\tBICW $2147483648, R1, R1\n")
+		fmt.Fprintf(b, "\tANDW $2147483648, R2, R2\n")
+		fmt.Fprintf(b, "\tORRW R2, R1, R1\n")
+		fmt.Fprintf(b, "\tFMOVS R1, %s\n", fTgt)
+		storeF32()
+		return true, nil
+	case "f64_copysign":
+		fmt.Fprintf(b, "\tFMOVD %s, F0\n", srcF(0))
+		fmt.Fprintf(b, "\tFMOVD %s, F1\n", srcF(1))
+		fmt.Fprintf(b, "\tFMOVD F0, R1\n")
+		fmt.Fprintf(b, "\tFMOVD F1, R2\n")
+		fmt.Fprintf(b, "\tBIC $-9223372036854775808, R1, R1\n")
+		fmt.Fprintf(b, "\tAND $-9223372036854775808, R2, R2\n")
+		fmt.Fprintf(b, "\tORR R2, R1, R1\n")
+		fmt.Fprintf(b, "\tFMOVD R1, %s\n", fTgt)
+		storeF64()
+		return true, nil
+
+	// --- float width conversions ---
+	case "f32_demote_f64":
+		fmt.Fprintf(b, "\tFMOVD %s, F0\n", srcF(0))
+		fmt.Fprintf(b, "\tFCVTDS F0, %s\n", fTgt)
+		storeF32()
+		return true, nil
+	case "f64_promote_f32":
+		fmt.Fprintf(b, "\tFMOVS %s, F0\n", srcF(0))
+		fmt.Fprintf(b, "\tFCVTSD F0, %s\n", fTgt)
+		storeF64()
+		return true, nil
+
+	// --- int → float conversions (arm64 has native unsigned forms) ---
+	case "f32_convert_i32_s":
+		fmt.Fprintf(b, "\tMOVW %s, R1\n", src32(0))
+		fmt.Fprintf(b, "\tSCVTFWS R1, %s\n", fTgt)
+		storeF32()
+		return true, nil
+	case "f64_convert_i32_s":
+		fmt.Fprintf(b, "\tMOVW %s, R1\n", src32(0))
+		fmt.Fprintf(b, "\tSCVTFWD R1, %s\n", fTgt)
+		storeF64()
+		return true, nil
+	case "f32_convert_i64_s":
+		fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		fmt.Fprintf(b, "\tSCVTFS R1, %s\n", fTgt)
+		storeF32()
+		return true, nil
+	case "f64_convert_i64_s":
+		fmt.Fprintf(b, "\tMOVD %s, R1\n", src64(0))
+		fmt.Fprintf(b, "\tSCVTFD R1, %s\n", fTgt)
+		storeF64()
+		return true, nil
+	case "f32_convert_i32_u":
+		return convert("UCVTFWS", false, false)
+	case "f64_convert_i32_u":
+		return convert("UCVTFWD", false, true)
+	case "f32_convert_i64_u":
+		return convert("UCVTFS", true, false)
+	case "f64_convert_i64_u":
+		return convert("UCVTFD", true, true)
+
+	// --- saturating float → int (single native instruction) ---
+	case "i32_trunc_sat_f32_s":
+		return truncSat("FCVTZSSW", false, false)
+	case "i32_trunc_sat_f64_s":
+		return truncSat("FCVTZSDW", true, false)
+	case "i64_trunc_sat_f32_s":
+		return truncSat("FCVTZSS", false, true)
+	case "i64_trunc_sat_f64_s":
+		return truncSat("FCVTZSD", true, true)
+	case "i32_trunc_sat_f32_u":
+		return truncSat("FCVTZUSW", false, false)
+	case "i32_trunc_sat_f64_u":
+		return truncSat("FCVTZUDW", true, false)
+	case "i64_trunc_sat_f32_u":
+		return truncSat("FCVTZUS", false, true)
+	case "i64_trunc_sat_f64_u":
+		return truncSat("FCVTZUD", true, true)
+	}
+	return false, nil
 }

--- a/internal/asmgen/emitarm64.go
+++ b/internal/asmgen/emitarm64.go
@@ -100,6 +100,13 @@ func (archARM64) SupportsRegHome() bool { return true }
 // end-to-end (and a matching reserved-register pool is chosen).
 func (archARM64) SupportsLoopCarryCoalesce() bool { return false }
 
+// HelperIsInline — conservative false for every helper until the
+// arm64 inline-helper set is audited for scratch-register discipline
+// the way inlineHelperNamesAMD64 was. Returning false keeps every
+// OpHelperCall a CALL barrier on arm64, exactly the pre-existing
+// behaviour.
+func (archARM64) HelperIsInline(string) bool { return false }
+
 // RegHomeEligibleOp — arm64 honours regHome on the set of ops
 // where both the consumer-side reader (operandSrc{32,64}ARM64 /
 // operandSrcFloat) and the producer-side write path have been

--- a/internal/asmgen/inline_helper_predicate_test.go
+++ b/internal/asmgen/inline_helper_predicate_test.go
@@ -1,0 +1,68 @@
+package asmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// TestInlineHelperPredicateMatchesEmit pins inlineHelperNamesAMD64 to
+// the emitInlineHelper switch: for every registered helper name, the
+// predicate must agree with what a dry-run of the emitter actually
+// does. A helper added to the switch without updating the set (or
+// vice versa) fails here — the set feeds the CALL-barrier analyses
+// (block-local regalloc, loop-carry coalesce, m-cache refresh), so a
+// drift in either direction is a silent perf or correctness hazard.
+func TestInlineHelperPredicateMatchesEmit(t *testing.T) {
+	synth := func(id ssa.ValueID, typ ssa.Type) *ssa.Value {
+		v := &ssa.Value{ID: id, Type: typ}
+		switch typ {
+		case ssa.TypeI32:
+			v.Op = ssa.OpConst32
+			v.AuxInt = 1
+		case ssa.TypeI64:
+			v.Op = ssa.OpConst64
+			v.AuxInt = 1
+		case ssa.TypeF32:
+			v.Op = ssa.OpConstF32
+		case ssa.TypeF64:
+			v.Op = ssa.OpConstF64
+		default:
+			t.Fatalf("unexpected helper param type %v", typ)
+		}
+		return v
+	}
+	for name, spec := range helperSigs {
+		args := make([]*ssa.Value, len(spec.params))
+		for i, pt := range spec.params {
+			args[i] = synth(ssa.ValueID(i+1), pt)
+		}
+		retType := spec.ret
+		if retType == ssa.TypeInvalid {
+			retType = ssa.TypeMem
+		}
+		v := &ssa.Value{ID: 100, Op: ssa.OpHelperCall, Type: retType, Args: args}
+		plan := &funcPlan{
+			offsets: map[ssa.ValueID]int{},
+			regHome: map[ssa.ValueID]string{},
+		}
+		var b strings.Builder
+		done, err := emitInlineHelper(&b, v, plan, argFrame{}, name)
+		if err != nil {
+			t.Errorf("helper %q: dry-run emit error: %v", name, err)
+			continue
+		}
+		if got := inlineHelperNamesAMD64[name]; got != done {
+			t.Errorf("helper %q: inlineHelperNamesAMD64=%v but emitInlineHelper handled-inline=%v — keep the set in sync with the switch",
+				name, got, done)
+		}
+	}
+	// The inline set must not name helpers that don't exist in the
+	// registry (typo guard).
+	for name := range inlineHelperNamesAMD64 {
+		if _, ok := helperSigs[name]; !ok {
+			t.Errorf("inlineHelperNamesAMD64 names unknown helper %q", name)
+		}
+	}
+}

--- a/internal/asmgen/inline_helper_predicate_test.go
+++ b/internal/asmgen/inline_helper_predicate_test.go
@@ -66,3 +66,58 @@ func TestInlineHelperPredicateMatchesEmit(t *testing.T) {
 		}
 	}
 }
+
+// TestInlineHelperPredicateMatchesEmitARM64 is the arm64 counterpart
+// of TestInlineHelperPredicateMatchesEmit: inlineHelperNamesARM64
+// must agree with a dry-run of emitInlineHelperARM64 for every
+// registered helper name.
+func TestInlineHelperPredicateMatchesEmitARM64(t *testing.T) {
+	synth := func(id ssa.ValueID, typ ssa.Type) *ssa.Value {
+		v := &ssa.Value{ID: id, Type: typ}
+		switch typ {
+		case ssa.TypeI32:
+			v.Op = ssa.OpConst32
+			v.AuxInt = 1
+		case ssa.TypeI64:
+			v.Op = ssa.OpConst64
+			v.AuxInt = 1
+		case ssa.TypeF32:
+			v.Op = ssa.OpConstF32
+		case ssa.TypeF64:
+			v.Op = ssa.OpConstF64
+		default:
+			t.Fatalf("unexpected helper param type %v", typ)
+		}
+		return v
+	}
+	for name, spec := range helperSigs {
+		args := make([]*ssa.Value, len(spec.params))
+		for i, pt := range spec.params {
+			args[i] = synth(ssa.ValueID(i+1), pt)
+		}
+		retType := spec.ret
+		if retType == ssa.TypeInvalid {
+			retType = ssa.TypeMem
+		}
+		v := &ssa.Value{ID: 100, Op: ssa.OpHelperCall, Type: retType, Args: args}
+		plan := &funcPlan{
+			offsets: map[ssa.ValueID]int{},
+			regHome: map[ssa.ValueID]string{},
+		}
+		var b strings.Builder
+		done, err := emitInlineHelperARM64(&b, v, plan, argFrame{}, name)
+		if err != nil {
+			t.Errorf("helper %q: arm64 dry-run emit error: %v", name, err)
+			continue
+		}
+		if got := inlineHelperNamesARM64[name]; got != done {
+			t.Errorf("helper %q: inlineHelperNamesARM64=%v but emitInlineHelperARM64 handled-inline=%v — keep the set in sync with the switch",
+				name, got, done)
+		}
+	}
+	for name := range inlineHelperNamesARM64 {
+		if _, ok := helperSigs[name]; !ok {
+			t.Errorf("inlineHelperNamesARM64 names unknown helper %q", name)
+		}
+	}
+}

--- a/internal/asmgen/regalloc.go
+++ b/internal/asmgen/regalloc.go
@@ -162,15 +162,16 @@ func computeRegHomes(f *ssa.Func, plan *funcPlan) {
 	// carry it was holding for.
 	// The cross-block loop-carry coalesce pass runs only on arches with
 	// a validated coalesce emit path (plan.supportsCoalesce, set from
-	// arch.SupportsLoopCarryCoalesce()). It is STRICTLY stronger than
-	// block-local regalloc: it keeps a carry in a reserved register
-	// across the whole loop with no per-iteration slot reload, so every
-	// per-op emit that can produce the carry must honour plan.regHome on
-	// the write side. An arch that only partially honours regHome (e.g.
-	// arm64 today) must NOT run this pass or the carry is silently
-	// clobbered. WASM2GO_NO_COALESCE additionally disables it everywhere
-	// — a fast kill-switch for confirming or ruling out the pass when a
-	// codegen miscompile is suspected.
+	// arch.SupportsLoopCarryCoalesce(); both amd64 and arm64 opt in).
+	// The SHARED mode is STRICTLY stronger than block-local regalloc —
+	// it keeps a carry in a reserved register across the whole loop
+	// with no per-iteration slot reload, so the eligibility filter
+	// only admits carries whose producer emit honours plan.regHome on
+	// the write side (planRegHomeEligibleOp, per arch). The
+	// OWN-REGISTER mode needs no producer cooperation (edge copies go
+	// through EmitPhiCopyValueToReg). WASM2GO_NO_COALESCE disables the
+	// pass everywhere — a fast kill-switch for confirming or ruling
+	// out the pass when a codegen miscompile is suspected.
 	if plan.supportsCoalesce && os.Getenv("WASM2GO_NO_COALESCE") == "" {
 		runCoalescePass(f, plan)
 	}
@@ -461,11 +462,10 @@ func assignBlockRegHomes(blk *ssa.Block, f *ssa.Func, plan *funcPlan) {
 			continue
 		}
 		// Inline-emitted helpers clobber only the fixed scratches
-		// (AX/CX/DX/X0/X1), never a pool register — a lifetime that
-		// crosses one is register-safe. WASM2GO_HELPER_BARRIER_REGALLOC
-		// restores the legacy behaviour (inline helpers barrier the
-		// block-local scan) — a bisect kill-switch.
-		if os.Getenv("WASM2GO_HELPER_BARRIER_REGALLOC") == "" && helperCallIsInline(plan, v) {
+		// (AX/CX/DX/X0/X1 on amd64, R0-R3/F0-F1 on arm64), never a
+		// pool register — a lifetime that crosses one is
+		// register-safe.
+		if helperCallIsInline(plan, v) {
 			continue
 		}
 		hasCallAt[i] = true

--- a/internal/asmgen/regalloc.go
+++ b/internal/asmgen/regalloc.go
@@ -462,8 +462,10 @@ func assignBlockRegHomes(blk *ssa.Block, f *ssa.Func, plan *funcPlan) {
 		}
 		// Inline-emitted helpers clobber only the fixed scratches
 		// (AX/CX/DX/X0/X1), never a pool register — a lifetime that
-		// crosses one is register-safe.
-		if helperCallIsInline(plan, v) {
+		// crosses one is register-safe. WASM2GO_HELPER_BARRIER_REGALLOC
+		// restores the legacy behaviour (inline helpers barrier the
+		// block-local scan) — a bisect kill-switch.
+		if os.Getenv("WASM2GO_HELPER_BARRIER_REGALLOC") == "" && helperCallIsInline(plan, v) {
 			continue
 		}
 		hasCallAt[i] = true

--- a/internal/asmgen/regalloc.go
+++ b/internal/asmgen/regalloc.go
@@ -460,6 +460,12 @@ func assignBlockRegHomes(blk *ssa.Block, f *ssa.Func, plan *funcPlan) {
 		if _, ok := plan.globalInline[v.ID]; ok {
 			continue
 		}
+		// Inline-emitted helpers clobber only the fixed scratches
+		// (AX/CX/DX/X0/X1), never a pool register — a lifetime that
+		// crosses one is register-safe.
+		if helperCallIsInline(plan, v) {
+			continue
+		}
 		hasCallAt[i] = true
 	}
 

--- a/internal/asmgen/regalloc_coalesce.go
+++ b/internal/asmgen/regalloc_coalesce.go
@@ -46,10 +46,34 @@ import (
 //     body; plan.coalescedPhi[P.ID] = R so emitPhiCopyValue can
 //     short-circuit the back-edge copy.
 //
-// This is intentionally conservative — single-phi natural loops
-// with no CALL inside, only — to keep the failure mode bounded
-// while we land it. Nested loops, multi-phi coalescing, and
-// CALL-spanning carries are follow-ups.
+// Two coalesce modes exist, tried in this order per phi:
+//
+//   - SHARED mode (the original): P and its unique back-edge carry V
+//     share one register. Requires V to be P's SOLE user function-wide
+//     (V's write to the shared register destroys P) and V's producer
+//     to honour regHome on the write side. The back-edge copy is
+//     elided entirely.
+//
+//   - OWN-REGISTER mode: P gets a register of its own; V is left
+//     wherever it lives (slot or block-local register). Every edge
+//     copy into P becomes a single `MOV <src>, R` (emitted by
+//     EmitPhiCopyValueToReg on entry AND back edges), and every
+//     in-loop read of P comes out of R via operandSrc. This fires for
+//     the multi-user carries the shared mode must decline — the
+//     varint-decoder shape (pos/shift/acc phis each read by several
+//     ops per iteration) that pprof flagged as the dominant asm-vs-
+//     pure-Go gap on the window suite. The per-iteration win is the
+//     removal of the store-to-load forwarding chain through the
+//     phi's stack slot.
+//
+// Both modes require the loop body to be CALL-free (Go ABI0
+// preserves none of R12/R13/R15 across a CALL) and the carry to not
+// be live across a CALL on any loop-exit path. The reserved register
+// is excluded from the per-block linear scan in every loop-body
+// block AND every out-of-body block the phi (or shared carry) is
+// still live in — an exit-path reader consumes the register long
+// after the body, so a block-local value grabbing R12 there would
+// clobber the carry before its last read.
 
 // coalesceReservedPool is the dedicated register set the
 // coalesce pass draws from when reserving a register across a
@@ -94,6 +118,14 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 			if _, ok := plan.globalInline[v.ID]; ok {
 				continue
 			}
+			// Inline-emitted helpers (extends, rotates, div/rem,
+			// float arith) produce no returning CALL and never touch
+			// a reserved register — without this subtraction a
+			// single i64.extend in a varint-decode loop marks the
+			// whole loop call-unsafe and blocks every coalesce in it.
+			if helperCallIsInline(plan, v) {
+				continue
+			}
 			blockHasCall[blk.ID] = true
 			break
 		}
@@ -118,6 +150,14 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 	// another phi's back-edge arg, a second consumer in some other
 	// block) would silently observe V's bytes instead.
 	phiUsers := map[ssa.ValueID]int{}
+	// soleUser[id] remembers the (last-seen) value that reads id; it is
+	// THE user exactly when phiUsers[id] == 1. The shared coalesce must
+	// verify that P's single user IS the back-edge carry V — a phi whose
+	// one user is anything else (the "lag" pattern: prev = phi(init, cur)
+	// with prev consumed by an exit read or an unrelated op) reads P
+	// AFTER V has already overwritten the shared register within the
+	// iteration, observing the new value instead of the phi.
+	soleUser := map[ssa.ValueID]*ssa.Value{}
 	phiUsedAsControl := map[ssa.ValueID]bool{}
 	// useBlocks[id] is the set of blocks that reference value id (as an
 	// arg or as a block control). Used to verify a coalesce candidate's
@@ -135,6 +175,17 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 		}
 		s[bid] = true
 	}
+	// phiArgOf[id] is the set of OpPhi values (by ID) that reference
+	// value id in their args, EXCLUDING self-references (a phi whose
+	// back-edge arg is the phi itself is a harmless no-op copy — the
+	// emit-side regHome-equality check skips it). Used by the
+	// own-register mode's parallel-copy hazard guard: edge copies for
+	// one edge are emitted in phi order with no staging for register
+	// destinations, so a phi P that is read by a SIBLING phi of the
+	// same header (or that reads a sibling) must stay slot-resident —
+	// the slot path is protected by the staged-phi machinery, the
+	// register path is not.
+	phiArgOf := map[ssa.ValueID]map[ssa.ValueID]bool{}
 	for _, blk2 := range f.Blocks {
 		for _, v2 := range blk2.Values {
 			for _, a := range v2.Args {
@@ -143,7 +194,16 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 				}
 				if act := resolveCopy(a); act != nil {
 					phiUsers[act.ID]++
+					soleUser[act.ID] = v2
 					noteUse(act.ID, blk2.ID)
+					if v2.Op == ssa.OpPhi && act.ID != v2.ID {
+						s := phiArgOf[act.ID]
+						if s == nil {
+							s = map[ssa.ValueID]bool{}
+							phiArgOf[act.ID] = s
+						}
+						s[v2.ID] = true
+					}
 				}
 			}
 		}
@@ -179,6 +239,39 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 		}
 		srcsByHdr[hdr.ID] = append(srcsByHdr[hdr.ID], src)
 	}
+
+	// reserve marks reg as untouchable by the block-local linear scan
+	// in every listed block.
+	reserve := func(reg string, blocks map[ssa.BlockID]bool) {
+		if plan.reservedRegs == nil {
+			plan.reservedRegs = map[ssa.BlockID]map[string]bool{}
+		}
+		for bid := range blocks {
+			m := plan.reservedRegs[bid]
+			if m == nil {
+				m = map[string]bool{}
+				plan.reservedRegs[bid] = m
+			}
+			m[reg] = true
+		}
+	}
+
+	// Own-register candidates are collected across every loop first
+	// and assigned AFTER all shared coalesces, ranked by in-loop use
+	// count: the shared mode saves strictly more per iteration (the
+	// back-edge copy disappears entirely), so it keeps first claim on
+	// the 3-register pool, and when the leftovers cannot cover every
+	// own-register candidate the hottest phis win.
+	type ownRegCand struct {
+		phi  *ssa.Value
+		body map[ssa.BlockID]bool
+		// liveOutside is the out-of-body live-in region (exit blocks
+		// that still read the phi after the loop). Pre-checked to be
+		// CALL-free; the register must stay reserved there.
+		liveOutside map[ssa.BlockID]bool
+		uses        int
+	}
+	var ownCands []ownRegCand
 
 	// Process each loop (one per header) as a unit.
 	for _, hid := range hdrOrder {
@@ -223,55 +316,23 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 			continue
 		}
 
-		// Walk hdr's phis. A phi is a coalesce candidate when ALL of
-		// its back-edge args resolve to the SAME value V — i.e. one
-		// loop carry flowing back from every continue site. (When the
-		// back edges carry different values we conservatively decline:
-		// a single reserved register can hold only one of them, and
-		// the emit-side short-circuit assumes the carry is already
-		// resident.) V must be regHome-eligible and defined inside the
-		// loop body. Each candidate gets its own register from freePool.
+		// Sibling-phi index for the own-register parallel-copy hazard
+		// guard: edge copies for one edge are emitted in phi order, and
+		// register-destination copies bypass the staged-phi temp
+		// machinery, so a register phi must not read — or be read by —
+		// another phi of the same header.
+		hdrPhiIDs := map[ssa.ValueID]bool{}
+		for _, q := range hdr.Values {
+			if q.Op == ssa.OpPhi {
+				hdrPhiIDs[q.ID] = true
+			}
+		}
+
+		// Walk hdr's phis. Try the SHARED coalesce first (see the file
+		// header); a phi the shared mode must decline can still become
+		// an OWN-REGISTER candidate.
 		for _, phi := range hdr.Values {
 			if phi.Op != ssa.OpPhi {
-				continue
-			}
-			// All back-edge args must resolve to the same V.
-			var actual *ssa.Value
-			sameV := true
-			for _, bi := range backIdxs {
-				if bi >= len(phi.Args) {
-					sameV = false
-					break
-				}
-				arg := phi.Args[bi]
-				if arg == nil {
-					sameV = false
-					break
-				}
-				act := resolveCopy(arg)
-				if act == nil {
-					sameV = false
-					break
-				}
-				if actual == nil {
-					actual = act
-				} else if act != actual {
-					sameV = false
-					break
-				}
-			}
-			if !sameV || actual == nil {
-				continue
-			}
-			if !planRegHomeEligibleOp(plan, actual.Op) {
-				continue
-			}
-			// V must be defined inside the loop body. (If V is
-			// defined OUTSIDE the body — e.g., a constant from
-			// before the loop — coalescing has no value beyond
-			// what the regular block-local regalloc already provides.)
-			vBlk, ok := valueBlock[actual.ID]
-			if !ok || !body[vBlk] {
 				continue
 			}
 			// Phi's destination must be a scalar of a kind GP
@@ -280,111 +341,328 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 			if !isCoalesceableType(phi.Type) {
 				continue
 			}
-			// Avoid double-coalescing: if either P or V already
-			// has a regHome (set by an earlier loop iteration of
-			// this pass), skip.
+			// Avoid double-coalescing: if P already has a regHome
+			// (set by an earlier loop iteration of this pass), skip.
 			if plan.regHome[phi.ID] != "" {
 				continue
 			}
-			if plan.regHome[actual.ID] != "" {
+			if trySharedCoalesce(f, plan, phi, hdr, body, backIdxs, valueBlock, phiUsers, soleUser, phiUsedAsControl, useBlocks, blockHasCall, &freePool, reserve) {
 				continue
 			}
-			// SAFETY: V's write to the shared register destroys
-			// P's value. So P must have NO uses other than V
-			// itself, anywhere in the function. (V is one of P's
-			// users — phi.ID appears in V.Args, the OpSub32 /
-			// OpAdd32 / etc. that reads the phi.) If P appears
-			// as an arg in some OTHER value besides V, or as a
-			// block control anywhere, the coalesce would silently
-			// hand the new V bytes to that other reader. Deny.
-			if phiUsers[phi.ID] != 1 || phiUsedAsControl[phi.ID] {
-				continue
-			}
-			// SAFETY: the reserved register is one of R12/R13/R15,
-			// none of which Go's ABI0 preserves across a CALL. The
-			// loop body is proven call-free above, so the carry is
-			// safe WHILE it stays in the loop. But a carry that is
-			// also live OUT of the loop — used in a block not in
-			// `body` — travels an exit path we have not proven
-			// call-free. If any CALL lies on that path with the carry
-			// still live across it (a very common shape: a scan-loop
-			// counter consumed after the loop, past a helper call),
-			// the callee clobbers the register and the out-of-loop
-			// reader sees garbage; the corrupted value then feeds the
-			// next iteration's address computation and the guest
-			// segfaults. We must keep such a carry slot-resident
-			// (decline the coalesce). A carry that escapes only onto
-			// call-free exit paths (e.g. returned directly) is still
-			// safe, so this checks for a CALL crossing, not mere
-			// escape. Both P and V are checked; P's sole user is V
-			// (verified above) so in practice only V can escape.
-			if liveAcrossExternalCall(f, phi, body, blockHasCall, useBlocks) ||
-				liveAcrossExternalCall(f, actual, body, blockHasCall, useBlocks) {
-				continue
-			}
-			// Pick a register; bail if the dedicated pool is
-			// drained (nested loops with many carries — rare).
-			if len(freePool) == 0 {
-				return
-			}
-			reg := freePool[0]
-			freePool = freePool[1:]
 
-			if dbg := os.Getenv("WASM2GO_COALESCE_DEBUG"); dbg != "" && (dbg == "1" || dbg == f.Name) {
-				bodyIDs := make([]int, 0, len(body))
-				for bid := range body {
-					bodyIDs = append(bodyIDs, int(bid))
+			// ---- OWN-REGISTER candidacy ----
+			// The pool only ever shrinks; once drained no later
+			// candidate can be assigned either.
+			if len(freePool) == 0 {
+				continue
+			}
+			// Parallel-copy hazard guard (both directions, see
+			// hdrPhiIDs above). Self-references are exempt: the
+			// emit-side regHome-equality check turns them into
+			// emitted-nothing no-ops.
+			hazard := false
+			for uid := range phiArgOf[phi.ID] {
+				if hdrPhiIDs[uid] {
+					hazard = true
+					break
 				}
-				sort.Ints(bodyIDs)
-				fmt.Fprintf(os.Stderr, "[coalesce] fn=%s hdr=b%d phi=v%d carry=v%d reg=%s body=%v\n",
-					f.Name, hdr.ID, phi.ID, actual.ID, reg, bodyIDs)
 			}
-			plan.regHome[phi.ID] = reg
-			plan.regHome[actual.ID] = reg
-			plan.coalescedPhi[phi.ID] = reg
-			if plan.reservedRegs == nil {
-				plan.reservedRegs = map[ssa.BlockID]map[string]bool{}
-			}
-			for bid := range body {
-				m := plan.reservedRegs[bid]
-				if m == nil {
-					m = map[string]bool{}
-					plan.reservedRegs[bid] = m
+			if !hazard {
+				for _, a := range phi.Args {
+					if a == nil {
+						continue
+					}
+					act := resolveCopy(a)
+					if act != nil && act.ID != phi.ID && act.Op == ssa.OpPhi && hdrPhiIDs[act.ID] {
+						hazard = true
+						break
+					}
 				}
-				m[reg] = true
 			}
+			if hazard {
+				continue
+			}
+			// Exit-path safety: the phi must not be live across a
+			// CALL outside the loop (the register is caller-save).
+			liveP := outOfBodyLiveIn(f, phi, body, useBlocks)
+			if liveHitsCall(liveP, blockHasCall) {
+				continue
+			}
+			// Worth a reserved register only when the loop actually
+			// re-reads the phi; a single in-loop read breaks even
+			// (one saved slot load vs one entry-edge register MOV)
+			// and is not worth burning a pool slot on.
+			uses := countInLoopUses(f, phi, body)
+			if uses < 2 {
+				continue
+			}
+			ownCands = append(ownCands, ownRegCand{phi: phi, body: body, liveOutside: liveP, uses: uses})
 		}
+	}
+
+	// Assign own-register candidates from whatever the shared mode
+	// left in the pool, hottest first. Ties break on phi ID to keep
+	// the emitted asm deterministic across runs.
+	sort.SliceStable(ownCands, func(i, j int) bool {
+		if ownCands[i].uses != ownCands[j].uses {
+			return ownCands[i].uses > ownCands[j].uses
+		}
+		return ownCands[i].phi.ID < ownCands[j].phi.ID
+	})
+	for _, c := range ownCands {
+		if len(freePool) == 0 {
+			break
+		}
+		if plan.regHome[c.phi.ID] != "" {
+			continue
+		}
+		reg := freePool[0]
+		freePool = freePool[1:]
+		if dbg := os.Getenv("WASM2GO_COALESCE_DEBUG"); dbg != "" && (dbg == "1" || dbg == f.Name) {
+			bodyIDs := make([]int, 0, len(c.body))
+			for bid := range c.body {
+				bodyIDs = append(bodyIDs, int(bid))
+			}
+			sort.Ints(bodyIDs)
+			fmt.Fprintf(os.Stderr, "[coalesce-own] fn=%s phi=v%d reg=%s uses=%d body=%v\n",
+				f.Name, c.phi.ID, reg, c.uses, bodyIDs)
+		}
+		plan.regHome[c.phi.ID] = reg
+		plan.coalescedPhi[c.phi.ID] = reg
+		reserve(reg, c.body)
+		reserve(reg, c.liveOutside)
 	}
 }
 
-// liveAcrossExternalCall reports whether value v is live across a CALL
-// in some block OUTSIDE the loop body. The loop body is call-free by
-// construction, so a reserved caller-save register (R12/R13/R15) only
-// survives while the carry stays in the body; this is the check that a
-// carry escaping onto an exit path does not have its register clobbered
-// by an intervening call.
+// trySharedCoalesce attempts the original shared-register coalesce
+// for one phi: P and its unique back-edge carry V share a reserved
+// register, eliding the back-edge copy entirely. Returns true when
+// the coalesce was assigned. The conditions are unchanged from the
+// original single-mode pass; see the comments inline.
+func trySharedCoalesce(
+	f *ssa.Func,
+	plan *funcPlan,
+	phi *ssa.Value,
+	hdr *ssa.Block,
+	body map[ssa.BlockID]bool,
+	backIdxs []int,
+	valueBlock map[ssa.ValueID]ssa.BlockID,
+	phiUsers map[ssa.ValueID]int,
+	soleUser map[ssa.ValueID]*ssa.Value,
+	phiUsedAsControl map[ssa.ValueID]bool,
+	useBlocks map[ssa.ValueID]map[ssa.BlockID]bool,
+	blockHasCall map[ssa.BlockID]bool,
+	freePool *[]string,
+	reserve func(reg string, blocks map[ssa.BlockID]bool),
+) bool {
+	// All back-edge args must resolve to the same V — one loop carry
+	// flowing back from every continue site. (When the back edges
+	// carry different values a single shared register cannot hold
+	// them; the own-register mode may still apply.)
+	var actual *ssa.Value
+	for _, bi := range backIdxs {
+		if bi >= len(phi.Args) {
+			return false
+		}
+		arg := phi.Args[bi]
+		if arg == nil {
+			return false
+		}
+		act := resolveCopy(arg)
+		if act == nil {
+			return false
+		}
+		if actual == nil {
+			actual = act
+		} else if act != actual {
+			return false
+		}
+	}
+	if actual == nil {
+		return false
+	}
+	// V's producer must honour regHome on the write side.
+	if !planRegHomeEligibleOp(plan, actual.Op) {
+		return false
+	}
+	// V must be defined inside the loop body. (If V is defined
+	// OUTSIDE the body — e.g., a constant from before the loop —
+	// coalescing has no value beyond what the regular block-local
+	// regalloc already provides.)
+	vBlk, ok := valueBlock[actual.ID]
+	if !ok || !body[vBlk] {
+		return false
+	}
+	if plan.regHome[actual.ID] != "" {
+		return false
+	}
+	// SAFETY: V's write to the shared register destroys P's value.
+	// So P must have NO uses other than V itself, anywhere in the
+	// function. If P appears as an arg in some OTHER value besides V,
+	// or as a block control anywhere, the coalesce would silently
+	// hand the new V bytes to that other reader. Deny.
+	if phiUsers[phi.ID] != 1 || phiUsedAsControl[phi.ID] {
+		return false
+	}
+	// The single user must BE V. A phi whose one user is anything
+	// else — the "lag" pattern `prev = phi(init, cur)` where cur does
+	// NOT read prev and the one reader is an exit copy or an
+	// unrelated op — reads P at a point that may execute AFTER V's
+	// write to the shared register within the same iteration, so the
+	// reader would observe the new carry instead of the phi. (Fn39800
+	// in the integration corpus has exactly this shape in its hash-
+	// probe loop; sharing there corrupts the probe index and the
+	// guest heap.) The own-register mode handles these safely — its
+	// back-edge copy runs at the very end of the edge, after every
+	// in-iteration read.
+	if soleUser[phi.ID] != actual {
+		return false
+	}
+	// The shared register also makes V's OWN emit read P through the
+	// home register, and the read must precede the emit's first
+	// write to the home. emitBinALU32/64 and emitShift32/64 write
+	// the home in their FIRST instruction (`MOV <src0>, home`), so P
+	// may only appear as src0 — a `V = x <op> P` shape with x != P
+	// would read the home after `MOV x, home` clobbered it. (When
+	// src0 is also P the leading MOV is a self-move and every later
+	// read still sees P.) Cmp / Load / Call emits write the home
+	// last, so any arg position is safe there.
+	switch actual.Op {
+	case ssa.OpAdd32, ssa.OpSub32, ssa.OpMul32,
+		ssa.OpAnd32, ssa.OpOr32, ssa.OpXor32,
+		ssa.OpAdd64, ssa.OpSub64, ssa.OpMul64,
+		ssa.OpAnd64, ssa.OpOr64, ssa.OpXor64,
+		ssa.OpShl32, ssa.OpShrS32, ssa.OpShrU32,
+		ssa.OpShl64, ssa.OpShrS64, ssa.OpShrU64:
+		if len(actual.Args) > 0 && resolveCopy(actual.Args[0]) != phi {
+			for _, a := range actual.Args[1:] {
+				if a != nil && resolveCopy(a) == phi {
+					return false
+				}
+			}
+		}
+	}
+	// SAFETY: the reserved register is one of R12/R13/R15, none of
+	// which Go's ABI0 preserves across a CALL. The loop body is
+	// proven call-free by the caller, so the carry is safe WHILE it
+	// stays in the loop. But a carry that is also live OUT of the
+	// loop travels an exit path we have not proven call-free. If any
+	// CALL lies on that path with the carry still live across it,
+	// the callee clobbers the register and the out-of-loop reader
+	// sees garbage. Keep such a carry slot-resident. A carry that
+	// escapes only onto call-free exit paths (e.g. returned
+	// directly) is still safe — the check is for a CALL crossing,
+	// not mere escape. Both P and V are checked; P's sole user is V
+	// (verified above) so in practice only V can escape.
+	liveP := outOfBodyLiveIn(f, phi, body, useBlocks)
+	if liveHitsCall(liveP, blockHasCall) {
+		return false
+	}
+	liveV := outOfBodyLiveIn(f, actual, body, useBlocks)
+	if liveHitsCall(liveV, blockHasCall) {
+		return false
+	}
+	// Pick a register; decline if the dedicated pool is drained
+	// (nested loops with many carries — rare).
+	if len(*freePool) == 0 {
+		return false
+	}
+	reg := (*freePool)[0]
+	*freePool = (*freePool)[1:]
+
+	if dbg := os.Getenv("WASM2GO_COALESCE_DEBUG"); dbg != "" && (dbg == "1" || dbg == f.Name) {
+		bodyIDs := make([]int, 0, len(body))
+		for bid := range body {
+			bodyIDs = append(bodyIDs, int(bid))
+		}
+		sort.Ints(bodyIDs)
+		fmt.Fprintf(os.Stderr, "[coalesce] fn=%s hdr=b%d phi=v%d carry=v%d reg=%s body=%v\n",
+			f.Name, hdr.ID, phi.ID, actual.ID, reg, bodyIDs)
+	}
+	plan.regHome[phi.ID] = reg
+	plan.regHome[actual.ID] = reg
+	plan.coalescedPhi[phi.ID] = reg
+	reserve(reg, body)
+	// The register must survive on every out-of-body block the carry
+	// (or the phi) is still live in: an exit-path reader consumes it
+	// via operandSrc long after the loop, and a block-local value
+	// grabbing the register there would clobber the carry before its
+	// last read.
+	reserve(reg, liveP)
+	reserve(reg, liveV)
+	return true
+}
+
+// countInLoopUses counts how many in-loop reads the phi has: args of
+// non-phi values in body blocks plus block controls. Edge-copy reads
+// by sibling phis are excluded (the hazard guard already declined
+// those candidates) and self-loop args are no-op copies.
+func countInLoopUses(f *ssa.Func, phi *ssa.Value, body map[ssa.BlockID]bool) int {
+	n := 0
+	for _, blk := range f.Blocks {
+		if !body[blk.ID] {
+			continue
+		}
+		for _, v2 := range blk.Values {
+			if v2.Op == ssa.OpPhi {
+				continue
+			}
+			for _, a := range v2.Args {
+				if a == nil {
+					continue
+				}
+				if resolveCopy(a) == phi {
+					n++
+				}
+			}
+		}
+		if blk.Control != nil && resolveCopy(blk.Control) == phi {
+			n++
+		}
+	}
+	return n
+}
+
+// liveHitsCall reports whether any block in the live-in set contains
+// a CALL — the caller-save reserved register would be clobbered with
+// the value still live.
+func liveHitsCall(liveIn map[ssa.BlockID]bool, blockHasCall map[ssa.BlockID]bool) bool {
+	for bid := range liveIn {
+		if blockHasCall[bid] {
+			return true
+		}
+	}
+	return false
+}
+
+// outOfBodyLiveIn computes the set of out-of-body blocks value v is
+// live into (or used in). The loop body is call-free by construction,
+// so a reserved caller-save register (R12/R13/R15) survives while the
+// carry stays in the body; the returned region is where the carry is
+// STILL live after leaving the loop — the caller must (a) verify no
+// block in it contains a CALL (liveHitsCall) and (b) reserve the
+// register there so a block-local allocation cannot clobber the carry
+// before its last exit-path read.
 //
 // It runs a single-value backward liveness over the out-of-body region:
 // in-body blocks are treated as absorbing (the carry's def lives there
 // and the body is safe), so propagation flows from out-of-body uses up
-// to — and stops at — the loop body. A block outside the body that has
-// a CALL and into which v is live on entry means v crosses that call.
+// to — and stops at — the loop body.
 //
 // Phi-arg uses are attributed to the predecessor edge (the value is
 // live-out of the predecessor, not live-through the phi's own block),
 // so a carry handed to an out-of-loop phi via a call-free exit copy is
-// correctly judged safe.
+// correctly scoped.
 //
 // useBlocks (the function-wide arg/control use index) is used only as a
-// fast reject: a value with no out-of-body uses cannot be live across an
-// out-of-body call, so the dataflow is skipped entirely.
-func liveAcrossExternalCall(
+// fast reject: a value with no out-of-body uses has an empty region, so
+// the dataflow is skipped entirely and nil is returned.
+func outOfBodyLiveIn(
 	f *ssa.Func,
 	v *ssa.Value,
 	body map[ssa.BlockID]bool,
-	blockHasCall map[ssa.BlockID]bool,
 	useBlocks map[ssa.ValueID]map[ssa.BlockID]bool,
-) bool {
+) map[ssa.BlockID]bool {
 	// Fast reject: no use outside the body at all.
 	anyExternal := false
 	for bid := range useBlocks[v.ID] {
@@ -394,7 +672,7 @@ func liveAcrossExternalCall(
 		}
 	}
 	if !anyExternal {
-		return false
+		return nil
 	}
 
 	usedIn := map[ssa.BlockID]bool{}
@@ -463,15 +741,20 @@ func liveAcrossExternalCall(
 		}
 	}
 
+	// Collect the live region: every out-of-body block v is live into.
+	// liveIn subsumes usedIn and liveOut by construction of the
+	// fixpoint (liveIn = usedIn ∨ liveOut), including the pure
+	// phi-arg-attribution blocks (liveOut set directly above).
+	region := map[ssa.BlockID]bool{}
 	for _, blk := range f.Blocks {
 		if body[blk.ID] {
 			continue
 		}
-		if blockHasCall[blk.ID] && liveIn[blk.ID] {
-			return true
+		if liveIn[blk.ID] {
+			region[blk.ID] = true
 		}
 	}
-	return false
+	return region
 }
 
 // naturalLoopBody returns the set of blocks (by ID) that form

--- a/internal/asmgen/regalloc_coalesce.go
+++ b/internal/asmgen/regalloc_coalesce.go
@@ -140,7 +140,11 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 		}
 	}
 
-	freePool := append([]string{}, coalesceReservedPool...)
+	pool := plan.coalescePool
+	if pool == nil {
+		pool = coalesceReservedPool
+	}
+	freePool := append([]string{}, pool...)
 
 	// Pre-compute P-is-used-only-by-V check inputs (function-wide,
 	// independent of any one loop). For each candidate (P, V) we must

--- a/internal/asmgen/regalloc_ownreg_test.go
+++ b/internal/asmgen/regalloc_ownreg_test.go
@@ -567,3 +567,82 @@ func TestRegallocOwnRegisterPhiEmitARM64(t *testing.T) {
 		t.Errorf("expected a MOVW edge copy targeting an arm64 coalesce-pool register:\n%s", asm)
 	}
 }
+
+// TestRegallocOwnRegisterPhiEmitI64 drives the 64-bit variant of the
+// two-carry loop through BOTH arch emitters, covering the MOVQ / MOVD
+// paths of EmitPhiCopyValueToReg (the 32-bit fixtures only exercise
+// MOVL / MOVW).
+func TestRegallocOwnRegisterPhiEmitI64(t *testing.T) {
+	build := func(t *testing.T) (*ssa.Func, wasm.FuncType) {
+		t.Helper()
+		sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI64, wasm.ValI64}, Results: []wasm.ValType{wasm.ValI64}}
+		fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI64}}
+		b := ssa.NewFuncBuilder("twocarry64", fsig)
+
+		b0 := b.NewBlock(ssa.BlockPlain)
+		b1 := b.NewBlock(ssa.BlockIf)
+		b2 := b.NewBlock(ssa.BlockRet)
+		b3 := b.NewBlock(ssa.BlockPlain)
+		b.SetEntry(b0)
+
+		b.SetCurrent(b0)
+		start := b.Param(0, ssa.TypeI64)
+		limit := b.Param(1, ssa.TypeI64)
+		b.LinkPlain(b1)
+
+		b.SetCurrent(b1)
+		posPhi := b.NewValue(ssa.OpPhi, ssa.TypeI64, start, nil)
+		accPhi := b.NewValue(ssa.OpPhi, ssa.TypeI64, start, nil)
+		one := b.Const64(1)
+		posNext := b.NewValue(ssa.OpAdd64, ssa.TypeI64, posPhi, one)
+		posPhi.Args[1] = posNext
+		accNext := b.NewValue(ssa.OpAdd64, ssa.TypeI64, accPhi, posPhi)
+		accPhi.Args[1] = accNext
+		cond := b.NewValue(ssa.OpLtS64, ssa.TypeBool, posNext, limit)
+		b.LinkIf(cond, b3, b2)
+
+		b.SetCurrent(b3)
+		b.LinkPlain(b1)
+
+		b.SetCurrent(b2)
+		b.FinishRet(accNext)
+
+		if err := ssa.Verify(b.Func()); err != nil {
+			t.Fatalf("SSA verify: %v", err)
+		}
+		return b.Func(), sig
+	}
+
+	t.Run("amd64", func(t *testing.T) {
+		f, sig := build(t)
+		asm, _, err := EmitFuncAMD64("twocarry64", sig, f, FuncOptions{ModulePkgRef: "*Module"})
+		if err != nil {
+			t.Fatalf("EmitFuncAMD64: %v", err)
+		}
+		saw := false
+		for _, reg := range coalesceReservedPool {
+			if strings.Contains(asm, ", "+reg+"\n") {
+				saw = true
+			}
+		}
+		if !saw {
+			t.Errorf("expected a 64-bit edge copy targeting a coalesce-pool register:\n%s", asm)
+		}
+	})
+	t.Run("arm64", func(t *testing.T) {
+		f, sig := build(t)
+		asm, _, err := EmitFuncARM64("twocarry64", sig, f, FuncOptions{ModulePkgRef: "*Module"})
+		if err != nil {
+			t.Fatalf("EmitFuncARM64: %v", err)
+		}
+		saw := false
+		for _, reg := range (archARM64{}).CoalesceRegPool() {
+			if strings.Contains(asm, ", "+reg+"\n") {
+				saw = true
+			}
+		}
+		if !saw {
+			t.Errorf("expected a 64-bit edge copy targeting an arm64 coalesce-pool register:\n%s", asm)
+		}
+	})
+}

--- a/internal/asmgen/regalloc_ownreg_test.go
+++ b/internal/asmgen/regalloc_ownreg_test.go
@@ -485,3 +485,85 @@ func TestRegallocSharedCoalesceArgPositionHazard(t *testing.T) {
 			"emitBinALU32 would compute limit - limit", pPhi.ID, pReg, pNext.ID)
 	}
 }
+
+// TestRegallocOwnRegisterPhiARM64Pool runs the two-carry fixture with
+// the arm64 arch hooks (register pools, eligibility filter, coalesce
+// pool) and checks both coalesce modes assign registers from arm64's
+// R13/R14/R15 pool. The allocation pass is arch-independent; this
+// pins the arm64 plumbing (plan.coalescePool + RegHomeEligibleOp).
+func TestRegallocOwnRegisterPhiARM64Pool(t *testing.T) {
+	f, sig, blocks, phis, carries := buildTwoCarryLoop(t)
+	b1, b3 := blocks[1], blocks[3]
+	posPhi, accPhi := phis[0], phis[1]
+	accNext := carries[1]
+
+	plan, err := planFunc(f, FuncOptions{ModulePkgRef: "*Module"}, sig, archARM64{}.CallArgBias(), true)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	a := archARM64{}
+	plan.gpRegPool = a.GPRegPool()
+	plan.sseRegPool = a.SSERegPool()
+	plan.regHomeEligibleOpFn = a.RegHomeEligibleOp
+	plan.supportsCoalesce = a.SupportsLoopCarryCoalesce()
+	plan.coalescePool = a.CoalesceRegPool()
+	plan.helperInlineFn = a.HelperIsInline
+	computeRegHomes(f, plan)
+
+	inPool := func(reg string) bool {
+		for _, r := range a.CoalesceRegPool() {
+			if r == reg {
+				return true
+			}
+		}
+		return false
+	}
+	accReg := plan.regHome[accPhi.ID]
+	if accReg == "" || !inPool(accReg) {
+		t.Fatalf("accPhi shared coalesce on arm64: regHome=%q, want a register from %v", accReg, a.CoalesceRegPool())
+	}
+	if got := plan.regHome[accNext.ID]; got != accReg {
+		t.Errorf("shared coalesce: accNext regHome=%q, want %q", got, accReg)
+	}
+	posReg := plan.regHome[posPhi.ID]
+	if posReg == "" || !inPool(posReg) {
+		t.Fatalf("posPhi own-register on arm64: regHome=%q, want a register from %v", posReg, a.CoalesceRegPool())
+	}
+	if posReg == accReg {
+		t.Errorf("posPhi and accPhi must not share a register; both got %q", posReg)
+	}
+	for _, blk := range []int{int(b1.ID), int(b3.ID)} {
+		for _, reg := range []string{posReg, accReg} {
+			if !plan.reservedRegs[ssa.BlockID(blk)][reg] {
+				t.Errorf("register %q not reserved in loop-body block %d", reg, blk)
+			}
+		}
+	}
+}
+
+// TestRegallocOwnRegisterPhiEmitARM64 checks the emitted arm64 asm
+// for the two-carry loop: edge copies target the coalesce-pool
+// registers (R13/R14/R15) and the emit completes without error with
+// the coalesce active.
+func TestRegallocOwnRegisterPhiEmitARM64(t *testing.T) {
+	f, sig, _, _, _ := buildTwoCarryLoop(t)
+	asm, _, err := EmitFuncARM64("twocarry", sig, f, FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncARM64: %v", err)
+	}
+	saw := false
+	for _, line := range strings.Split(asm, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "MOVW ") {
+			continue
+		}
+		for _, reg := range (archARM64{}).CoalesceRegPool() {
+			if strings.HasSuffix(trimmed, ", "+reg) {
+				saw = true
+			}
+		}
+	}
+	if !saw {
+		t.Errorf("expected a MOVW edge copy targeting an arm64 coalesce-pool register:\n%s", asm)
+	}
+}

--- a/internal/asmgen/regalloc_ownreg_test.go
+++ b/internal/asmgen/regalloc_ownreg_test.go
@@ -1,0 +1,487 @@
+package asmgen
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// buildTwoCarryLoop constructs the minimal Fn58-shaped loop the
+// own-register mode targets: two loop-carry phis where one (accPhi)
+// satisfies the SHARED coalesce conditions (its back-edge carry is
+// its sole user) and the other (posPhi) is read by several ops per
+// iteration, which the shared mode must decline:
+//
+//	block 0 (Plain):  start = param0, limit = param1; jmp b1
+//	block 1 (BlockIf):
+//	  posPhi = phi(start, posNext)
+//	  accPhi = phi(start, accNext)
+//	  posNext = OpAdd32(posPhi, 1)
+//	  accNext = OpAdd32(accPhi, posPhi)   // 2nd read of posPhi
+//	  cond    = OpLtS32(posNext, limit)
+//	  if cond -> b3 (continue) else -> b2 (exit)
+//	block 3 (Plain):  jmp b1               // back edge
+//	block 2 (BlockRet): return accNext
+func buildTwoCarryLoop(t *testing.T) (f *ssa.Func, sig wasm.FuncType, blocks [4]*ssa.Block, phis [2]*ssa.Value, carries [2]*ssa.Value) {
+	t.Helper()
+	sig = wasm.FuncType{Params: []wasm.ValType{wasm.ValI32, wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	b := ssa.NewFuncBuilder("twocarry", fsig)
+
+	b0 := b.NewBlock(ssa.BlockPlain)
+	b1 := b.NewBlock(ssa.BlockIf)
+	b2 := b.NewBlock(ssa.BlockRet)
+	b3 := b.NewBlock(ssa.BlockPlain)
+	b.SetEntry(b0)
+
+	b.SetCurrent(b0)
+	start := b.Param(0, ssa.TypeI32)
+	limit := b.Param(1, ssa.TypeI32)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b1)
+	posPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	accPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	one := b.Const32(1)
+	posNext := b.NewValue(ssa.OpAdd32, ssa.TypeI32, posPhi, one)
+	posPhi.Args[1] = posNext
+	accNext := b.NewValue(ssa.OpAdd32, ssa.TypeI32, accPhi, posPhi)
+	accPhi.Args[1] = accNext
+	cond := b.NewValue(ssa.OpLtS32, ssa.TypeBool, posNext, limit)
+	b.LinkIf(cond, b3, b2)
+
+	b.SetCurrent(b3)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b2)
+	b.FinishRet(accNext)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	return b.Func(), sig, [4]*ssa.Block{b0, b1, b2, b3}, [2]*ssa.Value{posPhi, accPhi}, [2]*ssa.Value{posNext, accNext}
+}
+
+// TestRegallocOwnRegisterPhi pins the own-register coalesce mode: a
+// multi-user loop-carry phi (declined by the shared mode) still gets
+// a reserved register of its own, with the register reserved across
+// the loop body, while the shared-eligible sibling keeps the original
+// shared coalesce.
+func TestRegallocOwnRegisterPhi(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	f, sig, blocks, phis, carries := buildTwoCarryLoop(t)
+	b1, b2, b3 := blocks[1], blocks[2], blocks[3]
+	posPhi, accPhi := phis[0], phis[1]
+	posNext, accNext := carries[0], carries[1]
+
+	plan, err := planFunc(f, FuncOptions{ModulePkgRef: "*Module"}, sig, 0, false)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	plan.supportsCoalesce = true
+	computeRegHomes(f, plan)
+
+	// accPhi: SHARED mode — same register as its sole-user carry.
+	accReg := plan.regHome[accPhi.ID]
+	if accReg == "" {
+		t.Fatalf("accPhi (v%d) has no regHome; expected the shared coalesce to fire", accPhi.ID)
+	}
+	if got := plan.regHome[accNext.ID]; got != accReg {
+		t.Errorf("shared coalesce: accNext regHome=%q, want the phi's register %q", got, accReg)
+	}
+	if got := plan.coalescedPhi[accPhi.ID]; got != accReg {
+		t.Errorf("plan.coalescedPhi[accPhi]=%q, want %q", got, accReg)
+	}
+
+	// posPhi: OWN-REGISTER mode — a register of its own, distinct
+	// from the shared pair's, with the carry (posNext) left alone.
+	posReg := plan.regHome[posPhi.ID]
+	if posReg == "" {
+		t.Fatalf("posPhi (v%d) has no regHome; expected the own-register mode to fire "+
+			"for the multi-user loop carry (users: posNext, accNext)", posPhi.ID)
+	}
+	if posReg == accReg {
+		t.Errorf("posPhi and accPhi must not share a register; both got %q", posReg)
+	}
+	if got := plan.coalescedPhi[posPhi.ID]; got != posReg {
+		t.Errorf("plan.coalescedPhi[posPhi]=%q, want %q (edge copies must target the register)", got, posReg)
+	}
+	if got := plan.regHome[posNext.ID]; got != "" && got == posReg {
+		t.Errorf("own-register mode must NOT alias the carry into the phi's register; posNext got %q", got)
+	}
+
+	// Both registers reserved across the loop body {b1, b3}.
+	for _, blk := range []*ssa.Block{b1, b3} {
+		for _, reg := range []string{posReg, accReg} {
+			if !plan.reservedRegs[blk.ID][reg] {
+				t.Errorf("register %q not reserved in loop-body block %d", reg, blk.ID)
+			}
+		}
+	}
+	// accNext is read by the BlockRet AFTER the loop — the shared
+	// register must stay reserved on that exit block so a block-local
+	// allocation there cannot clobber the carry before the return
+	// reads it.
+	if !plan.reservedRegs[b2.ID][accReg] {
+		t.Errorf("shared register %q not reserved in exit block %d where the carry is still live", accReg, b2.ID)
+	}
+}
+
+// TestRegallocOwnRegisterPhiEmit checks the emitted asm for the
+// two-carry loop: the own-register phi's back-edge copy is a single
+// MOV into its reserved register, and in-loop reads of the phi come
+// out of the register (no slot round-trip for the phi).
+func TestRegallocOwnRegisterPhiEmit(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	f, sig, _, _, _ := buildTwoCarryLoop(t)
+	asm, _, err := EmitFuncAMD64("twocarry", sig, f, FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncAMD64: %v", err)
+	}
+	// The own-register phi must be read from a coalesce-pool register
+	// somewhere in the body (the accNext = accPhi + posPhi add reads
+	// it as a register operand).
+	sawPoolRegRead := false
+	for _, reg := range coalesceReservedPool {
+		if strings.Contains(asm, reg+",") || strings.Contains(asm, reg+"\n") {
+			sawPoolRegRead = true
+			break
+		}
+	}
+	if !sawPoolRegRead {
+		t.Errorf("expected at least one coalesce-pool register operand in the emitted asm:\n%s", asm)
+	}
+	// The back edge must write one of the pool registers via a plain
+	// MOVL (the own-register phi's edge copy). We detect `MOVL <src>,
+	// R12/R13/R15` with a non-register, non-immediate source — i.e. a
+	// slot or FP read staged straight into the reserved register.
+	sawRegTargetCopy := false
+	for _, line := range strings.Split(asm, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "MOVL ") {
+			continue
+		}
+		for _, reg := range coalesceReservedPool {
+			if strings.HasSuffix(trimmed, ", "+reg) {
+				sawRegTargetCopy = true
+			}
+		}
+	}
+	if !sawRegTargetCopy {
+		t.Errorf("expected a MOVL edge copy targeting a coalesce-pool register:\n%s", asm)
+	}
+}
+
+// TestRegallocOwnRegisterSiblingHazard pins the parallel-copy hazard
+// guard: when one header phi reads another (a shift-register pair),
+// NEITHER side may take the own-register mode — register-destination
+// edge copies bypass the staged-phi temp machinery, so an emit-order
+// dependent read of the sibling would observe the new value.
+func TestRegallocOwnRegisterSiblingHazard(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32, wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	b := ssa.NewFuncBuilder("shiftpair", fsig)
+
+	b0 := b.NewBlock(ssa.BlockPlain)
+	b1 := b.NewBlock(ssa.BlockIf)
+	b2 := b.NewBlock(ssa.BlockRet)
+	b3 := b.NewBlock(ssa.BlockPlain)
+	b.SetEntry(b0)
+
+	b.SetCurrent(b0)
+	start := b.Param(0, ssa.TypeI32)
+	limit := b.Param(1, ssa.TypeI32)
+	b.LinkPlain(b1)
+
+	// prev/cur shift-register: cur's old value becomes prev each
+	// iteration (prevPhi's back-edge arg IS curPhi), so the pair has
+	// a genuine parallel-copy ordering dependency on the back edge.
+	// Both phis are multi-user (the adds below read each phi twice)
+	// so the shared mode declines them and only the own-register mode
+	// could fire — the hazard guard must keep it from doing so.
+	b.SetCurrent(b1)
+	prevPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	curPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	prevPhi.Args[1] = curPhi
+	sum := b.NewValue(ssa.OpAdd32, ssa.TypeI32, prevPhi, curPhi)
+	sum2 := b.NewValue(ssa.OpAdd32, ssa.TypeI32, sum, prevPhi)
+	curNext := b.NewValue(ssa.OpAdd32, ssa.TypeI32, sum2, curPhi)
+	curPhi.Args[1] = curNext
+	cond := b.NewValue(ssa.OpLtS32, ssa.TypeBool, curNext, limit)
+	b.LinkIf(cond, b3, b2)
+
+	b.SetCurrent(b3)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b2)
+	b.FinishRet(curNext)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	plan, err := planFunc(b.Func(), FuncOptions{ModulePkgRef: "*Module"}, sig, 0, false)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	plan.supportsCoalesce = true
+	computeRegHomes(b.Func(), plan)
+
+	// prevPhi reads curPhi (its back-edge arg) → read-side hazard.
+	// curPhi is read by prevPhi → write-side hazard. Both must stay
+	// slot-resident.
+	if reg := plan.regHome[prevPhi.ID]; reg != "" {
+		t.Errorf("prevPhi (v%d) got register %q; the sibling-phi hazard guard must decline it "+
+			"(its back-edge arg is curPhi, a phi of the same header)", prevPhi.ID, reg)
+	}
+	if reg := plan.regHome[curPhi.ID]; reg != "" {
+		t.Errorf("curPhi (v%d) got register %q; the sibling-phi hazard guard must decline it "+
+			"(prevPhi of the same header reads it on the back edge)", curPhi.ID, reg)
+	}
+}
+
+// TestRegallocOwnRegisterLiveAcrossCall pins the exit-path safety
+// check: a multi-user loop-carry phi that is still live across a CALL
+// after the loop must stay slot-resident (R12/R13/R15 are caller-save
+// and the callee would clobber the carry).
+func TestRegallocOwnRegisterLiveAcrossCall(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32, wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	b := ssa.NewFuncBuilder("liveacross", fsig)
+
+	b0 := b.NewBlock(ssa.BlockPlain)
+	b1 := b.NewBlock(ssa.BlockIf)
+	b2 := b.NewBlock(ssa.BlockRet)
+	b3 := b.NewBlock(ssa.BlockPlain)
+	b.SetEntry(b0)
+
+	b.SetCurrent(b0)
+	start := b.Param(0, ssa.TypeI32)
+	limit := b.Param(1, ssa.TypeI32)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b1)
+	posPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	one := b.Const32(1)
+	posNext := b.NewValue(ssa.OpAdd32, ssa.TypeI32, posPhi, one)
+	posPhi.Args[1] = posNext
+	// Second in-loop read of posPhi so the shared mode declines and
+	// the own-register mode is the one under test.
+	cond := b.NewValue(ssa.OpLtS32, ssa.TypeBool, posPhi, limit)
+	b.LinkIf(cond, b3, b2)
+
+	b.SetCurrent(b3)
+	b.LinkPlain(b1)
+
+	// Exit block: a memory.size CALL (opEmitsCall) fires BEFORE the
+	// phi's final read, so the phi is live across it.
+	b.SetCurrent(b2)
+	memSize := b.NewValue(ssa.OpMemSize, ssa.TypeI32)
+	after := b.NewValue(ssa.OpAdd32, ssa.TypeI32, posPhi, memSize)
+	b.FinishRet(after)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	plan, err := planFunc(b.Func(), FuncOptions{ModulePkgRef: "*Module"}, sig, 0, false)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	plan.supportsCoalesce = true
+	computeRegHomes(b.Func(), plan)
+
+	if reg := plan.regHome[posPhi.ID]; reg != "" {
+		t.Errorf("posPhi (v%d) got register %q; it is live across the OpMemSize CALL in the "+
+			"exit block and must stay slot-resident", posPhi.ID, reg)
+	}
+}
+
+// TestRegallocCoalesceAcrossInlineHelper pins the helperCallIsInline
+// subtraction in the coalesce pass's call-free check: a loop whose
+// only opEmitsCall value is an inline-emitted helper (i64.extend_i32_u
+// — the exact shape of the varint-decode loops pprof flagged) must
+// still coalesce its loop-carry phi. Before the subtraction the
+// OpHelperCall marked the block call-unsafe and every coalesce in the
+// loop was declined.
+func TestRegallocCoalesceAcrossInlineHelper(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32, wasm.ValI32}, Results: []wasm.ValType{wasm.ValI64}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64}}
+	b := ssa.NewFuncBuilder("inlinehelperloop", fsig)
+
+	b0 := b.NewBlock(ssa.BlockPlain)
+	b1 := b.NewBlock(ssa.BlockIf)
+	b2 := b.NewBlock(ssa.BlockRet)
+	b3 := b.NewBlock(ssa.BlockPlain)
+	b.SetEntry(b0)
+
+	b.SetCurrent(b0)
+	start := b.Param(0, ssa.TypeI32)
+	limit := b.Param(1, ssa.TypeI32)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b1)
+	posPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	one := b.Const32(1)
+	posNext := b.NewValue(ssa.OpAdd32, ssa.TypeI32, posPhi, one)
+	posPhi.Args[1] = posNext
+	// The inline helper in the loop body — must NOT be a CALL barrier.
+	ext := b.NewValueAux(ssa.OpHelperCall, ssa.TypeI64, "i64_extend_i32_u", posNext)
+	_ = ext
+	// Keep posPhi multi-user so the own-register mode is the mode
+	// under test (shared would also be blocked by the same bug).
+	cond := b.NewValue(ssa.OpLtS32, ssa.TypeBool, posPhi, limit)
+	b.LinkIf(cond, b3, b2)
+
+	b.SetCurrent(b3)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b2)
+	b.FinishRet(ext)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	plan, err := planFunc(b.Func(), FuncOptions{ModulePkgRef: "*Module"}, sig, 0, false)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	plan.supportsCoalesce = true
+	plan.helperInlineFn = archAMD64{}.HelperIsInline
+	computeRegHomes(b.Func(), plan)
+
+	if reg := plan.regHome[posPhi.ID]; reg == "" {
+		t.Errorf("posPhi (v%d) has no regHome; the inline helper (i64_extend_i32_u) in the loop "+
+			"body must not count as a CALL barrier", posPhi.ID)
+	}
+}
+
+// TestRegallocSharedCoalesceLagPattern is the regression for the
+// Fn39800 hash-probe miscompile: a loop-carry phi whose SINGLE user
+// is NOT the back-edge carry (here: an exit-block read) must not be
+// shared-coalesced. Sharing the register makes the exit read observe
+// the carry value computed in the FINAL iteration instead of the phi
+// value, which in the integration corpus corrupted a hash probe index
+// and took down the guest allocator.
+func TestRegallocSharedCoalesceLagPattern(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32, wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	b := ssa.NewFuncBuilder("lagpattern", fsig)
+
+	b0 := b.NewBlock(ssa.BlockPlain)
+	b1 := b.NewBlock(ssa.BlockIf)
+	b2 := b.NewBlock(ssa.BlockRet)
+	b3 := b.NewBlock(ssa.BlockPlain)
+	b.SetEntry(b0)
+
+	b.SetCurrent(b0)
+	start := b.Param(0, ssa.TypeI32)
+	limit := b.Param(1, ssa.TypeI32)
+	b.LinkPlain(b1)
+
+	// lagPhi's back-edge arg (next) does NOT read lagPhi; lagPhi's one
+	// and only user is the return in the exit block. This is the exact
+	// shape the sole-user==carry check must decline.
+	b.SetCurrent(b1)
+	lagPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	one := b.Const32(1)
+	next := b.NewValue(ssa.OpAdd32, ssa.TypeI32, limit, one)
+	lagPhi.Args[1] = next
+	cond := b.NewValue(ssa.OpLtS32, ssa.TypeBool, next, limit)
+	b.LinkIf(cond, b3, b2)
+
+	b.SetCurrent(b3)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b2)
+	b.FinishRet(lagPhi)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	plan, err := planFunc(b.Func(), FuncOptions{ModulePkgRef: "*Module"}, sig, 0, false)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	plan.supportsCoalesce = true
+	computeRegHomes(b.Func(), plan)
+
+	pReg, vReg := plan.regHome[lagPhi.ID], plan.regHome[next.ID]
+	if pReg != "" && pReg == vReg {
+		t.Errorf("lag-pattern phi (v%d) and its non-reading carry (v%d) were shared-coalesced "+
+			"into %q; the exit read of the phi would observe the final carry value", lagPhi.ID, next.ID, pReg)
+	}
+}
+
+// TestRegallocSharedCoalesceArgPositionHazard pins the emit-shape
+// guard: emitBinALU writes the shared home register in its FIRST
+// instruction (MOV src0, home), so a carry of the shape
+// `V = x - P` (phi as the SECOND operand, x != P) must not share a
+// register with P — the subtract would read the home after the MOV
+// already clobbered it, computing x - x instead of x - P.
+func TestRegallocSharedCoalesceArgPositionHazard(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32, wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	b := ssa.NewFuncBuilder("argpos", fsig)
+
+	b0 := b.NewBlock(ssa.BlockPlain)
+	b1 := b.NewBlock(ssa.BlockIf)
+	b2 := b.NewBlock(ssa.BlockRet)
+	b3 := b.NewBlock(ssa.BlockPlain)
+	b.SetEntry(b0)
+
+	b.SetCurrent(b0)
+	start := b.Param(0, ssa.TypeI32)
+	limit := b.Param(1, ssa.TypeI32)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b1)
+	pPhi := b.NewValue(ssa.OpPhi, ssa.TypeI32, start, nil)
+	// V = limit - P: P sits at args[1] with args[0] != P.
+	pNext := b.NewValue(ssa.OpSub32, ssa.TypeI32, limit, pPhi)
+	pPhi.Args[1] = pNext
+	cond := b.NewValue(ssa.OpLtS32, ssa.TypeBool, pNext, limit)
+	b.LinkIf(cond, b3, b2)
+
+	b.SetCurrent(b3)
+	b.LinkPlain(b1)
+
+	b.SetCurrent(b2)
+	b.FinishRet(pNext)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	plan, err := planFunc(b.Func(), FuncOptions{ModulePkgRef: "*Module"}, sig, 0, false)
+	if err != nil {
+		t.Fatalf("planFunc: %v", err)
+	}
+	plan.supportsCoalesce = true
+	computeRegHomes(b.Func(), plan)
+
+	pReg, vReg := plan.regHome[pPhi.ID], plan.regHome[pNext.ID]
+	if pReg != "" && pReg == vReg {
+		t.Errorf("arg-position hazard: phi (v%d) shared %q with V = limit - phi (v%d); "+
+			"emitBinALU32 would compute limit - limit", pPhi.ID, pReg, pNext.ID)
+	}
+}

--- a/internal/asmgen/regtrack.go
+++ b/internal/asmgen/regtrack.go
@@ -87,10 +87,25 @@ func regTrackPass(asm string) string {
 		}
 	}
 	invalidateSlot := func(slot string) {
-		if reg := slotReg[slot]; reg != "" {
-			delete(regSlot, reg)
-			delete(slotReg, slot)
+		// EVERY register currently mirroring the slot must drop its
+		// binding, not just the canonical slotReg entry. Multiple
+		// registers can mirror one slot at once (a forwarded load
+		// keeps the original writer as slotReg while binding the
+		// load's destination in regSlot; reg-to-reg moves add more
+		// mirrors). Clearing only slotReg[slot] left the secondary
+		// mirrors stale, and a later load of the slot into such a
+		// register was dropped by the "dst already mirrors src"
+		// check even though the slot had been overwritten in
+		// between — the Fn39269 128-bit-shift miscompile: the CX
+		// shift-count reload was deleted while CX still held the
+		// PREVIOUS extend's value that had shared the slot via slot
+		// reuse.
+		for reg, s := range regSlot {
+			if s == slot {
+				delete(regSlot, reg)
+			}
 		}
+		delete(slotReg, slot)
 		delete(slotImm, slot)
 		delete(slotImmInstr, slot)
 	}

--- a/internal/asmgen/regtrack_imm_test.go
+++ b/internal/asmgen/regtrack_imm_test.go
@@ -125,3 +125,37 @@ func TestRegTrackPass_SlotImmEndToEndFold(t *testing.T) {
 			count, got)
 	}
 }
+
+// TestRegTrackPass_StaleSecondaryMirrorInvalidated is the regression
+// for the Fn39269 128-bit-shift miscompile: a slot can be mirrored by
+// MORE THAN ONE register at once (the store's source stays the
+// canonical slotReg entry; a forwarded load binds its destination as
+// a secondary mirror in regSlot). A later write to the slot must drop
+// EVERY mirror. The buggy invalidateSlot only cleared the canonical
+// entry, so the secondary register (CX below) kept its stale binding
+// and the reload after the slot was overwritten got dropped by the
+// "dst already mirrors src" check — leaving CX holding the PREVIOUS
+// value (64-n instead of n) as the SHRQ shift count.
+func TestRegTrackPass_StaleSecondaryMirrorInvalidated(t *testing.T) {
+	in := joinLines(
+		"\tMOVL l3+32(FP), AX",
+		"\tMOVQ AX, 48(SP)", // slotReg[48]=AX
+		"\tMOVQ 48(SP), CX", // forwarded to "MOVQ AX, CX"; CX becomes a secondary mirror of 48(SP)
+		"\tSHLQ CX, R8",
+		"\tMOVL l3+36(FP), AX", // AX invalidated (canonical mirror gone)
+		"\tMOVQ AX, 48(SP)",    // slot overwritten — must ALSO clear CX's stale mirror
+		"\tMOVQ 48(SP), CX",    // must NOT be dropped (CX holds the OLD slot value)
+		"\tSHRQ CX, R9",
+		"\tRET",
+	)
+	got := regTrackPass(in)
+	// After the second store, CX must be (re)written before the SHRQ —
+	// either the original slot load survives or it is forwarded to the
+	// NEW canonical mirror (MOVQ AX, CX). What must NOT happen is the
+	// line disappearing entirely.
+	idx := strings.Index(got, "SHLQ CX, R8")
+	tail := got[idx:]
+	if !strings.Contains(tail, ", CX\n") {
+		t.Errorf("reload of CX after the slot overwrite was dropped; CX would keep the stale value:\n%s", got)
+	}
+}


### PR DESCRIPTION
Profile-guided register-allocation round against the window-suite gap
between the asm backend and pure-Go output, plus the arm64 port of the
same optimizations. Three commits, meant to be reviewed in order:

## 1. `asmgen: own-register loop-carry phis + inline-helper CALL-barrier fix`

pprof on `BenchmarkCorpus/window/sum_running_total` (asm vs purego
builds of the same bundle) put generated-code flat time at 1.93s vs
0.83s, with varint-decoder-shaped loops (p9.Fn58) at 4x because every
loop carry stayed stack-slot resident:

- **Own-register coalesce mode.** The existing shared coalesce
  requires the phi's sole user to be its back-edge carry, which
  multi-user carries (pos/shift/acc in Fn58) never satisfy. The new
  mode gives such a phi a reserved register of its own: edge copies
  become one MOV each, every in-loop read comes out of the register,
  and the per-iteration store-to-load forwarding chain disappears.
  Guards: sibling-phi parallel-copy hazard, exit-path CALL crossing,
  uses>=2 profitability floor, use-count ranking when the pool is
  short.
- **Inline helpers stop being CALL barriers (amd64).** A single
  `i64.extend` inline helper in a loop previously marked the whole
  loop call-unsafe, blocking every coalesce in it and forcing a
  spurious m-cache refresh. The block-local regalloc, the coalesce
  call-free check, and the m-cache refresh now subtract
  `arch.HelperIsInline` helpers (set pinned to the emitter by a
  dry-run test). Trap CALLs inside inline div/rem bodies never return,
  so they are not barriers.
- **Two latent SHARED-mode miscompiles fixed** (exposed once the
  barrier fix widened coalesce coverage, caught by the googlesqlite
  suite): the sole-user check never verified the single user IS the
  carry (the "lag" phi shape corrupted Fn39800's hash-probe index →
  guest allocator corruption), and emitBinALU/emitShift read the
  shared home after their first instruction clobbers it when the phi
  sits at args[1]. Reserved registers are now also excluded from
  block-local pools across the carry's out-of-body live region.

## 2. `asmgen: fix regTrackPass stale secondary slot mirror (Fn39269 miscompile)`

A pre-existing text-pass bug the barrier fix started triggering:
`invalidateSlot` only cleared the canonical slotReg mirror, so a
second register still bound to an overwritten slot had its reload
deleted by the "already mirrors" check. In the corpus this hit the
128-bit shift helper double_conversion's Bignum uses — every float
literal parsed to ~1e-13 garbage (9 googlesqlite test failures).
Localised by a package→function asm-splice bisect; the fix re-adds
exactly the 4 wrongly-deleted reloads bundle-wide and is pinned by a
regression test that fails on the pre-fix pass.

## 3. `asmgen: arm64 inline helpers + loop-carry coalesce enablement`

arm64 baseline was 1.44x–1.96x of pure-Go (vs amd64's 1.16x–1.34x)
because every OpHelperCall was a staged CALL and the coalesce pass was
disabled. This ports the amd64 inline set to native arm64 sequences
(every instruction selection verified by native execution first:
SDIV/UDIV+MSUB with explicit traps, FCMP+CSET NaN mappings,
FCVTZS/FCVTZU native saturation — including the unsigned trunc_sat
variants amd64 can't inline — FMIN/FMAX, SCVTF/UCVTF, FRINT*, FMOV
reinterprets, GP-side copysign; popcnt stays a CALL), makes the
coalesce pool arch-provided (amd64 R12/R13/R15, arm64 R13/R14/R15),
and enables both coalesce modes on arm64. Signed divisions register
`wasm_trap_int_overflow` in the per-chunk trampoline set.

## Benchmarks

googlesqlite window suite, `-benchtime=200x -count=5`, idle machine,
vs bundles generated from the pre-change HEAD (2a177f2). All deltas
exceed the ~2% noise floor with per-run ranges 0.4–2.3%.

amd64 (darwin, Rosetta on Apple M5):

| Query | base | new | delta | new asm/pure |
|---|---:|---:|---:|---:|
| array_agg_window | 2,136,988 | 2,099,468 | -1.8% | 1.134x |
| lag_lead | 8,843,855 | 8,627,009 | -2.5% | 1.255x |
| rank_dense_rank | 7,600,751 | 7,381,624 | -2.9% | 1.304x |
| row_number_partition | 4,957,251 | 4,765,669 | -3.9% | 1.266x |
| sum_running_total | 12,633,073 | 12,245,073 | -3.1% | 1.287x |

arm64 (native Apple M5):

| Query | base | new | delta | new asm/pure |
|---|---:|---:|---:|---:|
| array_agg_window | 2,035,161 | 1,917,678 | -5.8% | 1.359x |
| lag_lead | 9,932,364 | 9,121,989 | -8.2% | 1.653x |
| rank_dense_rank | 8,848,284 | 8,025,978 | -9.3% | 1.774x |
| row_number_partition | 5,572,294 | 5,057,997 | -9.2% | 1.684x |
| sum_running_total | 14,400,270 | 13,178,140 | -8.5% | 1.747x |

Non-window sweeps (aggregate/mixed/scalar): no regressions on either
arch (arm64 scalar/concat_strings -55%, information_schema -8.5%);
every apparent count=3 regression re-measured at count=5 landed within
noise. Size: amd64.s -0.46%, arm64.s -0.81%, binary __TEXT -0.11% /
-0.17% (no metadata inflation; symbol counts unchanged).

## Verification (all exit 0, observed in-session)

- `go test ./...` on host amd64 AND `GOARCH=arm64 go test ./...`
  (native run), plus `go vet ./internal/asmgen/`.
- googlesqlite full `go test -race -timeout 30m ./...` against
  regenerated bundles via go.mod replace: amd64 and arm64, 35 packages
  ok / 0 FAIL each.
- go-googlesql `go test -count=1 ./...` against the regenerated
  googlesql bundle.
- go-python `go test ./...` (its make-test/CI config) on amd64 and
  arm64 against a bundle regenerated from python-wasm v0.1.0's release
  `python.wasm`.
- Per-package `amd64.s` byte-identical across the arm64 commit
  (single-arch change confirmed by diff).
- The strict wasmify → buf generate e2e chain was NOT run this round.

New tests: own-register mode (allocation + emit, amd64 + arm64 pools),
sibling-phi hazard, live-across-call decline, shared-mode lag-pattern
and arg-position regressions, regTrackPass stale-mirror regression
(verified failing pre-fix), and dry-run predicate/emitter consistency
for both inline-helper sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
