### PR TITLE
asmgen: dataflow m.M-reload dedup + direct-index addressing (amd64)

### DIFF
--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -671,12 +671,12 @@ func extractSPSlots(line string) []string {
 }
 
 // dedupMemMReload drops redundant `MOVQ m+0(FP), BX; MOVQ 32(BX), BX`
-// (amd64) and `MOVD m+0(FP), R0; MOVD 32(R0), R0` (arm64) pairs when
+// (amd64) and `MOVD m+0(FP), R2; MOVD 32(R2), R2` (arm64) pairs when
 // the target register still holds m.M from a previous load. The
 // per-value emitter has no shared state, so every load / store
 // emits its own preamble — but between two const-base loads or
 // stores in the same straight-line span the second preamble is
-// dead code (the first preamble's BX / R0 is still live, the
+// dead code (the first preamble's BX / R2 is still live, the
 // `MOVx imm, disp(BX)` store form does not write BX, and no
 // other generated instruction between them touches BX as a
 // destination).
@@ -692,8 +692,8 @@ func extractSPSlots(line string) []string {
 //     on the branch keeps the analysis straight even if a later
 //     pass interleaves fall-through code).
 //   - Any instruction whose destination operand is exactly the
-//     target register (bare BX / R0 — `MOVQ src, BX`, `LEAQ ..., BX`,
-//     `ADDQ src, BX`, `MOVD src, R0`, etc.). CMP / TEST do not
+//     target register (bare BX / R2 — `MOVQ src, BX`, `LEAQ ..., BX`,
+//     `ADDQ src, BX`, `MOVD src, R2`, etc.). CMP / TEST do not
 //     write either operand and are excluded.
 //
 // The pass is a separate post-step from peepholeOpt because it
@@ -707,7 +707,7 @@ func dedupMemMReload(asm string) string {
 	lines := strings.Split(asm, "\n")
 	out := make([]string, 0, len(lines))
 	bxValid := false
-	r0Valid := false
+	r2Valid := false
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		// amd64 m.M load pair?
@@ -741,46 +741,48 @@ func dedupMemMReload(asm string) string {
 		}
 		// arm64 m.M load pair?
 		if i+1 < len(lines) &&
-			strings.TrimRight(line, " \t") == "\tMOVD m+0(FP), R0" &&
-			strings.TrimRight(lines[i+1], " \t") == "\tMOVD 32(R0), R0" {
-			if r0Valid {
+			strings.TrimRight(line, " \t") == "\tMOVD m+0(FP), R2" &&
+			strings.TrimRight(lines[i+1], " \t") == "\tMOVD 32(R2), R2" {
+			if r2Valid {
 				i++
 				continue
 			}
 			out = append(out, line, lines[i+1])
 			i++
-			r0Valid = true
+			r2Valid = true
 			continue
 		}
-		// arm64 m.M load via the R26 m-cache?
-		// Pattern: `MOVD 32(R26), R0`. Same logic as amd64's
+		// arm64 m.M load via the R4 m-cache?
+		// Pattern: `MOVD 32(R4), R2`. Same logic as amd64's
 		// `MOVQ 32(R11), BX`. The arm64 m-cache reservation places m
-		// in R26.
-		if strings.TrimRight(line, " \t") == "\tMOVD 32(R26), R0" {
-			if r0Valid {
+		// in R4 (archARM64.MCacheReg) and the memop emitters carry
+		// m.M in R2, addressing memory as (R2)(R3) so the memop
+		// itself never clobbers R2.
+		if strings.TrimRight(line, " \t") == "\tMOVD 32(R4), R2" {
+			if r2Valid {
 				continue
 			}
 			out = append(out, line)
-			r0Valid = true
+			r2Valid = true
 			continue
 		}
 		// State transitions for the current line.
 		switch {
 		case isAsmLabel(line):
 			bxValid = false
-			r0Valid = false
+			r2Valid = false
 		case isAsmCall(line):
 			bxValid = false
-			r0Valid = false
+			r2Valid = false
 		case isAsmUnconditionalOrCondBranch(line):
 			bxValid = false
-			r0Valid = false
+			r2Valid = false
 		default:
 			if writesRegister(line, "BX") {
 				bxValid = false
 			}
-			if writesRegister(line, "R0") {
-				r0Valid = false
+			if writesRegister(line, "R2") {
+				r2Valid = false
 			}
 		}
 		out = append(out, line)

--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -186,6 +186,7 @@ type arch interface {
 	// false for everything until its inline set is audited the same
 	// way.
 	HelperIsInline(name string) bool
+
 	// GPRegPool returns the GP register pool the block-local regalloc
 	// hands out to int / pointer SSA values. The order matters only
 	// for determinism — first-fit during linear scan. Each entry
@@ -483,6 +484,7 @@ func emitFunc(name string, sig wasm.FuncType, f *ssa.Func, opts FuncOptions, a a
 	//                      same slot silently overwrites, with no
 	//                      intervening read. D-1.
 	emitted := dedupMemMReload(b.String())
+	emitted = memBaseFlowDedup(emitted)
 	emitted = peepholeOpt(emitted)
 	emitted = regTrackPass(emitted)
 	emitted = peepholeOpt(emitted)

--- a/internal/asmgen/emit_archs.go
+++ b/internal/asmgen/emit_archs.go
@@ -939,6 +939,19 @@ func emitLoad(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFrame) 
 	if base, ok := inlineableI32(v.Args[0]); ok {
 		disp := int32(uint32(base) + uint32(off))
 		addr = fmt.Sprintf("%d(BX)", disp)
+	} else if home := gpRegHomeOf(plan, v.Args[0]); home != "" && off >= 0 {
+		// Direct-index fast path: the base value already lives in a
+		// GP register, and every i32 producer writes its register
+		// through a 32-bit op (upper halves are zero per amd64), so
+		// the register can serve as the scaled-index operand as-is —
+		// the `MOVL <src>, SI` staging hop disappears. Negative
+		// offsets keep the SI path: they need a wrapping ADDL that
+		// must not mutate the value's home register.
+		if off > 0 {
+			addr = fmt.Sprintf("%d(BX)(%s*1)", off, home)
+		} else {
+			addr = fmt.Sprintf("(BX)(%s*1)", home)
+		}
 	} else {
 		// Dynamic base: form the address through SI, then access via
 		// (BX)(SI*1) indexed addressing instead of `ADDQ AX, BX` +
@@ -1076,6 +1089,22 @@ func emitLoad(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFrame) 
 	return nil
 }
 
+// gpRegHomeOf resolves v through OpCopy chains and returns its GP
+// register home, or "" when the value is slot-resident, SSE-homed,
+// constant, or a parameter. Used by the memop emitters' direct-index
+// fast path.
+func gpRegHomeOf(plan *funcPlan, v *ssa.Value) string {
+	actual := resolveCopy(v)
+	if actual == nil {
+		return ""
+	}
+	home := plan.regHome[actual.ID]
+	if home == "" || isSSEReg(home) {
+		return ""
+	}
+	return home
+}
+
 // emitStore lowers a wasm linear-memory write. args = [base, value,
 // mem]; AuxInt = offset. Narrowing stores (Store8/16/32 of an i64)
 // truncate the value to the requested width.
@@ -1106,6 +1135,13 @@ func emitStore(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFrame)
 	if base, ok := inlineableI32(v.Args[0]); ok {
 		disp := int32(uint32(base) + uint32(off))
 		addr = fmt.Sprintf("%d(BX)", disp)
+	} else if home := gpRegHomeOf(plan, v.Args[0]); home != "" && off >= 0 {
+		// Direct-index fast path — see emitLoad.
+		if off > 0 {
+			addr = fmt.Sprintf("%d(BX)(%s*1)", off, home)
+		} else {
+			addr = fmt.Sprintf("(BX)(%s*1)", home)
+		}
 	} else {
 		// Dynamic-base store: form the address in SI so the access
 		// uses `(BX)(SI*1)` indexed addressing. Mirror of emitLoad's
@@ -2031,17 +2067,23 @@ func emitInlineFloatCmp(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame 
 	fmt.Fprintf(b, "\t%s %s, X0\n", cmp, operandSrcFloat(v.Args[1], plan, frame, "SP"))
 	fmt.Fprintf(b, "\t%s AL\n", setOp)
 	fmt.Fprintf(b, "\tMOVBLZX AL, AX\n")
+	// The parity fix-up stages through DX, NOT BX: BX carries the
+	// linear-memory base between memops (memBaseFlowDedup deletes
+	// reloads only while BX provably survives, so a BX write here
+	// would kill the fact at every float compare) and the
+	// inline-helper scratch contract documented on HelperIsInline is
+	// AX/CX/DX/X0/X1.
 	switch nanFix {
 	case "and-np":
 		// SETPC (parity clear, PF=0 — "ordered") in plan9 syntax.
-		fmt.Fprintf(b, "\tSETPC BL\n")
-		fmt.Fprintf(b, "\tMOVBLZX BL, BX\n")
-		fmt.Fprintf(b, "\tANDL BX, AX\n")
+		fmt.Fprintf(b, "\tSETPC DL\n")
+		fmt.Fprintf(b, "\tMOVBLZX DL, DX\n")
+		fmt.Fprintf(b, "\tANDL DX, AX\n")
 	case "or-p":
 		// SETPS (parity set, PF=1 — "unordered / NaN") in plan9.
-		fmt.Fprintf(b, "\tSETPS BL\n")
-		fmt.Fprintf(b, "\tMOVBLZX BL, BX\n")
-		fmt.Fprintf(b, "\tORL BX, AX\n")
+		fmt.Fprintf(b, "\tSETPS DL\n")
+		fmt.Fprintf(b, "\tMOVBLZX DL, DX\n")
+		fmt.Fprintf(b, "\tORL DX, AX\n")
 	}
 	fmt.Fprintf(b, "\tMOVL AX, %d(SP)\n", dst)
 	return true, nil

--- a/internal/asmgen/emitarm64.go
+++ b/internal/asmgen/emitarm64.go
@@ -759,8 +759,12 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 	}
 	off := int32(v.AuxInt)
 	dst := plan.offsets[v.ID]
-	// Compute effective address into R2:
-	//   R2 = *(m + moduleMOffset) + uint32(base) + uint32(off)
+	// R2 = m.M; R3 = uint32(base + off); the access itself uses
+	// register-offset addressing `(R2)(R3)`. Keeping the add inside
+	// the addressing mode (instead of the historical
+	// `ADD R3, R2, R2` + `(R2)`) both saves that ADD and leaves
+	// R2 == m.M intact across the memop, which is what lets
+	// memBaseFlowDedup delete the R2 reloads of later memops.
 	if plan.mCacheReg != "" {
 		// m is in mCacheReg, skip the `MOVD m+0(FP), R2`
 		// and read m.M directly off the cached pointer.
@@ -772,12 +776,16 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 	// Compute base+off in 32-bit so a negative int32 base wraps
 	// the way wasm semantics require — the pure-Go path uses
 	// `uint32(base + int32(off))`. ADDW writes the low 32 bits and
-	// zero-extends to 64, leaving R3 holding the correct u32.
+	// zero-extends to 64, leaving R3 holding the correct u32. The
+	// explicit MOVWU zero-extend stays even when the base already
+	// sits in a register home: arm64 register-register MOVW
+	// sign-extends, so (unlike amd64) "i32 home ⇒ upper bits zero"
+	// is NOT an invariant here and the home cannot serve as the
+	// offset register directly.
 	fmt.Fprintf(b, "\tMOVWU %s, R3\n", operandSrc32ARM64(v.Args[0], plan, frame))
 	if off != 0 {
 		fmt.Fprintf(b, "\tADDW $%d, R3, R3\n", off)
 	}
-	fmt.Fprintf(b, "\tADD R3, R2, R2\n")
 	is64 := v.Type == ssa.TypeI64
 	// Load directly into the destination register when the value
 	// has a regHome. Saves the final `MOVx R0, dst(RSP)` slot
@@ -790,7 +798,7 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 	}
 	switch v.Op {
 	case ssa.OpLoad8U:
-		fmt.Fprintf(b, "\tMOVBU (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVBU (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			if is64 {
 				fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
@@ -799,7 +807,7 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 			}
 		}
 	case ssa.OpLoad8S:
-		fmt.Fprintf(b, "\tMOVB (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVB (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			if is64 {
 				fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
@@ -808,7 +816,7 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 			}
 		}
 	case ssa.OpLoad16U:
-		fmt.Fprintf(b, "\tMOVHU (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVHU (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			if is64 {
 				fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
@@ -817,7 +825,7 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 			}
 		}
 	case ssa.OpLoad16S:
-		fmt.Fprintf(b, "\tMOVH (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVH (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			if is64 {
 				fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
@@ -826,13 +834,13 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 			}
 		}
 	case ssa.OpLoad32:
-		fmt.Fprintf(b, "\tMOVW (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVW (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			fmt.Fprintf(b, "\tMOVW R0, %d(RSP)\n", dst)
 		}
 	case ssa.OpLoad32U:
 		// i64.load32_u: read u32 → zero-extend to i64.
-		fmt.Fprintf(b, "\tMOVWU (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVWU (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
 		}
@@ -840,13 +848,13 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 		// Sign-extend in place. SXTW writes the full 64-bit
 		// result so the destination register holds the i64
 		// the consumer expects.
-		fmt.Fprintf(b, "\tMOVW (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVW (R2)(R3), %s\n", loadReg)
 		fmt.Fprintf(b, "\tSXTW %s, %s\n", loadReg, loadReg)
 		if home == "" {
 			fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
 		}
 	case ssa.OpLoad64:
-		fmt.Fprintf(b, "\tMOVD (R2), %s\n", loadReg)
+		fmt.Fprintf(b, "\tMOVD (R2)(R3), %s\n", loadReg)
 		if home == "" {
 			fmt.Fprintf(b, "\tMOVD R0, %d(RSP)\n", dst)
 		}
@@ -857,7 +865,7 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 		if home != "" {
 			fLoadReg = home
 		}
-		fmt.Fprintf(b, "\tFMOVS (R2), %s\n", fLoadReg)
+		fmt.Fprintf(b, "\tFMOVS (R2)(R3), %s\n", fLoadReg)
 		if home == "" {
 			fmt.Fprintf(b, "\tFMOVS F0, %d(RSP)\n", dst)
 		}
@@ -866,7 +874,7 @@ func emitLoadARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argFr
 		if home != "" {
 			fLoadReg = home
 		}
-		fmt.Fprintf(b, "\tFMOVD (R2), %s\n", fLoadReg)
+		fmt.Fprintf(b, "\tFMOVD (R2)(R3), %s\n", fLoadReg)
 		if home == "" {
 			fmt.Fprintf(b, "\tFMOVD F0, %d(RSP)\n", dst)
 		}
@@ -888,12 +896,12 @@ func emitStoreARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argF
 		fmt.Fprintf(b, "\tMOVD m+0(FP), R2\n")
 		fmt.Fprintf(b, "\tMOVD %d(R2), R2\n", moduleMOffset)
 	}
-	// Same u32 wrap-around story as emitLoadARM64.
+	// Same u32 wrap-around story and register-offset addressing as
+	// emitLoadARM64 — R2 stays == m.M across the store.
 	fmt.Fprintf(b, "\tMOVWU %s, R3\n", operandSrc32ARM64(v.Args[0], plan, frame))
 	if off != 0 {
 		fmt.Fprintf(b, "\tADDW $%d, R3, R3\n", off)
 	}
-	fmt.Fprintf(b, "\tADD R3, R2, R2\n")
 	valIs64 := v.Args[1].Type == ssa.TypeI64
 	val32 := operandSrc32ARM64(v.Args[1], plan, frame)
 	val64 := operandSrc64ARM64(v.Args[1], plan, frame)
@@ -905,30 +913,30 @@ func emitStoreARM64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argF
 		} else {
 			fmt.Fprintf(b, "\tMOVW %s, R0\n", val32)
 		}
-		fmt.Fprintf(b, "\tMOVB R0, (R2)\n")
+		fmt.Fprintf(b, "\tMOVB R0, (R2)(R3)\n")
 	case ssa.OpStore16:
 		if valIs64 {
 			fmt.Fprintf(b, "\tMOVD %s, R0\n", val64)
 		} else {
 			fmt.Fprintf(b, "\tMOVW %s, R0\n", val32)
 		}
-		fmt.Fprintf(b, "\tMOVH R0, (R2)\n")
+		fmt.Fprintf(b, "\tMOVH R0, (R2)(R3)\n")
 	case ssa.OpStore32:
 		if valIs64 {
 			fmt.Fprintf(b, "\tMOVD %s, R0\n", val64)
 		} else {
 			fmt.Fprintf(b, "\tMOVW %s, R0\n", val32)
 		}
-		fmt.Fprintf(b, "\tMOVW R0, (R2)\n")
+		fmt.Fprintf(b, "\tMOVW R0, (R2)(R3)\n")
 	case ssa.OpStore64:
 		fmt.Fprintf(b, "\tMOVD %s, R0\n", val64)
-		fmt.Fprintf(b, "\tMOVD R0, (R2)\n")
+		fmt.Fprintf(b, "\tMOVD R0, (R2)(R3)\n")
 	case ssa.OpStoreF32:
 		fmt.Fprintf(b, "\tFMOVS %s, F0\n", valFlt)
-		fmt.Fprintf(b, "\tFMOVS F0, (R2)\n")
+		fmt.Fprintf(b, "\tFMOVS F0, (R2)(R3)\n")
 	case ssa.OpStoreF64:
 		fmt.Fprintf(b, "\tFMOVD %s, F0\n", valFlt)
-		fmt.Fprintf(b, "\tFMOVD F0, (R2)\n")
+		fmt.Fprintf(b, "\tFMOVD F0, (R2)(R3)\n")
 	default:
 		return fmt.Errorf("OpStore variant %v not supported", v.Op)
 	}

--- a/internal/asmgen/memmflow.go
+++ b/internal/asmgen/memmflow.go
@@ -2,18 +2,50 @@ package asmgen
 
 import "strings"
 
-// memBaseFlowDedup removes m.M reloads (`MOVQ 32(R11), BX`, and the
-// two-line `MOVQ m+0(FP), BX; MOVQ 32(BX), BX` no-mcache form) that
-// are redundant on EVERY control-flow path — a dataflow
-// generalisation of dedupMemMReload, which can only track validity
-// through straight-line spans and must give up at labels.
+// memMFlowConfig names, per architecture, the emitted-text patterns
+// whose redundancy memBaseFlowDedup eliminates: the reload of m.M
+// into the memop base register, and that register itself (the
+// dataflow fact tracked is "<reg> == m.M").
+type memMFlowConfig struct {
+	genCache string // m-cache form: one-line m.M read
+	genFP1   string // no-cache form, line 1: m pointer from the frame
+	genFP2   string // no-cache form, line 2: m.M off the m pointer
+	reg      string // the register the fact is about
+	regByte  string // partial-register alias whose write kills reg ("" if none)
+}
+
+var memMFlowConfigs = []memMFlowConfig{
+	{
+		// amd64: BX carries m.M; R11 is the function-wide m cache.
+		genCache: "\tMOVQ 32(R11), BX",
+		genFP1:   "\tMOVQ m+0(FP), BX",
+		genFP2:   "\tMOVQ 32(BX), BX",
+		reg:      "BX",
+		regByte:  "BL",
+	},
+	{
+		// arm64: R2 carries m.M; R4 is the m cache. Only meaningful
+		// once memops address memory as (R2)(R3) — the historical
+		// `ADD R3, R2, R2` form killed the fact inside every memop.
+		genCache: "\tMOVD 32(R4), R2",
+		genFP1:   "\tMOVD m+0(FP), R2",
+		genFP2:   "\tMOVD 32(R2), R2",
+		reg:      "R2",
+	},
+}
+
+// memBaseFlowDedup removes m.M reloads (per-arch patterns in
+// memMFlowConfigs) that are redundant on EVERY control-flow path — a
+// dataflow generalisation of dedupMemMReload, which can only track
+// validity through straight-line spans and must give up at labels.
 //
-// The property computed is the classic "available expression": BX
-// holds m.M on entry to a block iff it holds it on exit of ALL
-// predecessors. m.M itself can only change inside a CALL (memory.grow
-// is a call), and CALLs clobber BX anyway, so the kill set is simply
-// {CALL, any BX write}. The pass only DELETES existing reload lines —
-// it never inserts code — so unlike a prologue-loaded function-wide
+// The property computed is the classic "available expression": the
+// base register holds m.M on entry to a block iff it holds it on
+// exit of ALL predecessors. m.M itself can only change inside a CALL
+// (memory.grow is a call), and CALLs clobber every caller-save
+// register anyway, so the kill set is simply {CALL, any write of the
+// base register}. The pass only DELETES existing reload lines — it
+// never inserts code — so unlike a prologue-loaded function-wide
 // cache it cannot regress functions whose shape doesn't profit
 // (Phase F-1's failure mode, re-measured and reproduced as a
 // consistent window-suite loss before this pass replaced that
@@ -25,10 +57,15 @@ import "strings"
 // the optimism is what lets loop headers keep validity across
 // call-free loop bodies.
 func memBaseFlowDedup(asm string) string {
-	if !strings.Contains(asm, "\tMOVQ 32(R11), BX") &&
-		!strings.Contains(asm, "\tMOVQ m+0(FP), BX") {
-		return asm
+	for _, cfg := range memMFlowConfigs {
+		if strings.Contains(asm, cfg.genCache) || strings.Contains(asm, cfg.genFP1) {
+			asm = memBaseFlowDedupFor(asm, cfg)
+		}
 	}
+	return asm
+}
+
+func memBaseFlowDedupFor(asm string, cfg memMFlowConfig) string {
 	lines := strings.Split(asm, "\n")
 
 	// ---- 1. Partition into blocks. A leader is line 0, every label,
@@ -81,7 +118,7 @@ func memBaseFlowDedup(asm string) string {
 
 	// ---- 2. Successor edges: explicit branch targets plus
 	// fall-through (unless the block's last line is an unconditional
-	// JMP or RET).
+	// JMP / B or RET).
 	branchTarget := func(s string) (string, bool) {
 		t := strings.TrimSpace(s)
 		sp := strings.IndexAny(t, " \t")
@@ -89,6 +126,10 @@ func memBaseFlowDedup(asm string) string {
 			return "", false
 		}
 		return strings.TrimSpace(t[sp:]), true
+	}
+	isUncond := func(t string) bool {
+		return strings.HasPrefix(t, "JMP ") || strings.HasPrefix(t, "JMP\t") ||
+			strings.HasPrefix(t, "B ") || strings.HasPrefix(t, "B\t")
 	}
 	for bi := range blocks {
 		blk := &blocks[bi]
@@ -107,7 +148,7 @@ func memBaseFlowDedup(asm string) string {
 					blk.succs = append(blk.succs, blockAt[pos])
 				}
 			}
-			if strings.HasPrefix(t, "JMP ") || strings.HasPrefix(t, "JMP\t") {
+			if isUncond(t) {
 				fallThrough = false
 			}
 		}
@@ -122,33 +163,29 @@ func memBaseFlowDedup(asm string) string {
 		}
 	}
 
-	// ---- 3. Per-line transfer over the "BX == m.M" fact.
-	const (
-		genR11  = "\tMOVQ 32(R11), BX"
-		genFP   = "\tMOVQ m+0(FP), BX"
-		genFP2  = "\tMOVQ 32(BX), BX"
-		bxKillB = "BL" // byte-writer alias of BX
-	)
+	// ---- 3. Per-line transfer over the "<reg> == m.M" fact.
 	step := func(valid bool, i int) bool {
 		ln := strings.TrimRight(lines[i], " \t")
 		switch {
-		case ln == genR11:
+		case ln == cfg.genCache:
 			return true
-		case ln == genFP:
+		case ln == cfg.genFP1:
 			// Only the completed two-line pair re-establishes the
-			// fact; the first line alone leaves BX = m.
-			if i+1 < len(lines) && strings.TrimRight(lines[i+1], " \t") == genFP2 {
+			// fact; the first line alone leaves the register = m.
+			if i+1 < len(lines) && strings.TrimRight(lines[i+1], " \t") == cfg.genFP2 {
 				return valid // decided when the pair's 2nd line runs
 			}
 			return false
-		case ln == genFP2 && i > 0 && strings.TrimRight(lines[i-1], " \t") == genFP:
+		case ln == cfg.genFP2 && i > 0 && strings.TrimRight(lines[i-1], " \t") == cfg.genFP1:
 			return true
 		case isAsmCall(lines[i]):
 			return false
 		default:
-			// A byte write through BL clobbers BX's low byte; treat it
-			// as a full kill (nothing emits BL today, but stay safe).
-			if writesRegister(lines[i], "BX") || writesRegister(lines[i], bxKillB) {
+			// A partial-register write (BL on amd64) clobbers the low
+			// byte; treat it as a full kill (nothing emits BL today,
+			// but stay safe).
+			if writesRegister(lines[i], cfg.reg) ||
+				(cfg.regByte != "" && writesRegister(lines[i], cfg.regByte)) {
 				return false
 			}
 			return valid
@@ -198,11 +235,11 @@ func memBaseFlowDedup(asm string) string {
 		v := in[bi]
 		for i := blocks[bi].start; i < blocks[bi].end; i++ {
 			ln := strings.TrimRight(lines[i], " \t")
-			if v && ln == genR11 {
+			if v && ln == cfg.genCache {
 				dropped[i] = true
 			}
-			if v && ln == genFP && i+1 < blocks[bi].end &&
-				strings.TrimRight(lines[i+1], " \t") == genFP2 {
+			if v && ln == cfg.genFP1 && i+1 < blocks[bi].end &&
+				strings.TrimRight(lines[i+1], " \t") == cfg.genFP2 {
 				dropped[i] = true
 				dropped[i+1] = true
 			}

--- a/internal/asmgen/memmflow.go
+++ b/internal/asmgen/memmflow.go
@@ -1,0 +1,223 @@
+package asmgen
+
+import "strings"
+
+// memBaseFlowDedup removes m.M reloads (`MOVQ 32(R11), BX`, and the
+// two-line `MOVQ m+0(FP), BX; MOVQ 32(BX), BX` no-mcache form) that
+// are redundant on EVERY control-flow path — a dataflow
+// generalisation of dedupMemMReload, which can only track validity
+// through straight-line spans and must give up at labels.
+//
+// The property computed is the classic "available expression": BX
+// holds m.M on entry to a block iff it holds it on exit of ALL
+// predecessors. m.M itself can only change inside a CALL (memory.grow
+// is a call), and CALLs clobber BX anyway, so the kill set is simply
+// {CALL, any BX write}. The pass only DELETES existing reload lines —
+// it never inserts code — so unlike a prologue-loaded function-wide
+// cache it cannot regress functions whose shape doesn't profit
+// (Phase F-1's failure mode, re-measured and reproduced as a
+// consistent window-suite loss before this pass replaced that
+// design).
+//
+// Solved as a forward must-analysis with optimistic initialisation
+// (everything valid except the function entry), AND-meet over
+// predecessors, iterated to fixpoint — the standard formulation, and
+// the optimism is what lets loop headers keep validity across
+// call-free loop bodies.
+func memBaseFlowDedup(asm string) string {
+	if !strings.Contains(asm, "\tMOVQ 32(R11), BX") &&
+		!strings.Contains(asm, "\tMOVQ m+0(FP), BX") {
+		return asm
+	}
+	lines := strings.Split(asm, "\n")
+
+	// ---- 1. Partition into blocks. A leader is line 0, every label,
+	// and every line following a branch. Record label positions.
+	isBranch := func(s string) bool { return isAsmUnconditionalOrCondBranch(s) }
+	labelOf := func(s string) (string, bool) {
+		if !isAsmLabel(s) {
+			return "", false
+		}
+		t := strings.TrimSpace(s)
+		return strings.TrimSuffix(t, ":"), true
+	}
+	leader := make([]bool, len(lines))
+	if len(lines) > 0 {
+		leader[0] = true
+	}
+	labelLine := map[string]int{}
+	for i, ln := range lines {
+		if name, ok := labelOf(ln); ok {
+			leader[i] = true
+			labelLine[name] = i
+		}
+		if isBranch(ln) || strings.TrimSpace(ln) == "RET" {
+			if i+1 < len(lines) {
+				leader[i+1] = true
+			}
+		}
+	}
+	type block struct {
+		start, end int // [start, end) line range
+		succs      []int
+	}
+	var blocks []block
+	blockAt := make([]int, len(lines))
+	for i := 0; i < len(lines); i++ {
+		if leader[i] {
+			blocks = append(blocks, block{start: i})
+			if len(blocks) > 1 {
+				blocks[len(blocks)-2].end = i
+			}
+		}
+		if len(blocks) > 0 {
+			blockAt[i] = len(blocks) - 1
+		}
+	}
+	if len(blocks) == 0 {
+		return asm
+	}
+	blocks[len(blocks)-1].end = len(lines)
+
+	// ---- 2. Successor edges: explicit branch targets plus
+	// fall-through (unless the block's last line is an unconditional
+	// JMP or RET).
+	branchTarget := func(s string) (string, bool) {
+		t := strings.TrimSpace(s)
+		sp := strings.IndexAny(t, " \t")
+		if sp < 0 {
+			return "", false
+		}
+		return strings.TrimSpace(t[sp:]), true
+	}
+	for bi := range blocks {
+		blk := &blocks[bi]
+		fallThrough := true
+		for i := blk.start; i < blk.end; i++ {
+			t := strings.TrimSpace(lines[i])
+			if t == "RET" {
+				fallThrough = false
+				continue
+			}
+			if !isBranch(lines[i]) {
+				continue
+			}
+			if tgt, ok := branchTarget(lines[i]); ok {
+				if pos, ok := labelLine[tgt]; ok {
+					blk.succs = append(blk.succs, blockAt[pos])
+				}
+			}
+			if strings.HasPrefix(t, "JMP ") || strings.HasPrefix(t, "JMP\t") {
+				fallThrough = false
+			}
+		}
+		if fallThrough && bi+1 < len(blocks) {
+			blk.succs = append(blk.succs, bi+1)
+		}
+	}
+	preds := make([][]int, len(blocks))
+	for bi, blk := range blocks {
+		for _, s := range blk.succs {
+			preds[s] = append(preds[s], bi)
+		}
+	}
+
+	// ---- 3. Per-line transfer over the "BX == m.M" fact.
+	const (
+		genR11  = "\tMOVQ 32(R11), BX"
+		genFP   = "\tMOVQ m+0(FP), BX"
+		genFP2  = "\tMOVQ 32(BX), BX"
+		bxKillB = "BL" // byte-writer alias of BX
+	)
+	step := func(valid bool, i int) bool {
+		ln := strings.TrimRight(lines[i], " \t")
+		switch {
+		case ln == genR11:
+			return true
+		case ln == genFP:
+			// Only the completed two-line pair re-establishes the
+			// fact; the first line alone leaves BX = m.
+			if i+1 < len(lines) && strings.TrimRight(lines[i+1], " \t") == genFP2 {
+				return valid // decided when the pair's 2nd line runs
+			}
+			return false
+		case ln == genFP2 && i > 0 && strings.TrimRight(lines[i-1], " \t") == genFP:
+			return true
+		case isAsmCall(lines[i]):
+			return false
+		default:
+			// A byte write through BL clobbers BX's low byte; treat it
+			// as a full kill (nothing emits BL today, but stay safe).
+			if writesRegister(lines[i], "BX") || writesRegister(lines[i], bxKillB) {
+				return false
+			}
+			return valid
+		}
+	}
+	transferBlock := func(in bool, bi int) bool {
+		v := in
+		for i := blocks[bi].start; i < blocks[bi].end; i++ {
+			v = step(v, i)
+		}
+		return v
+	}
+
+	// ---- 4. Fixpoint (optimistic init; entry pessimistic).
+	in := make([]bool, len(blocks))
+	out := make([]bool, len(blocks))
+	for i := range out {
+		in[i], out[i] = true, true
+	}
+	in[0] = false
+	out[0] = transferBlock(false, 0)
+	for changed := true; changed; {
+		changed = false
+		for bi := range blocks {
+			ni := true
+			if bi == 0 {
+				ni = false
+			} else if len(preds[bi]) == 0 {
+				// Unreachable via edges we model — be conservative.
+				ni = false
+			} else {
+				for _, p := range preds[bi] {
+					ni = ni && out[p]
+				}
+			}
+			no := transferBlock(ni, bi)
+			if ni != in[bi] || no != out[bi] {
+				in[bi], out[bi] = ni, no
+				changed = true
+			}
+		}
+	}
+
+	// ---- 5. Rewrite: drop reload lines whose fact is already valid.
+	dropped := map[int]bool{}
+	for bi := range blocks {
+		v := in[bi]
+		for i := blocks[bi].start; i < blocks[bi].end; i++ {
+			ln := strings.TrimRight(lines[i], " \t")
+			if v && ln == genR11 {
+				dropped[i] = true
+			}
+			if v && ln == genFP && i+1 < blocks[bi].end &&
+				strings.TrimRight(lines[i+1], " \t") == genFP2 {
+				dropped[i] = true
+				dropped[i+1] = true
+			}
+			v = step(v, i)
+		}
+	}
+	if len(dropped) == 0 {
+		return asm
+	}
+	outLines := make([]string, 0, len(lines))
+	for i, ln := range lines {
+		if dropped[i] {
+			continue
+		}
+		outLines = append(outLines, ln)
+	}
+	return strings.Join(outLines, "\n")
+}

--- a/internal/asmgen/memmflow_test.go
+++ b/internal/asmgen/memmflow_test.go
@@ -226,3 +226,82 @@ func TestFlowDedupAcrossDiamondEndToEnd(t *testing.T) {
 		t.Errorf("want at most 2 m.M reloads (one per arm, none at the merge), got %d:\n%s", n, asm)
 	}
 }
+
+// TestMemBaseFlowDedup_ARM64LoopHeader mirrors the amd64 loop-header
+// shape for the arm64 config: R2 carries m.M, R4 is the m cache, and
+// register-offset addressing keeps R2 alive through the memop, so
+// the in-loop reload folds when the body is call-free.
+func TestMemBaseFlowDedup_ARM64LoopHeader(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVD 32(R4), R2",
+		"\tMOVWU R5, R3",
+		"\tMOVW (R2)(R3), R6",
+		"L1:",
+		"\tMOVD 32(R4), R2", // redundant: preheader valid, body call-free
+		"\tMOVWU R6, R3",
+		"\tMOVW (R2)(R3), R6",
+		"\tADDW $1, R7, R7",
+		"\tCMPW R8, R7",
+		"\tBNE L1",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := strings.Count(got, "\tMOVD 32(R4), R2"); n != 1 {
+		t.Fatalf("want 1 arm64 reload (preheader only), got %d:\n%s", n, got)
+	}
+}
+
+// TestMemBaseFlowDedup_ARM64CallKills: a CALL in the loop body keeps
+// the header reload alive.
+func TestMemBaseFlowDedup_ARM64CallKills(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVD 32(R4), R2",
+		"L1:",
+		"\tMOVD 32(R4), R2",
+		"\tMOVWU R5, R3",
+		"\tMOVW (R2)(R3), R6",
+		"\tCALL ·Fn1(SB)",
+		"\tMOVD m+0(FP), R4",
+		"\tBNE L1",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := strings.Count(got, "\tMOVD 32(R4), R2"); n != 2 {
+		t.Fatalf("want both arm64 reloads kept, got %d:\n%s", n, got)
+	}
+}
+
+// TestARM64RegisterOffsetAndFlowDedupEndToEnd pins the arm64 memop
+// shape on real emitted output: accesses use register-offset
+// addressing `(R2)(R3)` (no `ADD R3, R2, R2` clobber), so dependent
+// loads share a single m.M read.
+func TestARM64RegisterOffsetAndFlowDedupEndToEnd(t *testing.T) {
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	bb := ssa.NewFuncBuilder("dixa64", fsig)
+	b0 := bb.NewBlock(ssa.BlockRet)
+	bb.SetEntry(b0)
+	bb.SetCurrent(b0)
+	base := bb.Param(0, ssa.TypeI32)
+	v1 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 0, base)
+	v2 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 8, v1)
+	v3 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 4, v1)
+	sum := bb.NewValue(ssa.OpAdd32, ssa.TypeI32, v2, v3)
+	bb.FinishRet(sum)
+	if err := ssa.Verify(bb.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	asm, _, err := EmitFuncARM64("dixa64", sig, bb.Func(), FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncARM64: %v", err)
+	}
+	if strings.Contains(asm, "ADD R3, R2, R2") {
+		t.Errorf("R2-clobbering ADD survived — memops must use (R2)(R3) addressing:\n%s", asm)
+	}
+	if !strings.Contains(asm, "(R2)(R3)") {
+		t.Errorf("expected register-offset `(R2)(R3)` addressing:\n%s", asm)
+	}
+	if n := strings.Count(asm, "\tMOVD 32(R4), R2"); n != 1 {
+		t.Errorf("want exactly 1 m.M reload for 3 dependent loads, got %d:\n%s", n, asm)
+	}
+}

--- a/internal/asmgen/memmflow_test.go
+++ b/internal/asmgen/memmflow_test.go
@@ -1,0 +1,228 @@
+package asmgen
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+func countReloads(s string) int { return strings.Count(s, "\tMOVQ 32(R11), BX") }
+
+// TestMemBaseFlowDedup_JoinBothPredsValid: both branch arms load m.M
+// and neither calls; the reload after the join is redundant on every
+// path and must be dropped, while each arm's own (first) load stays.
+func TestMemBaseFlowDedup_JoinBothPredsValid(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVL l0+8(FP), AX",
+		"\tTESTL AX, AX",
+		"\tJE L2",
+		"L1:",
+		"\tMOVQ 32(R11), BX",
+		"\tMOVL (BX)(SI*1), AX",
+		"\tJMP L3",
+		"L2:",
+		"\tMOVQ 32(R11), BX",
+		"\tMOVL 4(BX)(SI*1), AX",
+		"L3:",
+		"\tMOVQ 32(R11), BX", // redundant: valid on both preds
+		"\tMOVL 8(BX)(SI*1), AX",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := countReloads(got); n != 2 {
+		t.Fatalf("want 2 reloads after dedup, got %d:\n%s", n, got)
+	}
+	if !strings.Contains(got, "L3:\n\tMOVL 8(BX)(SI*1), AX") {
+		t.Fatalf("join-block reload not the one dropped:\n%s", got)
+	}
+}
+
+// TestMemBaseFlowDedup_CallOnOnePathKeepsReload: one arm CALLs after
+// its load, so the join reload is NOT redundant and must survive.
+func TestMemBaseFlowDedup_CallOnOnePathKeepsReload(t *testing.T) {
+	in := strings.Join([]string{
+		"\tJE L2",
+		"L1:",
+		"\tMOVQ 32(R11), BX",
+		"\tCALL ·Fn1(SB)",
+		"\tJMP L3",
+		"L2:",
+		"\tMOVQ 32(R11), BX",
+		"L3:",
+		"\tMOVQ 32(R11), BX",
+		"\tMOVL (BX)(SI*1), AX",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := countReloads(got); n != 3 {
+		t.Fatalf("want all 3 reloads kept, got %d:\n%s", n, got)
+	}
+}
+
+// TestMemBaseFlowDedup_LoopHeader: a call-free loop re-loads m.M
+// every iteration; with the pre-loop load available the in-loop
+// reload must be dropped (optimistic fixpoint across the back edge).
+func TestMemBaseFlowDedup_LoopHeader(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVQ 32(R11), BX",
+		"\tMOVL (BX)(SI*1), AX",
+		"L1:",
+		"\tMOVQ 32(R11), BX", // redundant: preheader valid, body call-free
+		"\tMOVL 4(BX)(SI*1), AX",
+		"\tADDL $1, CX",
+		"\tCMPL CX, DX",
+		"\tJNE L1",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := countReloads(got); n != 1 {
+		t.Fatalf("want 1 reload (preheader only), got %d:\n%s", n, got)
+	}
+}
+
+// TestMemBaseFlowDedup_LoopWithCallKeepsReload: the loop body calls,
+// so the back edge invalidates the fact and the header reload stays.
+func TestMemBaseFlowDedup_LoopWithCallKeepsReload(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVQ 32(R11), BX",
+		"L1:",
+		"\tMOVQ 32(R11), BX",
+		"\tMOVL (BX)(SI*1), AX",
+		"\tCALL ·Fn1(SB)",
+		"\tMOVQ m+0(FP), R11",
+		"\tJNE L1",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := countReloads(got); n != 2 {
+		t.Fatalf("want both reloads kept, got %d:\n%s", n, got)
+	}
+}
+
+// TestMemBaseFlowDedup_BXClobberKills: a plain write to BX between
+// the load and the next reload keeps the reload alive.
+func TestMemBaseFlowDedup_BXClobberKills(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVQ 32(R11), BX",
+		"\tMOVQ AX, BX", // clobber
+		"\tMOVQ 32(R11), BX",
+		"\tMOVL (BX)(SI*1), AX",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if n := countReloads(got); n != 2 {
+		t.Fatalf("want both reloads kept, got %d:\n%s", n, got)
+	}
+}
+
+// TestMemBaseFlowDedup_TwoLineFPFormPair: the no-mcache two-line form
+// participates as a unit — dropped together when redundant.
+func TestMemBaseFlowDedup_TwoLineFPFormPair(t *testing.T) {
+	in := strings.Join([]string{
+		"\tMOVQ m+0(FP), BX",
+		"\tMOVQ 32(BX), BX",
+		"\tMOVL (BX)(SI*1), AX",
+		"\tMOVQ m+0(FP), BX", // redundant pair
+		"\tMOVQ 32(BX), BX",
+		"\tMOVL 4(BX)(SI*1), AX",
+		"\tRET",
+	}, "\n")
+	got := memBaseFlowDedup(in)
+	if strings.Count(got, "MOVQ m+0(FP), BX") != 1 || strings.Count(got, "MOVQ 32(BX), BX") != 1 {
+		t.Fatalf("redundant FP pair not dropped exactly once:\n%s", got)
+	}
+}
+
+// TestDirectIndexAndFlowDedupEndToEnd pins the two memop-addressing
+// properties on real emitted output (not synthetic text):
+//
+//  1. direct-index: a load whose base value has a GP register home
+//     addresses memory as `disp(BX)(<home>*1)` with no `MOVL <reg>,
+//     SI` staging hop;
+//  2. flow dedup: dependent loads in one function share a single
+//     `MOVQ 32(R11), BX` m.M read.
+func TestDirectIndexAndFlowDedupEndToEnd(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	bb := ssa.NewFuncBuilder("dix", fsig)
+	b0 := bb.NewBlock(ssa.BlockRet)
+	bb.SetEntry(b0)
+	bb.SetCurrent(b0)
+	base := bb.Param(0, ssa.TypeI32)
+	v1 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 0, base)
+	v2 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 8, v1)
+	v3 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 4, v1)
+	sum := bb.NewValue(ssa.OpAdd32, ssa.TypeI32, v2, v3)
+	bb.FinishRet(sum)
+	if err := ssa.Verify(bb.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	asm, _, err := EmitFuncAMD64("dix", sig, bb.Func(), FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncAMD64: %v", err)
+	}
+	// v1 has two load users reading offsets 8 and 4 off it. With a GP
+	// home the addressing must be direct-index; a `MOVL <home>, SI`
+	// staging hop for either user means the fast path regressed.
+	if !strings.Contains(asm, "8(BX)(") || !strings.Contains(asm, "4(BX)(") {
+		t.Errorf("expected direct-index `8(BX)(<reg>*1)` / `4(BX)(<reg>*1)` addressing:\n%s", asm)
+	}
+	if n := countReloads(asm); n != 1 {
+		t.Errorf("want exactly 1 m.M reload for 3 dependent loads, got %d:\n%s", n, asm)
+	}
+}
+
+// TestFlowDedupAcrossDiamondEndToEnd pins the cross-label case the
+// straight-line dedupMemMReload cannot handle: both diamond arms
+// load m.M and neither calls, so the merge block's load must be
+// deleted by memBaseFlowDedup.
+func TestFlowDedupAcrossDiamondEndToEnd(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64-only test (GOARCH=%s)", runtime.GOARCH)
+	}
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	bb := ssa.NewFuncBuilder("diamond", fsig)
+	b0 := bb.NewBlock(ssa.BlockIf)
+	b1 := bb.NewBlock(ssa.BlockPlain)
+	b2 := bb.NewBlock(ssa.BlockPlain)
+	b3 := bb.NewBlock(ssa.BlockRet)
+	bb.SetEntry(b0)
+
+	bb.SetCurrent(b0)
+	p := bb.Param(0, ssa.TypeI32)
+	zero := bb.Const32(0)
+	cond := bb.NewValue(ssa.OpNe32, ssa.TypeBool, p, zero)
+	bb.LinkIf(cond, b1, b2)
+
+	bb.SetCurrent(b1)
+	t1 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 16, p)
+	ssa.AddEdge(b1, b3)
+
+	bb.SetCurrent(b2)
+	t2 := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 32, p)
+	ssa.AddEdge(b2, b3)
+
+	bb.SetCurrent(b3)
+	merged := bb.NewValue(ssa.OpPhi, ssa.TypeI32, t1, t2)
+	final := bb.NewValueAuxInt(ssa.OpLoad32, ssa.TypeI32, 0, merged)
+	bb.FinishRet(final)
+
+	if err := ssa.Verify(bb.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	asm, _, err := EmitFuncAMD64("diamond", sig, bb.Func(), FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncAMD64: %v", err)
+	}
+	// One reload per arm; the merge block's reload must be gone.
+	if n := countReloads(asm); n > 2 {
+		t.Errorf("want at most 2 m.M reloads (one per arm, none at the merge), got %d:\n%s", n, asm)
+	}
+}


### PR DESCRIPTION
Linear-memory addressing round for the **asm backend** (P2 of the
linear-memory work; P1 = #13 covered the pure backend). Two commits:
amd64 first, then the arm64 port. Both are pure code-shape changes:

## 1. `memBaseFlowDedup` — CFG-level m.M reload elimination

Every memop re-read `m.M` with `MOVQ 32(R11), BX`. The existing
`dedupMemMReload` could only drop repeats inside a straight-line
span — every label reset it. The new pass builds the block CFG over
the emitted text and solves the classic available-expression
fixpoint ("BX still holds m.M" — AND-meet over predecessors,
optimistic init, kill = CALL or BX write), then deletes every reload
whose fact already holds on all incoming paths. Loop headers with
call-free bodies and post-branch join blocks are the big winners.

Why deletion instead of a function-wide BX cache: a prologue-primed
cache INSERTS instructions and measured as a consistent
+0.6..+1.5% loss on the googlesqlite window suite (call-dense
functions never win the priming back). A pass that only deletes
instructions cannot regress instruction count by construction and
needs no profitability gate.

## 2. Direct-index addressing for register-homed bases

`MOVL <home>, SI` + `(BX)(SI*1)` becomes `disp(BX)(<home>*1)` when
the base value already has a GP register home. Sound because every
i32 producer writes its register through a 32-bit op (zero-extending
on amd64). Negative offsets keep the SI path. The inline float-cmp
parity fix-up moves its scratch from BL/BX to DL/DX so float
compares no longer kill BX's m.M fact (and conform to the documented
inline-helper scratch contract).

## Effect

Static (regenerated bundles vs main, same CLI parameters):

| bundle | m.M reloads | amd64.s size |
|---|---|---|
| googlesql.wasm | 241,209 → 184,543 (**−23.5%**) | 127.2 MB → 125.2 MB (−1.6%) |
| python.wasm | 84,563 → 54,777 (**−35.2%**) | 36.0 MB → 34.9 MB (−3.3%) |

`arm64.s` and `*_pure.go` are byte-identical to main for both
bundles (checksum-verified) — amd64.s is the only changed artifact.

Runtime (Rosetta amd64 — the only arch whose output changed;
go-python numbers from alternating A/B at n=12):

| workload | main | this PR | Δ |
|---|---:|---:|---|
| go-python loop-sum | 89.09ms | 85.10ms | **−4.5% (p=0.000)** |
| go-python fib(28) | 413.2ms | 405.6ms | −1.8% (p=0.198, noise) |
| go-python startup | — | — | flat (p=0.590) |
| googlesqlite window | — | — | −0.06% geomean, flat (p>0.15) |

The loop-sum win is the pass's target shape hit dead-on: the CPython
eval loop is a call-free hot loop whose per-iteration m.M reloads
fold to one pre-loop load. The window suite is SQLite/driver-
dominated and stays flat. An initial back-to-back run showed startup
+14.6%; the alternating re-run proved that was machine-state noise
(p=0.590). Everything else deleted is L1-hit loads that wide OOO
cores hide (P1's lesson) — the residual value there is smaller text
and a shape the arm64 port can reuse, at zero measured cost.

## Verification (all exit 0, judged by exit code)

- wasm2go `go test ./...` on host amd64 AND `GOARCH=arm64`;
  `make lint` 0 issues.
- googlesqlite full `go test -race -timeout 30m ./...` against a
  regenerated bundle (go.mod replace), amd64.
- go-python `go test -count=1 ./...` and `-race` against a
  regenerated python bundle, amd64.
- Committed generator reproduces the verified bundle bit-for-bit
  (post-restore regeneration checksummed against the tested bundle).
- New tests: 6 unit shapes for the dataflow pass + 2 emitted-output
  pins (direct-index & single reload on dependent loads; no reload
  at a diamond merge).

## arm64 port (2nd commit)

The follow-up promised above is now included. arm64's memops
historically folded the effective address INTO the m.M register
(`ADD R3, R2, R2` + `(R2)`), so "R2 == m.M" died inside every memop
and no dedup was possible. The port:

1. switches emitLoad/emitStore to register-offset addressing
   `(R2)(R3)` — one ADD saved per memop, and R2 survives;
2. parameterises `memBaseFlowDedup` over per-arch patterns
   (amd64 BX/R11, arm64 R2/R4);
3. fixes `dedupMemMReload`'s arm64 patterns, which referenced
   `R0`/`R26` — registers the current emitters never use for m.M
   (dead patterns from an earlier emitter shape).

The amd64 direct-index fast path is deliberately NOT ported: arm64
register-register `MOVW` sign-extends, so the "i32 home ⇒ upper bits
zero" invariant that justifies indexing by the home register on
amd64 does not hold; the explicit `MOVWU` zero-extend staging stays.

Static (regenerated bundles; commit 1's arm64.s equals main's):

| bundle | arm64 m.M reloads | arm64.s size |
|---|---|---|
| googlesql.wasm | 649,610 → 205,378 (**−68.4%**) | 222.3 MB → 207.0 MB (−6.9%) |
| python.wasm | 133,187 → 60,004 (**−54.9%**) | 58.8 MB → 55.9 MB (−4.8%) |

The reduction dwarfs amd64's −23..−35% because arm64 previously got
NO dedup at all — the stale patterns matched nothing and the
ADD-into-R2 form blocked reuse, so every memop paid the reload.

Runtime (native arm64 M5, alternating A/B) — unlike amd64, every
workload moves:

| workload | main | this PR | Δ |
|---|---:|---:|---|
| googlesqlite window (geomean) | 6.114ms | 6.032ms | **−1.35%** (4/5 queries p<0.05) |
| go-python fib(28) | 579.6ms | 571.4ms | **−1.4% (p=0.000)** |
| go-python loop-sum | 123.1ms | 120.3ms | **−2.2% (p=0.000)** |
| go-python startup | 19.02ms | 18.37ms | **−3.4% (p=0.000)** |

Verification note: the first full `-race` run on native arm64
tripped a **pre-existing googlesqlite data race** (unsynchronised
package-level `sequenceCounters` map in
`internal/functions/spanner/singletons.go`, hit by parallel
sequence-function specs). It reproduces with the baseline bundle
too, and neither racing stack enters generated code. The green run
below used a local verification-only mutex patch on googlesqlite
(restored afterwards); googlesqlite needs a proper fix.

`amd64.s` and `*_pure.go` byte-identical to commit 1's bundles
(checksums); verification: wasm2go suites amd64+arm64 + lint,
googlesqlite full `-race` native arm64, go-python ±race native
arm64 — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
