### PR TITLE
codegen: add base.AccessMemory — synchronised out-of-band memory window

### DIFF
--- a/internal/codegen/accessmemory_emit_test.go
+++ b/internal/codegen/accessmemory_emit_test.go
@@ -1,0 +1,63 @@
+package codegen_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// TestAccessMemoryEmitted pins the host-facing synchronised memory
+// window: every module WITH a linear memory must emit the accessMemory
+// helper, the memMu field it locks, and a memoryGrow that takes the
+// same lock — that trio is what makes out-of-band writers (e.g. an
+// interrupt watchdog) sound against concurrent grows. The memMu field
+// must sit AFTER the M field so the memory/maxMem/M offsets the asm
+// hardcodes (moduleMOffset) stay put.
+func TestAccessMemoryEmitted(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_memops")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := codegen.Translate(&buf, mod, codegen.Options{Package: "memmod", OutputImportPath: "gentest/memmod"}); err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	src := buf.String()
+	for _, expect := range []string{
+		"func accessMemory(m *Module, f func(mem []byte))",
+		// gofmt aligns struct fields, so match name and type separately.
+		"memMu",
+		"sync.Mutex",
+		"m.memMu.Lock()",
+	} {
+		if !strings.Contains(src, expect) {
+			t.Errorf("output missing %q", expect)
+		}
+	}
+	if mIdx, muIdx := strings.Index(src, "M      unsafe.Pointer"), strings.Index(src, "memMu"); mIdx >= 0 && muIdx >= 0 && muIdx < mIdx {
+		t.Errorf("memMu declared before M — the moduleMOffset layout contract requires new fields AFTER M")
+	}
+}
+
+// TestAccessMemoryNotEmittedWithoutMemory: a memory-less module must
+// not pull the helper (its body references memory fields the struct
+// would not have).
+func TestAccessMemoryNotEmittedWithoutMemory(t *testing.T) {
+	bin := testfixture.Wasm(t, "arith")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := codegen.Translate(&buf, mod, codegen.Options{Package: "arithmod", OutputImportPath: "gentest/arithmod"}); err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if src := buf.String(); strings.Contains(src, "accessMemory") {
+		t.Errorf("memory-less module emitted accessMemory")
+	}
+}

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/bits"
 	"runtime"
+	"sync"
 	"unsafe"
 )
 
@@ -22,6 +23,12 @@ type Module struct {
 	memory []byte
 	maxMem uint64
 	M      unsafe.Pointer
+	// memMu serialises mutations of the memory slice header (and any
+	// relocation of its backing array) against out-of-band readers and
+	// writers — see memoryGrow and accessMemory. Generated output
+	// declares the same field at the END of its Module struct so the
+	// memory/maxMem/M offsets the asm hardcodes stay put.
+	memMu sync.Mutex
 }
 
 // ----- Opaque identity helpers ---------------------------------------------
@@ -693,6 +700,15 @@ func memorySize(m *Module) int32 {
 // capacity makes the common grow a zero-copy reslice and amortizes the
 // reallocations to O(n).
 func memoryGrow(m *Module, n int32) int32 {
+	// The slice-header rewrite below (and the backing-array relocation
+	// on the slow path) must not run concurrently with an out-of-band
+	// accessMemory: a host goroutine writing through the old header
+	// mid-relocation would land its write in the abandoned array. The
+	// guest's own loads/stores never take this lock — only grow does,
+	// so the hot memory path is unaffected and the cost is one
+	// uncontended lock per memory.grow call.
+	m.memMu.Lock()
+	defer m.memMu.Unlock()
 	prev := int32(len(m.memory) >> 16)
 	if n == 0 {
 		return prev
@@ -735,6 +751,31 @@ func memoryGrow(m *Module, n int32) int32 {
 	// the data pointer untouched so don't need this refresh.
 	m.M = unsafe.Pointer(unsafe.SliceData(m.memory))
 	return prev
+}
+
+// accessMemory runs f with the module's current linear memory while
+// holding the same lock memoryGrow takes to mutate the memory slice
+// header or relocate its backing array. It is the ONE safe way to
+// touch linear memory from OUTSIDE the module's execution goroutine —
+// e.g. a watchdog goroutine raising CPython's eval-breaker bit while
+// an evaluation is running. For the duration of f the memory can
+// neither be resliced nor relocated, so f's writes land in the array
+// the guest observes; a grow that raced in just before blocks until f
+// returns and then copies f's writes forward with the rest of the
+// contents. Determinism notes for callers:
+//
+//   - f MUST NOT call back into the module or into memoryGrow — that
+//     would self-deadlock.
+//   - f should be short: a running guest blocks inside memory.grow
+//     until f returns (ordinary guest loads/stores do not block).
+//   - Bytes the guest reads or writes concurrently with f (that is
+//     the point of an eval-breaker-style flag) are exchanged with
+//     plain single-word accesses; keep such shared words
+//     word-aligned and word-sized.
+func accessMemory(m *Module, f func(mem []byte)) {
+	m.memMu.Lock()
+	defer m.memMu.Unlock()
+	f(m.memory)
 }
 
 // ----- Integer unary helpers ----------------------------------------------

--- a/internal/codegen/helpers/helpers_accessmemory_test.go
+++ b/internal/codegen/helpers/helpers_accessmemory_test.go
@@ -1,0 +1,56 @@
+package helpers
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+// TestAccessMemoryConcurrentGrow drives memoryGrow and accessMemory
+// from two goroutines. Run under -race this pins the synchronisation
+// contract: the out-of-band writer never observes a torn slice header
+// and never writes into an abandoned backing array — accessMemory
+// holds the same lock memoryGrow takes for the header rewrite and the
+// relocating copy, so a write that lands is either already in the
+// live array or is carried into the next one by the relocation copy.
+func TestAccessMemoryConcurrentGrow(t *testing.T) {
+	const flagAddr = 64 // low static-region word, always < initial len
+	m := &Module{memory: make([]byte, 1<<16, 1<<17)}
+	m.M = unsafe.Pointer(unsafe.SliceData(m.memory))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Grow one page at a time: the capacity doubling makes this
+		// alternate between reslice-only and relocating grows, so both
+		// header-mutation paths run against the concurrent writer.
+		for i := 0; i < 200; i++ {
+			if memoryGrow(m, 1) < 0 {
+				t.Errorf("memoryGrow failed at step %d", i)
+				return
+			}
+		}
+	}()
+
+	for i := uint32(1); i <= 1000; i++ {
+		accessMemory(m, func(mem []byte) {
+			binary.LittleEndian.PutUint32(mem[flagAddr:], i)
+		})
+	}
+	wg.Wait()
+
+	// After both sides quiesce, the LAST write must be visible in the
+	// final backing array — relocations must have carried it forward.
+	var got uint32
+	accessMemory(m, func(mem []byte) {
+		got = binary.LittleEndian.Uint32(mem[flagAddr:])
+	})
+	if got != 1000 {
+		t.Fatalf("final flag = %d, want 1000 (write lost across a relocation)", got)
+	}
+	if wantPages := int32((1<<16)/65536 + 200); memorySize(m) != wantPages {
+		t.Fatalf("memorySize = %d, want %d", memorySize(m), wantPages)
+	}
+}

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -228,6 +228,12 @@ func Translate(w io.Writer, m *wasm.Module, opts Options) (Result, error) {
 	// module has a memory so the API is uniformly available.
 	if len(m.Memories) > 0 {
 		t.helpers["accessMemory"] = true
+		// The Module struct's memMu field needs "sync" — register it
+		// HERE, not only in emitModuleStruct: the multi-package path
+		// snapshots base's import set after emitHelpers but BEFORE
+		// emitModuleStruct runs, so a use() from inside the struct
+		// emitter is too late for base/base.go.
+		t.use("sync")
 	}
 
 	// Compute the call graph once and thread it through reachability

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -222,6 +222,14 @@ func Translate(w io.Writer, m *wasm.Module, opts Options) (Result, error) {
 	t.helpers["wasm_trap_int_overflow"] = true
 	t.helpers["wasm_trap_invalid_conv"] = true
 
+	// accessMemory is the host-facing synchronised window into linear
+	// memory (out-of-band writers like go-python's interrupter use it;
+	// nothing in the generated code calls it). Pull it whenever the
+	// module has a memory so the API is uniformly available.
+	if len(m.Memories) > 0 {
+		t.helpers["accessMemory"] = true
+	}
+
 	// Compute the call graph once and thread it through reachability
 	// + multi-package planning. The bytecode scan is the same for all
 	// three consumers; running it three times wastes a substantial
@@ -1146,6 +1154,18 @@ func (t *translator) emitModuleStruct() ast.Decl {
 			Names: []*ast.Ident{newID(t.fieldName(MangleModuleField(mod)))},
 			Type:  newID(t.importIfaceName(mod)),
 		})
+	}
+
+	// memMu serialises memory-slice-header mutations (memoryGrow) against
+	// out-of-band host access (accessMemory). Declared LAST so the
+	// memory/maxMem/M offsets the generated asm hardcodes (moduleMOffset)
+	// are unaffected.
+	if len(t.mod.Memories) > 0 {
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{newID(t.fieldName("memMu"))},
+			Type:  &ast.SelectorExpr{X: newID("sync"), Sel: newID("Mutex")},
+		})
+		t.use("sync")
 	}
 
 	return &ast.GenDecl{
@@ -2561,6 +2581,8 @@ func rewriteHelperNode(n ast.Node, helperNames map[string]bool) ast.Node {
 			out.Type = rewriteHelperNode(v.Type, helperNames).(ast.Expr)
 		}
 		return out
+	case *ast.DeferStmt:
+		return &ast.DeferStmt{Call: rewriteHelperNode(v.Call, helperNames).(*ast.CallExpr)}
 	case *ast.BranchStmt:
 		return v
 	case *ast.LabeledStmt:


### PR DESCRIPTION
Hosts sometimes need to write a word into guest linear memory from a
goroutine OTHER than the one executing the module — go-python's
Interrupter is the motivating case: it raises CPython's eval-breaker
bit from a watchdog while an Eval is busy in an infinite loop. Today
there is no sound way to do that: memory.grow mutates the memory
slice header without synchronisation and, when the spare capacity
runs out, relocates the whole backing array — so an out-of-band
writer either races the header read (go test -race flags it) or
lands its write in an abandoned array mid-relocation and the signal
is silently lost. go-python's first fix attempt worked around this
with a snapshot + //go:norace + bounded retry loop; the retry/polling
shape was rejected in review, and rightly so — the runtime owns the
relocation, so the runtime is where the synchronisation belongs.

This adds the primitive at that layer:

  - Module gains a `memMu sync.Mutex`, declared LAST in the struct so
    the memory/maxMem/M offsets the generated asm hardcodes
    (moduleMOffset = 32) are untouched; the existing offset pin tests
    guard that.
  - memoryGrow takes memMu for its whole body — both the reslice
    header rewrite and the relocating copy. Ordinary guest loads and
    stores never touch the lock; the cost is one uncontended
    lock/unlock per memory.grow call, on a path that already does
    bounds math and possibly a full copy.
  - New helper `accessMemory(m, f func(mem []byte))` runs f under the
    same lock with the CURRENT memory slice: for the duration of f
    the memory can neither be resliced nor relocated, so f's writes
    land in the array the guest observes, and a grow that raced in
    just before will copy them forward with the rest of the contents.
    Deterministic — no snapshots, no retries, no polling; the only
    wait is bounded by an in-flight grow. Emitted for every module
    that has a linear memory (nothing generated calls it; it is
    host-facing API, exported as base.AccessMemory in multi-package
    mode).

rewriteHelperNode learns *ast.DeferStmt — the new helpers are the
first ones using defer, and the multi-package field-capitalisation
pass previously passed defer statements through unrewritten.

Verification (all exit 0):
  - go test ./...              (host amd64)
  - GOARCH=arm64 go test ./... (native arm64)
  - make lint                  (0 issues)
  - go test -race ./internal/codegen/helpers/ — includes the new
    TestAccessMemoryConcurrentGrow, which hammers memoryGrow
    (alternating reslice and relocating grows) against a concurrent
    accessMemory writer and asserts the final write survived every
    relocation.
  - Emission pin tests: modules with memory emit
    accessMemory/memMu/locked grow with memMu AFTER M; memory-less
    modules emit none of it.
  - Consumer verification per docs/consumer-verification.md:
    regenerated googlesql + python bundles; googlesqlite full
    `go test -race ./...` on amd64 and GOARCH=arm64; go-python full
    matrix (amd64/arm64 × race on/off) against a Fire reworked on
    top of base.AccessMemory — the -race interrupt test that
    motivated all of this passes with the deterministic
    implementation (count=5, both arches).

Motivating consumer change: goccy/go-python#3 (deterministic Interrupter.Fire on top of this API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)