### PR TITLE
codegen: per-function linear-memory base hoist + memoryFill fast paths

### DIFF
--- a/internal/codegen/emit_memops.go
+++ b/internal/codegen/emit_memops.go
@@ -152,11 +152,20 @@ func (em *ssaEmitter) unsafeDerefExpr(spec memOpSpec, baseExpr ast.Expr, offset 
 	return &ast.StarExpr{X: cast}
 }
 
-// memBasePtrExpr returns the `m.M` selector expression — the cached
-// unsafe.Pointer to the start of the wasm linear memory's backing
-// array. See emitModuleStruct (where the M field is declared) and
-// memoryGrow (where M is refreshed on reallocate) for the lifecycle.
+// memBasePtrExpr returns the expression for the linear-memory base
+// pointer at a load/store site. When the function hoisted the base
+// (see emitFuncBody) this is the `mBase` LOCAL — which the Go
+// compiler can keep in a register across unsafe stores, unlike the
+// `m.M` FIELD it shadows, because a local whose address never
+// escapes cannot be aliased by a store. Functions without memops
+// (never reached here) and non-hoisted contexts fall back to the
+// field read. See emitModuleStruct (where the M field is declared)
+// and memoryGrow (where M is refreshed on reallocate) for the
+// lifecycle.
 func (em *ssaEmitter) memBasePtrExpr() ast.Expr {
+	if em.memBaseHoisted {
+		return newID(memBaseLocal)
+	}
 	return &ast.SelectorExpr{X: newID("m"), Sel: newID("M")}
 }
 

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -17,6 +17,12 @@ import (
 // single-package qualifier choice, etc).
 type ssaEmitter struct {
 	t *translator
+	// memBaseHoisted is set (per function) when the function contains
+	// wasm memory loads/stores: memBasePtrExpr then resolves to the
+	// hoisted `mBase` local instead of the `m.M` field, and the
+	// emitters insert `mBase = m.M` refreshes after every value whose
+	// evaluation could run memory.grow. See emitFuncBody.
+	memBaseHoisted bool
 }
 
 // newSSAEmitter constructs an emitter bound to a translator. nil t
@@ -49,21 +55,103 @@ func emitSSAFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
 // Callers pass t so helper registrations (e.g. mload32) propagate to
 // the output's import / helper list.
 func (em *ssaEmitter) emitFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
+	// Hoist the linear-memory base pointer into a function-level local
+	// when the function touches memory at all. `m.M` is a Module FIELD,
+	// so the Go compiler must conservatively reload it after every
+	// unsafe store (any store may alias the field) and every call; as a
+	// LOCAL whose address never escapes, `mBase` stays in a register
+	// across stores, and only the sites that can actually run
+	// memory.grow — calls and memory.grow itself, the only operations
+	// that ever relocate the backing array — re-read it. The refresh
+	// statements are inserted by both block emitters right after each
+	// such value; see maybeMemBaseRefresh.
+	em.memBaseHoisted = funcTouchesMemory(f)
+
 	// Prefer structured reconstruction (if/else, straight-line — no
 	// goto/label). emitStructured returns ok=false for any CFG shape
 	// it cannot cleanly structure (loops, irreducible, ambiguous
 	// joins); those fall through to the goto-based emitMultiBlock,
 	// which handles every shape and is the proven baseline.
-	if body, ok := em.emitStructured(f); ok {
-		if em.t != nil && em.t.memMetrics != nil {
-			em.t.memMetrics.StructuredFuncs++
+	body, err := func() (*ast.BlockStmt, error) {
+		if body, ok := em.emitStructured(f); ok {
+			if em.t != nil && em.t.memMetrics != nil {
+				em.t.memMetrics.StructuredFuncs++
+			}
+			return body, nil
 		}
-		return body, nil
+		if em.t != nil && em.t.memMetrics != nil {
+			em.t.memMetrics.GotoFuncs++
+		}
+		return em.emitMultiBlock(f)
+	}()
+	if err != nil {
+		return nil, err
 	}
-	if em.t != nil && em.t.memMetrics != nil {
-		em.t.memMetrics.GotoFuncs++
+	if em.memBaseHoisted {
+		decl := &ast.AssignStmt{
+			Tok: token.DEFINE,
+			Lhs: []ast.Expr{newID(memBaseLocal)},
+			Rhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID("M")}},
+		}
+		body.List = append([]ast.Stmt{decl}, body.List...)
 	}
-	return em.emitMultiBlock(f)
+	return body, nil
+}
+
+// memBaseLocal is the name of the per-function hoisted copy of m.M.
+// It cannot collide with generated value names (v<N>), parameters
+// (l<N>), or phi temps (t<N>_...).
+const memBaseLocal = "mBase"
+
+// funcTouchesMemory reports whether f contains any linear-memory load
+// or store — the ops whose emission goes through memBasePtrExpr. Any
+// such op is force-hoisted (loads) or emitted as its own statement
+// (stores), so a true here guarantees the hoisted local is used and a
+// false guarantees it is not declared.
+func funcTouchesMemory(f *ssa.Func) bool {
+	for _, blk := range f.Blocks {
+		for _, v := range blk.Values {
+			switch v.Op {
+			case ssa.OpLoad8U, ssa.OpLoad8S, ssa.OpLoad16U, ssa.OpLoad16S,
+				ssa.OpLoad32, ssa.OpLoad32U, ssa.OpLoad32S, ssa.OpLoad64,
+				ssa.OpLoadF32, ssa.OpLoadF64,
+				ssa.OpStore8, ssa.OpStore16, ssa.OpStore32, ssa.OpStore64,
+				ssa.OpStoreF32, ssa.OpStoreF64:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// opCanGrowMemory reports whether evaluating v can run memory.grow —
+// the ONLY operation that relocates the linear-memory backing array
+// and rewrites m.M. Guest calls (direct/indirect) can grow
+// transitively; import calls can re-enter the module from host code;
+// OpMemGrow is the grow itself. Everything else — loads, stores,
+// arithmetic, pure helpers (div/rot/float), memory.size, and the
+// memory.copy/fill builtins (which move bytes but never resize) —
+// cannot.
+func opCanGrowMemory(op ssa.Op) bool {
+	switch op {
+	case ssa.OpCallDirect, ssa.OpCallImport, ssa.OpCallIndirect, ssa.OpMemGrow:
+		return true
+	}
+	return false
+}
+
+// maybeMemBaseRefresh appends `mBase = m.M` to stmts when the just-
+// emitted value can have grown (and therefore relocated) the linear
+// memory. No-op when the function has no hoisted base.
+func (em *ssaEmitter) maybeMemBaseRefresh(stmts []ast.Stmt, v *ssa.Value) []ast.Stmt {
+	if !em.memBaseHoisted || !opCanGrowMemory(v.Op) {
+		return stmts
+	}
+	return append(stmts, &ast.AssignStmt{
+		Tok: token.ASSIGN,
+		Lhs: []ast.Expr{newID(memBaseLocal)},
+		Rhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID("M")}},
+	})
 }
 
 // emitMultiBlock handles multi-block CFGs using a goto/label form.
@@ -213,6 +301,7 @@ func (em *ssaEmitter) emitMultiBlock(f *ssa.Func) (*ast.BlockStmt, error) {
 			}
 			// Non-hoisted pure values are folded into uses; no
 			// statement here.
+			body.List = em.maybeMemBaseRefresh(body.List, v)
 		}
 
 		// 3. Terminator.

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -382,6 +382,7 @@ func (se *structEmitter) blockValues(blk *ssa.Block) ([]ast.Stmt, error) {
 			}
 			out = append(out, stmt)
 		}
+		out = se.em.maybeMemBaseRefresh(out, v)
 	}
 	return out, nil
 }

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -974,10 +974,21 @@ func memoryFill(m *Module, dst int32, val int32, n int32) {
 	}
 	b := m.memory[uint32(dst):uint32(end)]
 	v := byte(val)
-	// Use Go's optimised slice fill: for k := range b { b[k] = v } is
-	// rewritten to memclr-like code by the compiler.
-	for k := range b {
-		b[k] = v
+	// The compiler's range-fill-to-memclr rewrite fires only for a
+	// CONSTANT zero — `b[k] = v` with a variable v stays a plain byte
+	// loop (~1 byte/cycle). Dispatch the overwhelmingly common zero
+	// fill (calloc paths) onto the constant form explicitly, and run
+	// the rare non-zero fill at memmove speed by seeding one byte and
+	// doubling with copy() — O(log n) memmoves instead of n stores.
+	if v == 0 {
+		for k := range b {
+			b[k] = 0
+		}
+		return
+	}
+	b[0] = v
+	for filled := 1; filled < len(b); filled *= 2 {
+		copy(b[filled:], b[:filled])
 	}
 }
 

--- a/internal/codegen/helpers/helpers_accessmemory_test.go
+++ b/internal/codegen/helpers/helpers_accessmemory_test.go
@@ -54,3 +54,39 @@ func TestAccessMemoryConcurrentGrow(t *testing.T) {
 		t.Fatalf("memorySize = %d, want %d", memorySize(m), wantPages)
 	}
 }
+
+// TestMemoryFillPaths pins both memoryFill fast paths: the constant-
+// zero range fill (compiler memclr form) and the copy-doubling
+// non-zero fill, across sizes that exercise the doubling loop's
+// partial final chunk, plus byte-exact content and neighbour
+// preservation.
+func TestMemoryFillPaths(t *testing.T) {
+	for _, n := range []int32{1, 2, 3, 7, 8, 9, 1000, 4096, 65537} {
+		for _, val := range []int32{0, 0xA5} {
+			m := &Module{memory: make([]byte, 70000)}
+			for i := range m.memory {
+				m.memory[i] = 0xEE
+			}
+			memoryFill(m, 16, val, n)
+			if m.memory[15] != 0xEE || m.memory[16+int(n)] != 0xEE {
+				t.Fatalf("n=%d val=%#x: neighbours clobbered", n, val)
+			}
+			want := byte(val)
+			for i := int32(0); i < n; i++ {
+				if m.memory[16+i] != want {
+					t.Fatalf("n=%d val=%#x: byte %d = %#x, want %#x", n, val, i, m.memory[16+i], want)
+				}
+			}
+		}
+	}
+	// Out-of-bounds still panics.
+	m := &Module{memory: make([]byte, 64)}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected OOB panic")
+			}
+		}()
+		memoryFill(m, 60, 1, 8)
+	}()
+}

--- a/internal/codegen/membase_hoist_test.go
+++ b/internal/codegen/membase_hoist_test.go
@@ -1,0 +1,73 @@
+package codegen_test
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// TestMemBaseHoistEmitted pins the linear-memory base hoist: every
+// function that touches memory declares `mBase := m.M` exactly once
+// at the top, all load/store sites deref mBase (never m.M), and a
+// grow-capable value (a call or memory.grow) is followed by a
+// `mBase = m.M` refresh. Functions without memops must not declare
+// the local (it would be an unused variable).
+func TestMemBaseHoistEmitted(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_memops")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "memmod", OutputImportPath: "gentest/memmod"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	// Function bodies with memops live in the pure-Go fallback aux
+	// files (asm emission is always on; the main file only carries
+	// wrappers and runtime plumbing). Concatenate everything so the
+	// assertions see the real memop emission.
+	var sb strings.Builder
+	sb.Write(buf.Bytes())
+	for _, data := range res.AuxFiles {
+		sb.Write(data)
+	}
+	for _, data := range res.Files {
+		sb.Write(data)
+	}
+	src := sb.String()
+	if !strings.Contains(src, "mBase := m.M") {
+		t.Fatalf("no hoisted mBase declaration in output")
+	}
+	// Every unsafe.Add memop must go through the hoisted local; the
+	// only remaining `m.M` reads are the hoist/refresh assignments.
+	if re := regexp.MustCompile(`unsafe\.Add\(m\.M`); re.MatchString(src) {
+		t.Errorf("found unsafe.Add(m.M, ...) — memop bypassed the hoisted base")
+	}
+	// The grow-refresh interaction is pinned separately by
+	// TestMemBaseRefreshAfterGrow (the fixture has no function that
+	// combines memops with memory.grow; a grow-only function
+	// correctly skips the hoist entirely).
+}
+
+// TestMemBaseHoistAbsentWithoutMemops: a module whose functions never
+// touch linear memory must not declare the local.
+func TestMemBaseHoistAbsentWithoutMemops(t *testing.T) {
+	bin := testfixture.Wasm(t, "arith")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := codegen.Translate(&buf, mod, codegen.Options{Package: "arithmod", OutputImportPath: "gentest/arithmod"}); err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if strings.Contains(buf.String(), "mBase") {
+		t.Errorf("memory-less module declared mBase")
+	}
+}

--- a/internal/codegen/membase_hoist_unit_test.go
+++ b/internal/codegen/membase_hoist_unit_test.go
@@ -1,0 +1,73 @@
+package codegen
+
+import (
+	"bytes"
+	"go/format"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// TestMemBaseRefreshAfterGrow pins the exact soundness contract of the
+// base hoist at the emitter level: in a function that both touches
+// memory and can grow it, the emitted body must (1) declare the
+// hoisted base first, (2) route every load/store through it, and
+// (3) re-read m.M immediately after each grow-capable value — the
+// only points where the backing array can relocate.
+func TestMemBaseRefreshAfterGrow(t *testing.T) {
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	b := ssa.NewFuncBuilder("growmix", fsig)
+	b0 := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(b0)
+	b.SetCurrent(b0)
+	addr := b.Param(0, ssa.TypeI32)
+	before := b.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 0, addr)
+	pages := b.Const32(1)
+	grown := b.NewValue(ssa.OpMemGrow, ssa.TypeI32, pages)
+	after := b.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 4, addr)
+	sum := b.NewValue(ssa.OpAdd32, ssa.TypeI32, before, after)
+	sum2 := b.NewValue(ssa.OpAdd32, ssa.TypeI32, sum, grown)
+	b.FinishRet(sum2)
+
+	if err := ssa.Verify(b.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	body, err := emitSSAFuncBody(b.Func())
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := format.Node(&buf, token.NewFileSet(), body); err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	src := buf.String()
+
+	declIdx := strings.Index(src, "mBase := m.M")
+	if declIdx < 0 {
+		t.Fatalf("no hoisted declaration:\n%s", src)
+	}
+	growIdx := strings.Index(src, "memoryGrow(m")
+	if growIdx < 0 {
+		// nil-translator emission spells the helper differently only
+		// if helperRef changes; pin failure loudly either way.
+		t.Fatalf("no grow site found:\n%s", src)
+	}
+	refreshIdx := strings.Index(src, "mBase = m.M")
+	if refreshIdx < 0 {
+		t.Fatalf("no refresh after grow:\n%s", src)
+	}
+	if declIdx >= growIdx || growIdx >= refreshIdx {
+		t.Fatalf("order wrong (decl=%d grow=%d refresh=%d):\n%s", declIdx, growIdx, refreshIdx, src)
+	}
+	if strings.Contains(src, "unsafe.Add(m.M") {
+		t.Fatalf("memop bypassed hoisted base:\n%s", src)
+	}
+	// The load AFTER the grow must read through the refreshed base —
+	// i.e. appear after the refresh in statement order.
+	lastLoad := strings.LastIndex(src, "unsafe.Add(mBase")
+	if lastLoad < refreshIdx {
+		t.Fatalf("post-grow load precedes the refresh:\n%s", src)
+	}
+}


### PR DESCRIPTION
Linear-memory access redesign for the pure-Go backend, plus a
profile-guided memory.fill fix shared by both backends. Two commits.

## 1. `codegen: hoist the linear-memory base into a per-function local`

Every pure-mode memory access read the base through the `m.M` FIELD.
Since any unsafe store may alias a struct field, the Go compiler
discards its cached copy of `m.M` — and the whole address web derived
from it — after EVERY store, and again after every call. Disassembly
of the hot varint loop showed 2 dependent reloads per iteration;
interpreter-shaped code (CPython's eval loop) pays this on virtually
every operation.

The generator knows the invariant the compiler cannot see: the base
only changes when memory.grow relocates the backing array, and grow
only runs inside calls or the memory.grow op — never a plain
load/store. So the emitters now hoist `mBase := m.M` once per
function, route every memop through the local (which stores cannot
alias), and re-read `m.M` only right after grow-capable values. Sound
today, with the relocating grow, on every GOOS/GOARCH — no runtime
change needed. Disassembly of the new output confirms zero base
reloads inside hot loops.

## 2. `helpers: memoryFill fast paths`

base.MemoryFill was 4–5% flat in window-suite profiles on BOTH
backends: the compiler's range-fill-to-memclr rewrite only fires for
a constant zero, and the old body filled with a variable byte —
a ~1 byte/cycle loop. Zero fills (the common calloc path) now take
the constant-zero form (→ `runtime.memclrNoHeapPointers`); non-zero
fills seed one byte and double with `copy()` (O(log n) memmoves).

## Measurements

`-count=5` protocol, idle machine, baselines regenerated from main
with the same CLI parameters. go-python benches (`bench/`, generated
code dominates the profile):

| workload | mode/arch | main | this PR | Δ |
|---|---|---:|---:|---:|
| fib(28) | pure/amd64 | 424.2ms | 288.2ms | **−32.1%** |
| loop-sum | pure/amd64 | 90.9ms | 50.1ms | **−44.8%** |
| startup | pure/amd64 | 14.7ms | 8.1ms | **−44.6%** |
| fib(28) | pure/arm64 | 578.8ms | 193.6ms | **−66.6%** |
| loop-sum | pure/arm64 | 124.0ms | 33.9ms | **−72.7%** |
| startup | pure/arm64 | 18.9ms | 6.2ms | **−67.0%** |
| (all) | asm/both | — | — | within noise (asm untouched) |

Context: on native arm64 the pure backend is now ~3× faster than the
asm backend on CPython workloads, and go-python's gap to gpython on
fib(28) narrows from 3.77× to 1.25× (loop-sum: 10.7× → 2.9×).

googlesqlite window suite (SQLite/driver-heavy, so smaller
generated-code fraction; deltas here are mostly the memoryFill fix
on asm and memoryFill+hoist on pure):

| mode/arch | Δ range across the 5 window queries |
|---|---|
| asm/amd64 | −2.2% .. −4.5% |
| pure/amd64 | −5.1% .. −6.1% |
| asm/arm64 | −1.3% .. −3.5% |
| pure/arm64 | −3.7% .. −9.4% |

## Verification (all exit 0, judged by exit code)

- wasm2go `go test ./...` on host amd64 AND `GOARCH=arm64` (native);
  `make lint` 0 issues.
- googlesqlite, bundles regenerated from this branch via go.mod
  replace: full `go test -race ./...` on amd64 AND arm64 (asm mode),
  plus the full pure-mode suite (`-tags purego`) — 35 packages ok
  each.
- go-python: asm 4-config matrix (amd64/arm64 × race on/off) AND
  pure-mode suites on amd64, arm64, and arm64 `-race`.
- Per-package `amd64.s` byte-identical for the hoist commit
  (pure-only change).
- New tests: emission pins for the hoist (declaration, no `m.M`
  bypass, absence without memops) and an emitter-level pin for the
  decl → grow → refresh ordering; memoryFill path tests (both fast
  paths, partial final chunk, neighbour preservation, OOB panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
