### PR TITLE
ssa/codegen/asmgen: first-class br_table dispatch (BlockBrTable)

### DIFF
--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -119,6 +120,19 @@ type arch interface {
 	// the optimisation; arches that ignore the hint produce the
 	// classic `JCC thenLabel; JMP elseLabel` pair.
 	EmitIfBranch(b *strings.Builder, cond *ssa.Value, thenLabel, elseLabel, fallthroughLabel string, plan *funcPlan, frame argFrame)
+	// EmitBrTableLoadSel stages a BlockBrTable's i32 selector into the
+	// arch's dispatch scratch register (AX / R0) once, ahead of the
+	// compare tree emitted via EmitBrTableCmpBranch.
+	EmitBrTableLoadSel(b *strings.Builder, sel *ssa.Value, plan *funcPlan, frame argFrame)
+	// EmitBrTableCmpBranch compares the staged selector against the
+	// constant val and branches: to eqLabel when equal, and — when
+	// ltLabel is non-empty — to ltLabel when the selector is
+	// (signed-)less than val. Falls through otherwise. The signed
+	// compare is correct for br_table dispatch because every case
+	// value is a non-negative table index: a "negative" selector
+	// (u32 ≥ 2^31) compares below every case value and walks off the
+	// tree into the default, exactly wasm's out-of-range rule.
+	EmitBrTableCmpBranch(b *strings.Builder, val int32, eqLabel, ltLabel string)
 	// EmitReturn moves the function's K return values into their
 	// FP-relative result locations, then RET.
 	EmitReturn(b *strings.Builder, blk *ssa.Block, sig wasm.FuncType, plan *funcPlan, frame argFrame) error
@@ -1678,6 +1692,55 @@ func emitBlock(b *strings.Builder, blk *ssa.Block, f *ssa.Func, plan *funcPlan, 
 			}
 			a.EmitJmp(b, thenLabel, "")
 		}
+	case ssa.BlockBrTable:
+		if blk.Control == nil || len(blk.Succs) == 0 || len(blk.TableCases) != len(blk.Succs) {
+			return fmt.Errorf("malformed BrTable block b%d", blk.ID)
+		}
+		// Resolve each successor to its dispatch label. Successors
+		// whose blocks carry phis route through a PHI_<blk>_<si>
+		// intermediate (mirroring the BlockIf arms): the tree branches
+		// to the intermediate, which runs the edge copies and jumps
+		// on. Phi-free successors dispatch straight to the (pass-
+		// through-redirected) target label.
+		succLabel := make([]string, len(blk.Succs))
+		type phiInter struct {
+			label string
+			si    int
+		}
+		var inters []phiInter
+		for si, e := range blk.Succs {
+			if plan.hasPhi[e.Block.ID] {
+				succLabel[si] = fmt.Sprintf("PHI_%d_%d", blk.ID, si)
+				inters = append(inters, phiInter{succLabel[si], si})
+			} else {
+				succLabel[si] = labelFor(passthroughTarget(e.Block, plan))
+			}
+		}
+		// Flatten TableCases into a sorted (value → label) list for
+		// the binary-search tree. Values routed to the default block
+		// are dropped — the tree's misses land on default anyway.
+		var pairs []brTableCase
+		for si, vals := range blk.TableCases {
+			if si == blk.TableDefault {
+				continue
+			}
+			for _, cv := range vals {
+				pairs = append(pairs, brTableCase{val: cv, label: succLabel[si]})
+			}
+		}
+		sort.Slice(pairs, func(i, j int) bool { return pairs[i].val < pairs[j].val })
+		a.EmitBrTableLoadSel(b, blk.Control, plan, frame)
+		emitBrTableTree(b, a, pairs, succLabel[blk.TableDefault], blk.ID, 0)
+		a.EmitJmp(b, succLabel[blk.TableDefault], "")
+		// Phi intermediates.
+		for _, in := range inters {
+			fmt.Fprintf(b, "%s:\n", in.label)
+			succ := blk.Succs[in.si]
+			if err := emitPhiEdgeCopies(b, blk, succ.Block, succ.Index, plan, frame, a); err != nil {
+				return err
+			}
+			a.EmitJmp(b, labelFor(passthroughTarget(succ.Block, plan)), "")
+		}
 	case ssa.BlockRet:
 		if err := a.EmitReturn(b, blk, sig, plan, frame); err != nil {
 			return err
@@ -1688,6 +1751,40 @@ func emitBlock(b *strings.Builder, blk *ssa.Block, f *ssa.Func, plan *funcPlan, 
 		return fmt.Errorf("unsupported block kind %v", blk.Kind)
 	}
 	return nil
+}
+
+// brTableCase is one (selector value → dispatch label) entry of a
+// BlockBrTable's flattened, sorted case list.
+type brTableCase struct {
+	val   int32
+	label string
+}
+
+// emitBrTableTree emits a binary-search compare tree over the sorted
+// case list: O(log n) compares per dispatch instead of the O(n)
+// equality chain the old If-chain lowering produced. Leaves (≤ 4
+// entries) emit a short equality run; inner nodes split at the
+// median with a single compare that branches equal→target and
+// less→left-subtree label, falling through to the right subtree.
+// Control that walks off any leaf reaches the caller-emitted jump to
+// the default label. `depth` disambiguates the per-node labels.
+func emitBrTableTree(b *strings.Builder, a arch, pairs []brTableCase, defaultLabel string, blkID ssa.BlockID, node int) int {
+	if len(pairs) <= 4 {
+		for _, p := range pairs {
+			a.EmitBrTableCmpBranch(b, p.val, p.label, "")
+		}
+		return node
+	}
+	mid := len(pairs) / 2
+	leftLabel := fmt.Sprintf("BT_%d_%d", blkID, node)
+	node++
+	// Equal → dispatch; less → left subtree; fall through → right.
+	a.EmitBrTableCmpBranch(b, pairs[mid].val, pairs[mid].label, leftLabel)
+	node = emitBrTableTree(b, a, pairs[mid+1:], defaultLabel, blkID, node)
+	a.EmitJmp(b, defaultLabel, "")
+	fmt.Fprintf(b, "%s:\n", leftLabel)
+	node = emitBrTableTree(b, a, pairs[:mid], defaultLabel, blkID, node)
+	return node
 }
 
 // emitPhiEdgeCopies emits MOV instructions that copy each phi's

--- a/internal/asmgen/brtable_tree_test.go
+++ b/internal/asmgen/brtable_tree_test.go
@@ -1,0 +1,117 @@
+package asmgen
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// buildBrTableFunc constructs f(sel i32) i32 with an n-way arity-0
+// BlockBrTable: case k returns k*10, default returns -1.
+func buildBrTableFunc(t *testing.T, n int) (*ssa.Func, wasm.FuncType) {
+	t.Helper()
+	sig := wasm.FuncType{Params: []wasm.ValType{wasm.ValI32}, Results: []wasm.ValType{wasm.ValI32}}
+	fsig := ssa.FuncSig{Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}}
+	bb := ssa.NewFuncBuilder("bt", fsig)
+	dispatch := bb.NewBlock(ssa.BlockBrTable)
+	bb.SetEntry(dispatch)
+	bb.SetCurrent(dispatch)
+	sel := bb.Param(0, ssa.TypeI32)
+	dispatch.Control = sel
+	for k := 0; k < n; k++ {
+		target := bb.NewBlock(ssa.BlockRet)
+		bb.SetCurrent(target)
+		bb.FinishRet(bb.Const32(int32(k * 10)))
+		ssa.AddEdge(dispatch, target)
+		dispatch.TableCases = append(dispatch.TableCases, []int32{int32(k)})
+	}
+	dflt := bb.NewBlock(ssa.BlockRet)
+	bb.SetCurrent(dflt)
+	bb.FinishRet(bb.Const32(-1))
+	ssa.AddEdge(dispatch, dflt)
+	dispatch.TableCases = append(dispatch.TableCases, nil)
+	dispatch.TableDefault = len(dispatch.Succs) - 1
+	if err := ssa.Verify(bb.Func()); err != nil {
+		t.Fatalf("SSA verify: %v", err)
+	}
+	return bb.Func(), sig
+}
+
+// TestBrTableBinarySearchTreeAMD64 pins the dispatch shape: for a
+// 64-way table the tree must stay logarithmic — every root-to-leaf
+// path is ≤ ~log2(n) inner compares + a ≤4-entry leaf run — instead
+// of the old 64-long equality chain. We assert the structural
+// signals: BT_ split labels exist, and the JE count equals the case
+// count while split compares (JLT) stay ≈ n/4 (each split's JLT is
+// one per inner node ≈ n/4 for leaf size 4).
+func TestBrTableBinarySearchTreeAMD64(t *testing.T) {
+	f, sig := buildBrTableFunc(t, 64)
+	asm, _, err := EmitFuncAMD64("bt", sig, f, FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncAMD64: %v", err)
+	}
+	if !strings.Contains(asm, "BT_") {
+		t.Fatalf("no binary-search split labels — dispatch degenerated to a linear chain:\n%s", asm)
+	}
+	je := strings.Count(asm, "\tJE ")
+	jlt := strings.Count(asm, "\tJLT ")
+	if je != 64 {
+		t.Fatalf("JE count = %d, want 64 (one per case)", je)
+	}
+	// 64 cases with ≤4-entry leaves ⇒ ~2^4 leaves ⇒ ~15 inner nodes.
+	// Anything close to 64 would mean the tree collapsed to a chain.
+	if jlt < 8 || jlt > 24 {
+		t.Fatalf("JLT (split) count = %d, want ~15 (log-shaped tree)", jlt)
+	}
+	if !strings.Contains(asm, "\tMOVL l0+8(FP), AX") && !strings.Contains(asm, ", AX\n\tCMPL AX, $") {
+		t.Fatalf("selector not staged in AX before the tree:\n%s", asm)
+	}
+}
+
+// TestBrTableTreeARM64Shape mirrors the amd64 pin for the arm64
+// emitter (BEQ per case, BLT splits).
+func TestBrTableTreeARM64Shape(t *testing.T) {
+	f, sig := buildBrTableFunc(t, 64)
+	asm, _, err := EmitFuncARM64("bt", sig, f, FuncOptions{ModulePkgRef: "*Module"})
+	if err != nil {
+		t.Fatalf("EmitFuncARM64: %v", err)
+	}
+	if !strings.Contains(asm, "BT_") {
+		t.Fatalf("no binary-search split labels:\n%s", asm)
+	}
+	beq := strings.Count(asm, "\tBEQ ")
+	blt := strings.Count(asm, "\tBLT ")
+	if beq != 64 {
+		t.Fatalf("BEQ count = %d, want 64", beq)
+	}
+	if blt < 8 || blt > 24 {
+		t.Fatalf("BLT (split) count = %d, want ~15", blt)
+	}
+}
+
+// TestBrTable64Runtime executes the emitted amd64 binary-search tree
+// for a 64-way dispatcher, probing selectors that walk distinct
+// root-to-leaf paths (splits, leaf runs, both extremes) plus the
+// out-of-range default. The payload-carrying `pick` export pins the
+// arity>0 If-chain fallback at runtime in the same build.
+func TestBrTable64Runtime(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("amd64 driver test (GOARCH=%s)", runtime.GOARCH)
+	}
+	var cases []driverCase
+	for _, sel := range []int{0, 1, 2, 7, 15, 16, 31, 32, 33, 47, 48, 62, 63} {
+		cases = append(cases, driverCase{"switch64", []string{fmt.Sprintf("%d", sel)}, fmt.Sprintf("%d", sel*10+7)})
+	}
+	cases = append(cases,
+		driverCase{"switch64", []string{"64"}, "-1"},
+		driverCase{"switch64", []string{"1000000"}, "-1"},
+		driverCase{"pick", []string{"0"}, "1111"},
+		driverCase{"pick", []string{"1"}, "111"},
+		driverCase{"pick", []string{"9"}, "1111"},
+	)
+	buildAndRunDriver(t, "cg_brtable64", []string{"switch64", "pick"}, driverPlaceholder, cases)
+}

--- a/internal/asmgen/emit_archs.go
+++ b/internal/asmgen/emit_archs.go
@@ -177,6 +177,24 @@ func emitFusedCmpBranchAMD64(b *strings.Builder, cond *ssa.Value, plan *funcPlan
 	emitCondBranchAMD64(b, jcc, jccInv, thenLabel, elseLabel, fallthroughLabel)
 }
 
+// EmitBrTableLoadSel stages the br_table selector in AX for the
+// compare tree. AX survives the whole dispatch: the tree emits only
+// CMP/JCC/JMP and labels, none of which write it.
+func (archAMD64) EmitBrTableLoadSel(b *strings.Builder, sel *ssa.Value, plan *funcPlan, frame argFrame) {
+	fmt.Fprintf(b, "\tMOVL %s, AX\n", operandSrc32(sel, plan, frame, "SP"))
+}
+
+// EmitBrTableCmpBranch — one node of the binary-search dispatch tree.
+// Same CMP orientation as emitFusedCmpBranchAMD64 (`CMPL AX, $v` +
+// JLT ⇔ sel < v).
+func (archAMD64) EmitBrTableCmpBranch(b *strings.Builder, val int32, eqLabel, ltLabel string) {
+	fmt.Fprintf(b, "\tCMPL AX, $%d\n", val)
+	fmt.Fprintf(b, "\tJE %s\n", eqLabel)
+	if ltLabel != "" {
+		fmt.Fprintf(b, "\tJLT %s\n", ltLabel)
+	}
+}
+
 func (archAMD64) SupportsRegHome() bool { return true }
 
 // SupportsLoopCarryCoalesce — amd64 has the validated coalesce emit

--- a/internal/asmgen/emitarm64.go
+++ b/internal/asmgen/emitarm64.go
@@ -87,6 +87,24 @@ func emitCondBranchARM64(b *strings.Builder, branchOp, branchOpInv, thenLabel, e
 // per-op emits that RegHomeEligibleOp accepts honour it on the write
 // side. Block-local regalloc keeps every value within one block, so a
 // carry is reloaded from its slot each iteration — always correct.
+// EmitBrTableLoadSel stages the br_table selector in R0 for the
+// compare tree. R0 survives the whole dispatch: the tree emits only
+// CMPW/B<cond>/JMP and labels, none of which write it.
+func (archARM64) EmitBrTableLoadSel(b *strings.Builder, sel *ssa.Value, plan *funcPlan, frame argFrame) {
+	fmt.Fprintf(b, "\tMOVW %s, R0\n", operandSrc32ARM64(sel, plan, frame))
+}
+
+// EmitBrTableCmpBranch — one node of the binary-search dispatch tree.
+// Same CMP orientation as emitFusedCmpBranchARM64 (`CMPW $v, R0`
+// computes R0 - v, so BLT ⇔ sel < v).
+func (archARM64) EmitBrTableCmpBranch(b *strings.Builder, val int32, eqLabel, ltLabel string) {
+	fmt.Fprintf(b, "\tCMPW $%d, R0\n", val)
+	fmt.Fprintf(b, "\tBEQ %s\n", eqLabel)
+	if ltLabel != "" {
+		fmt.Fprintf(b, "\tBLT %s\n", ltLabel)
+	}
+}
+
 func (archARM64) SupportsRegHome() bool { return true }
 
 // SupportsLoopCarryCoalesce — arm64 opts into the cross-block

--- a/internal/codegen/brtable_switch_test.go
+++ b/internal/codegen/brtable_switch_test.go
@@ -1,0 +1,122 @@
+package codegen_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// TestBrTableEmitsSwitch pins the pure-mode br_table emission to a Go
+// switch STATEMENT. The Go compiler lowers dense integer switches to
+// jump tables but never reconstructs a switch from an if-else
+// cascade, so the old chain-of-equality-Ifs emission cost
+// O(len(cases)) compares per dispatch (CPython's eval loop: a
+// 255-deep chain). The control fixture's switch3 export is a 3-case
+// br_table.
+func TestBrTableEmitsSwitch(t *testing.T) {
+	bin := testfixture.Wasm(t, "control")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "ctl", OutputImportPath: "gentest/ctl"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var sb strings.Builder
+	sb.Write(buf.Bytes())
+	for _, data := range res.AuxFiles {
+		sb.Write(data)
+	}
+	for _, data := range res.Files {
+		sb.Write(data)
+	}
+	src := sb.String()
+
+	// A switch with the three dispatch cases must exist...
+	swRe := regexp.MustCompile(`switch [^\n]+\{`)
+	if !swRe.MatchString(src) {
+		t.Fatalf("no switch statement emitted for the br_table dispatcher")
+	}
+	if !strings.Contains(src, "case 0:") || !strings.Contains(src, "case 1:") || !strings.Contains(src, "case 2:") {
+		t.Fatalf("switch missing dispatch case clauses:\n%s", clip(src))
+	}
+	if !strings.Contains(src, "default:") {
+		t.Fatalf("switch missing default clause")
+	}
+}
+
+func clip(s string) string {
+	if len(s) > 4000 {
+		return s[:4000] + "\n...[clipped]"
+	}
+	return s
+}
+
+// TestBrTable64RuntimePure diffs the pure-mode switch dispatch against
+// wazero for every selector 0..70 (all 64 cases + a band of
+// out-of-range values) plus the payload-carrying `pick` fallback.
+func TestBrTable64RuntimePure(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_brtable64")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	r := wazero.NewRuntime(ctx)
+	t.Cleanup(func() {
+		if err := r.Close(ctx); err != nil {
+			t.Errorf("wazero close: %v", err)
+		}
+	})
+	wmod, err := r.Instantiate(ctx, bin)
+	if err != nil {
+		t.Fatalf("wazero instantiate: %v", err)
+	}
+
+	var mainSB strings.Builder
+	mainSB.WriteString("package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n")
+	var want []string
+	for sel := int32(0); sel <= 70; sel++ {
+		o, err := wmod.ExportedFunction("switch64").Call(ctx, u32(sel))
+		if err != nil {
+			t.Fatalf("wazero switch64(%d): %v", sel, err)
+		}
+		want = append(want, fmt.Sprintf("%d", int32(o[0])))
+		fmt.Fprintf(&mainSB, "\tfmt.Println(m.Switch64(int32(%d)))\n", sel)
+	}
+	for _, sel := range []int32{0, 1, 2} {
+		o, err := wmod.ExportedFunction("pick").Call(ctx, u32(sel))
+		if err != nil {
+			t.Fatalf("wazero pick(%d): %v", sel, err)
+		}
+		want = append(want, fmt.Sprintf("%d", int32(o[0])))
+		fmt.Fprintf(&mainSB, "\tfmt.Println(m.Pick(int32(%d)))\n", sel)
+	}
+	mainSB.WriteString("}\n")
+
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	out := strings.Fields(strings.TrimSpace(runGoSnippet(t, buf.String(), mainSB.String(), res.Sidecars, res.Files)))
+	if len(out) != len(want) {
+		t.Fatalf("got %d outputs, want %d", len(out), len(want))
+	}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Fatalf("output %d: got %s want %s", i, out[i], want[i])
+		}
+	}
+}

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -357,6 +357,45 @@ func (em *ssaEmitter) emitMultiBlock(f *ssa.Func) (*ast.BlockStmt, error) {
 				Body: thenBody,
 				Else: elseBody,
 			})
+		case ssa.BlockBrTable:
+			if blk.Control == nil || len(blk.Succs) == 0 || len(blk.TableCases) != len(blk.Succs) {
+				return nil, fmt.Errorf("ssa emit: malformed BrTable block b%d", blk.ID)
+			}
+			selExpr, err := emitExpr(blk.Control)
+			if err != nil {
+				return nil, err
+			}
+			// One switch STATEMENT, not an if-chain: the Go compiler
+			// lowers dense integer switches to jump tables (O(1)
+			// dispatch) but never recovers a switch from a cascade of
+			// ifs. Each clause carries the per-edge phi assigns and a
+			// goto, exactly like an If arm. The default clause also
+			// absorbs any TableCases values routed to the same block
+			// as the wasm default label — they need no explicit case
+			// literals because default reaches the same target.
+			swBody := &ast.BlockStmt{}
+			for si, e := range blk.Succs {
+				clauseBody := &ast.BlockStmt{}
+				if err := emitPhiAssignsFor(clauseBody, blk, e.Block, e.Index, emitExpr, stagedPhi); err != nil {
+					return nil, err
+				}
+				clauseBody.List = append(clauseBody.List, &ast.BranchStmt{
+					Tok:   token.GOTO,
+					Label: newID(labelForBlock(e.Block)),
+				})
+				var caseExprs []ast.Expr
+				if si != blk.TableDefault {
+					caseExprs = make([]ast.Expr, len(blk.TableCases[si]))
+					for ci, cv := range blk.TableCases[si] {
+						caseExprs[ci] = &ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", cv)}
+					}
+				}
+				swBody.List = append(swBody.List, &ast.CaseClause{
+					List: caseExprs, // nil = default
+					Body: clauseBody.List,
+				})
+			}
+			body.List = append(body.List, &ast.SwitchStmt{Tag: selExpr, Body: swBody})
 		case ssa.BlockRet:
 			nRes := len(f.Sig.Results)
 			if nRes == 0 {

--- a/internal/lower/lower.go
+++ b/internal/lower/lower.go
@@ -789,16 +789,22 @@ func (ls *lowerState) handleBrIf(r *wasm.InstrReader) error {
 // result arity (validated by wasm), so the same top-K stack values are
 // passed as the branch payload regardless of which target is taken.
 //
-// We do not introduce a new SSA block kind for switch dispatch; instead
-// we lower the table to a chain of If blocks of the form
+// Arity-0 tables (no branch payload) lower to a single BlockBrTable —
+// one successor per unique target, selector as Control — which the
+// pure emitter renders as a Go switch statement and asmgen as a
+// binary-search compare tree. This matters: the Go compiler lowers
+// dense switch STATEMENTS to jump tables but never reconstructs a
+// switch from an if-else cascade, so the previous chain-of-Ifs
+// lowering executed O(len(cases)) sequential compares per dispatch
+// (CPython's eval loop: a 255-deep chain, ~127 compares per bytecode).
+//
+// Payload-carrying tables (branch arity > 0) still lower to the chain
+// of If blocks
 //
 //	if sel == 0 { goto cases[0] } else if sel == 1 { goto cases[1] }
 //	... else { goto default }
 //
-// which the goto-based SSA emitter handles natively. The downstream Go
-// compiler is well-equipped to fold such cascades back into a jump
-// table where profitable; the extra blocks are also cheap for the SSA
-// optimization passes because the equality checks are pure.
+// which the goto-based SSA emitter handles natively.
 func (ls *lowerState) handleBrTable(r *wasm.InstrReader) error {
 	cases, err := r.ReadVecU32()
 	if err != nil {
@@ -844,6 +850,49 @@ func (ls *lowerState) handleBrTable(r *wasm.InstrReader) error {
 			return fmt.Errorf("%w: br_table target %d has branch arity %d, default has %d",
 				ErrSSAUnsupported, i, f.branchArity(), wantArity)
 		}
+	}
+
+	// Arity-0 dispatch — the shape a bytecode interpreter's computed
+	// goto compiles to, and the hot path this lowering exists for —
+	// becomes a single BlockBrTable with one edge per UNIQUE target.
+	// The pure emitter turns it into a Go switch (which the Go
+	// compiler lowers to a jump table) and asmgen into a
+	// binary-search compare tree; the old equality-If chain cost
+	// O(len(cases)) sequential compare+branch pairs per dispatch —
+	// measured at a 255-deep chain on CPython's eval loop, ~127
+	// compares per bytecode executed.
+	//
+	// Payload-carrying br_tables (branch arity > 0) keep the If-chain
+	// lowering below: their per-edge stack payload rides the same
+	// recordIncoming machinery, but they are rare and never the hot
+	// dispatch shape.
+	if wantArity == 0 {
+		cur := ls.b.Current()
+		cur.Kind = ssa.BlockBrTable
+		cur.Control = sel
+		succIdx := map[*ssa.Block]int{}
+		addTarget := func(depth uint32) int {
+			frame := ls.ctrl[len(ls.ctrl)-1-int(depth)]
+			if si, ok := succIdx[frame.target]; ok {
+				return si
+			}
+			si := len(cur.Succs)
+			succIdx[frame.target] = si
+			ls.recordIncoming(frame.target, 0)
+			if frame.kind == ctrlLoop {
+				ls.appendLoopBackArgs(frame.target)
+			}
+			ssa.AddEdge(cur, frame.target)
+			cur.TableCases = append(cur.TableCases, nil)
+			return si
+		}
+		for i, depth := range cases {
+			si := addTarget(depth)
+			cur.TableCases[si] = append(cur.TableCases[si], int32(i))
+		}
+		cur.TableDefault = addTarget(defaultDepth)
+		ls.unreachable = true
+		return nil
 	}
 
 	// Emit one If block per case index. The fall-through path of each

--- a/internal/lower/lower_cf_test.go
+++ b/internal/lower/lower_cf_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/goccy/wasm2go/internal/ssa"
 	"github.com/goccy/wasm2go/internal/testfixture"
 	"github.com/goccy/wasm2go/internal/wasm"
 )
@@ -81,5 +82,78 @@ func TestLowerBrTableLoopArity(t *testing.T) {
 	}
 	if _, err := LowerFunction(mod, 0, "f"); err != nil {
 		t.Fatalf("lower br_table-loop-arity func: %v", err)
+	}
+}
+
+// TestLowerBrTableBlockKind pins the arity-0 br_table lowering to a
+// single BlockBrTable: one successor per UNIQUE target, TableCases
+// mapping selector values to successors, and the default index set.
+// The hand-built function reuses TestLowerBrTableLoopArity's shape
+// with a 3-case table where two cases and the default share targets:
+//
+//	br_table [1 1 0] default 0
+//	  case 0, case 1 -> $b (block)   — one succ, cases [0 1]
+//	  case 2, default -> $l (loop)   — one succ, cases [2] + default
+func TestLowerBrTableBlockKind(t *testing.T) {
+	bin := []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+		// type section: (param i32) (result i32)
+		0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+		// function section: func0 : type0
+		0x03, 0x02, 0x01, 0x00,
+		// export section: "f" = func0
+		0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+		// code section
+		0x0a, 0x14, 0x01, // section id, size, func count
+		0x12,       // body size
+		0x00,       // 0 local decls
+		0x02, 0x40, // block (empty blocktype)
+		0x03, 0x7f, // loop (result i32)
+		0x20, 0x00, // local.get 0
+		0x0e, 0x03, 0x01, 0x01, 0x00, 0x00, // br_table [1 1 0] default 0
+		0x0b,       // end loop
+		0x0b,       // end block
+		0x41, 0x00, // i32.const 0
+		0x0b, // end func
+	}
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	f, err := LowerFunction(mod, 0, "f")
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	var bt *ssa.Block
+	for _, b := range f.Blocks {
+		if b.Kind == ssa.BlockBrTable {
+			if bt != nil {
+				t.Fatalf("more than one BlockBrTable")
+			}
+			bt = b
+		}
+	}
+	if bt == nil {
+		t.Fatalf("no BlockBrTable produced; arity-0 br_table should not lower to an If chain:\n%s", ssa.FuncString(f))
+	}
+	if len(bt.Succs) != 2 {
+		t.Fatalf("want 2 deduped successors, got %d:\n%s", len(bt.Succs), ssa.FuncString(f))
+	}
+	if bt.Control == nil || bt.Control.Type != ssa.TypeI32 {
+		t.Fatalf("BrTable control missing or not i32")
+	}
+	// Succ 0 = the block target (cases 0,1); succ 1 = the loop header
+	// (case 2 + default).
+	if got := bt.TableCases[0]; len(got) != 2 || got[0] != 0 || got[1] != 1 {
+		t.Fatalf("succ0 cases = %v, want [0 1]", got)
+	}
+	if got := bt.TableCases[1]; len(got) != 1 || got[0] != 2 {
+		t.Fatalf("succ1 cases = %v, want [2]", got)
+	}
+	if bt.TableDefault != 1 {
+		t.Fatalf("TableDefault = %d, want 1", bt.TableDefault)
+	}
+	if err := ssa.Verify(f); err != nil {
+		t.Fatalf("verify: %v", err)
 	}
 }

--- a/internal/ssa/print.go
+++ b/internal/ssa/print.go
@@ -83,6 +83,24 @@ func FuncString(f *Func) string {
 			b.WriteString("    Ret\n")
 		case BlockUnreachable:
 			b.WriteString("    Unreachable\n")
+		case BlockBrTable:
+			ctrlID := ValueID(0)
+			if blk.Control != nil {
+				ctrlID = blk.Control.ID
+			}
+			fmt.Fprintf(&b, "    BrTable v%d →", ctrlID)
+			for si, e := range blk.Succs {
+				if si == blk.TableDefault {
+					fmt.Fprintf(&b, " b%d(default", e.Block.ID)
+					if len(blk.TableCases[si]) > 0 {
+						fmt.Fprintf(&b, ",%v", blk.TableCases[si])
+					}
+					b.WriteString(")")
+				} else {
+					fmt.Fprintf(&b, " b%d%v", e.Block.ID, blk.TableCases[si])
+				}
+			}
+			b.WriteString("\n")
 		default:
 			fmt.Fprintf(&b, "    %s\n", "<invalid block kind>")
 		}

--- a/internal/ssa/ssa.go
+++ b/internal/ssa/ssa.go
@@ -98,9 +98,19 @@ type Block struct {
 	Preds  []Edge
 	Succs  []Edge
 	Values []*Value // owned values, in dependency order
-	// Control is the value the block branches on (for If kind), the
-	// returned value(s) marker (Ret kind), or nil (Plain).
+	// Control is the value the block branches on (for If and BrTable
+	// kinds), the returned value(s) marker (Ret kind), or nil (Plain).
 	Control *Value
+
+	// TableCases / TableDefault describe a BlockBrTable terminator
+	// (nil / 0 otherwise). TableCases[i] lists the selector values
+	// routed to Succs[i]; every selector value not present in any
+	// list goes to Succs[TableDefault]. Successor blocks are unique
+	// (a wasm br_table routing several indices — or the default — to
+	// one label dedupes into a single edge), which keeps phi-arg
+	// bookkeeping one-arg-per-pred like every other block kind.
+	TableCases   [][]int32
+	TableDefault int
 
 	f *Func
 }
@@ -128,6 +138,14 @@ const (
 	BlockRet
 	// Unreachable: zero successors, traps at runtime.
 	BlockUnreachable
+	// BrTable: one successor per unique branch target of a wasm
+	// br_table. Control is the i32 selector; Block.TableCases /
+	// Block.TableDefault map selector values to successors. Lowered
+	// from arity-0 br_table dispatch (a bytecode interpreter's
+	// computed goto); emitted as a Go switch (pure) or a
+	// binary-search compare tree (asm) instead of the O(n)
+	// equality-If chain used before.
+	BlockBrTable
 )
 
 // AddEdge wires src → dst as a CFG edge, updating both lists. The returned

--- a/internal/ssa/verify.go
+++ b/internal/ssa/verify.go
@@ -77,6 +77,40 @@ func Verify(f *Func) error {
 			}
 		case BlockUnreachable:
 			// no constraint
+		case BlockBrTable:
+			if len(b.Succs) == 0 {
+				return fmt.Errorf("verify %s: BrTable b%d has no successors", f.Name, b.ID)
+			}
+			if b.Control == nil {
+				return fmt.Errorf("verify %s: BrTable b%d has nil Control", f.Name, b.ID)
+			}
+			if b.Control.Type != TypeI32 {
+				return fmt.Errorf("verify %s: BrTable b%d selector v%d has type %v (want i32)",
+					f.Name, b.ID, b.Control.ID, b.Control.Type)
+			}
+			if len(b.TableCases) != len(b.Succs) {
+				return fmt.Errorf("verify %s: BrTable b%d has %d case lists for %d successors",
+					f.Name, b.ID, len(b.TableCases), len(b.Succs))
+			}
+			if b.TableDefault < 0 || b.TableDefault >= len(b.Succs) {
+				return fmt.Errorf("verify %s: BrTable b%d default index %d out of range (%d succs)",
+					f.Name, b.ID, b.TableDefault, len(b.Succs))
+			}
+			seenCase := map[int32]bool{}
+			seenSucc := map[BlockID]bool{}
+			for si, vals := range b.TableCases {
+				if seenSucc[b.Succs[si].Block.ID] {
+					return fmt.Errorf("verify %s: BrTable b%d successor b%d appears twice (targets must be deduped)",
+						f.Name, b.ID, b.Succs[si].Block.ID)
+				}
+				seenSucc[b.Succs[si].Block.ID] = true
+				for _, cv := range vals {
+					if seenCase[cv] {
+						return fmt.Errorf("verify %s: BrTable b%d selector value %d routed twice", f.Name, b.ID, cv)
+					}
+					seenCase[cv] = true
+				}
+			}
 		default:
 			return fmt.Errorf("verify %s: b%d has invalid kind %v", f.Name, b.ID, b.Kind)
 		}

--- a/testdata/cg_brtable64.wat
+++ b/testdata/cg_brtable64.wat
@@ -1,0 +1,283 @@
+(module
+  ;; 64-way arity-0 br_table dispatcher — the computed-goto shape a
+  ;; bytecode interpreter compiles to. Case k returns k*10+7 (odd
+  ;; constants so a mis-routed binary-search tree path is caught by
+  ;; value, not just by reachability); out-of-range returns -1.
+  (func (export "switch64") (param i32) (result i32)
+    (block $d
+      (block $b63
+        (block $b62
+          (block $b61
+            (block $b60
+              (block $b59
+                (block $b58
+                  (block $b57
+                    (block $b56
+                      (block $b55
+                        (block $b54
+                          (block $b53
+                            (block $b52
+                              (block $b51
+                                (block $b50
+                                  (block $b49
+                                    (block $b48
+                                      (block $b47
+                                        (block $b46
+                                          (block $b45
+                                            (block $b44
+                                              (block $b43
+                                                (block $b42
+                                                  (block $b41
+                                                    (block $b40
+                                                      (block $b39
+                                                        (block $b38
+                                                          (block $b37
+                                                            (block $b36
+                                                              (block $b35
+                                                                (block $b34
+                                                                  (block $b33
+                                                                    (block $b32
+                                                                      (block $b31
+                                                                        (block $b30
+                                                                          (block $b29
+                                                                            (block $b28
+                                                                              (block $b27
+                                                                                (block $b26
+                                                                                  (block $b25
+                                                                                    (block $b24
+                                                                                      (block $b23
+                                                                                        (block $b22
+                                                                                          (block $b21
+                                                                                            (block $b20
+                                                                                              (block $b19
+                                                                                                (block $b18
+                                                                                                  (block $b17
+                                                                                                    (block $b16
+                                                                                                      (block $b15
+                                                                                                        (block $b14
+                                                                                                          (block $b13
+                                                                                                            (block $b12
+                                                                                                              (block $b11
+                                                                                                                (block $b10
+                                                                                                                  (block $b9
+                                                                                                                    (block $b8
+                                                                                                                      (block $b7
+                                                                                                                        (block $b6
+                                                                                                                          (block $b5
+                                                                                                                            (block $b4
+                                                                                                                              (block $b3
+                                                                                                                                (block $b2
+                                                                                                                                  (block $b1
+                                                                                                                                    (block $b0
+                                                                                                                                      local.get 0
+                                                                                                                                      br_table 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
+                                                                                                                                    )
+                                                                                                                                    i32.const 7
+                                                                                                                                    return
+                                                                                                                                  )
+                                                                                                                                  i32.const 17
+                                                                                                                                  return
+                                                                                                                                )
+                                                                                                                                i32.const 27
+                                                                                                                                return
+                                                                                                                              )
+                                                                                                                              i32.const 37
+                                                                                                                              return
+                                                                                                                            )
+                                                                                                                            i32.const 47
+                                                                                                                            return
+                                                                                                                          )
+                                                                                                                          i32.const 57
+                                                                                                                          return
+                                                                                                                        )
+                                                                                                                        i32.const 67
+                                                                                                                        return
+                                                                                                                      )
+                                                                                                                      i32.const 77
+                                                                                                                      return
+                                                                                                                    )
+                                                                                                                    i32.const 87
+                                                                                                                    return
+                                                                                                                  )
+                                                                                                                  i32.const 97
+                                                                                                                  return
+                                                                                                                )
+                                                                                                                i32.const 107
+                                                                                                                return
+                                                                                                              )
+                                                                                                              i32.const 117
+                                                                                                              return
+                                                                                                            )
+                                                                                                            i32.const 127
+                                                                                                            return
+                                                                                                          )
+                                                                                                          i32.const 137
+                                                                                                          return
+                                                                                                        )
+                                                                                                        i32.const 147
+                                                                                                        return
+                                                                                                      )
+                                                                                                      i32.const 157
+                                                                                                      return
+                                                                                                    )
+                                                                                                    i32.const 167
+                                                                                                    return
+                                                                                                  )
+                                                                                                  i32.const 177
+                                                                                                  return
+                                                                                                )
+                                                                                                i32.const 187
+                                                                                                return
+                                                                                              )
+                                                                                              i32.const 197
+                                                                                              return
+                                                                                            )
+                                                                                            i32.const 207
+                                                                                            return
+                                                                                          )
+                                                                                          i32.const 217
+                                                                                          return
+                                                                                        )
+                                                                                        i32.const 227
+                                                                                        return
+                                                                                      )
+                                                                                      i32.const 237
+                                                                                      return
+                                                                                    )
+                                                                                    i32.const 247
+                                                                                    return
+                                                                                  )
+                                                                                  i32.const 257
+                                                                                  return
+                                                                                )
+                                                                                i32.const 267
+                                                                                return
+                                                                              )
+                                                                              i32.const 277
+                                                                              return
+                                                                            )
+                                                                            i32.const 287
+                                                                            return
+                                                                          )
+                                                                          i32.const 297
+                                                                          return
+                                                                        )
+                                                                        i32.const 307
+                                                                        return
+                                                                      )
+                                                                      i32.const 317
+                                                                      return
+                                                                    )
+                                                                    i32.const 327
+                                                                    return
+                                                                  )
+                                                                  i32.const 337
+                                                                  return
+                                                                )
+                                                                i32.const 347
+                                                                return
+                                                              )
+                                                              i32.const 357
+                                                              return
+                                                            )
+                                                            i32.const 367
+                                                            return
+                                                          )
+                                                          i32.const 377
+                                                          return
+                                                        )
+                                                        i32.const 387
+                                                        return
+                                                      )
+                                                      i32.const 397
+                                                      return
+                                                    )
+                                                    i32.const 407
+                                                    return
+                                                  )
+                                                  i32.const 417
+                                                  return
+                                                )
+                                                i32.const 427
+                                                return
+                                              )
+                                              i32.const 437
+                                              return
+                                            )
+                                            i32.const 447
+                                            return
+                                          )
+                                          i32.const 457
+                                          return
+                                        )
+                                        i32.const 467
+                                        return
+                                      )
+                                      i32.const 477
+                                      return
+                                    )
+                                    i32.const 487
+                                    return
+                                  )
+                                  i32.const 497
+                                  return
+                                )
+                                i32.const 507
+                                return
+                              )
+                              i32.const 517
+                              return
+                            )
+                            i32.const 527
+                            return
+                          )
+                          i32.const 537
+                          return
+                        )
+                        i32.const 547
+                        return
+                      )
+                      i32.const 557
+                      return
+                    )
+                    i32.const 567
+                    return
+                  )
+                  i32.const 577
+                  return
+                )
+                i32.const 587
+                return
+              )
+              i32.const 597
+              return
+            )
+            i32.const 607
+            return
+          )
+          i32.const 617
+          return
+        )
+        i32.const 627
+        return
+      )
+      i32.const 637
+      return
+    )
+    i32.const -1
+  )
+
+  ;; Payload-carrying br_table (branch arity 1) — pins the If-chain
+  ;; fallback lowering that arity>0 tables keep using.
+  (func (export "pick") (param i32) (result i32)
+    (block $b (result i32)
+      (block $a (result i32)
+        i32.const 111
+        local.get 0
+        br_table 0 1 0
+      )
+      i32.const 1000
+      i32.add
+    )
+  )
+)


### PR DESCRIPTION
Makes `br_table` a first-class SSA terminator and emits it as an O(1)
Go switch (pure) / O(log n) binary-search tree (asm) instead of an
O(n) equality-If chain. P3 of the perf work (P1 = #13, P2 = #14).

## The problem

Arity-0 `br_table` — the shape a bytecode interpreter's computed
goto compiles to — lowered to a chain of `if sel == k` blocks, on
the recorded assumption that the Go compiler would fold the cascade
back into a jump table. It does not: gc lowers dense integer
`switch` STATEMENTS to jump tables but never reconstructs a switch
from an if-else chain.

Measured cost on go-python: CPython's eval loop (`p0.Fn3247`)
dispatches every bytecode through a **255-deep chain** (~127
sequential compare+branch per bytecode), and the pure-mode CPU
profile puts **79% (fib) / 50% (loop-sum) of total flat time inside
that one function**.

## The change

- **ssa**: new `BlockBrTable` kind — one successor per *unique*
  target (cases sharing a label dedupe into one edge, keeping phi
  bookkeeping one-arg-per-pred), selector as `Control`,
  `TableCases`/`TableDefault` map selector values to successors.
  Verify/print support; existing passes needed zero changes.
- **lower**: arity-0 tables → `BlockBrTable`; payload-carrying
  tables (arity > 0, rare, never the hot dispatch) keep the chain.
- **codegen (pure)**: the goto emitter renders it as ONE `switch`
  statement — case clauses carry the per-edge phi assigns + goto,
  the default clause absorbs values sharing the default target. gc
  emits a jump table: O(1) dispatch.
- **asmgen (amd64 + arm64)**: binary-search compare tree over the
  sorted case values (~8 compares for a 256-way table vs ~127).
  Signed compares are sound: case values are non-negative table
  indices, so a selector ≥ 2^31 walks off the tree into the
  default — exactly wasm's out-of-range rule.

## Results

All A/B pairs are alternating runs at n=12 vs bundles regenerated
from current main (P1+P2), idle machine, all p=0.000 unless noted.

**go-python (CPython via pythonwasm2go) — the dispatch-bound consumer:**

| workload | mode/arch | main | this PR | Δ |
|---|---|---:|---:|---|
| fib(28) | pure/arm64 | 189.8ms | 44.0ms | **−76.8%** |
| loop-sum | pure/arm64 | 33.9ms | 16.3ms | **−51.9%** |
| startup | pure/arm64 | 6.27ms | 5.66ms | **−9.7%** |
| fib(28) | pure/amd64 | 284.2ms | 56.3ms | **−80.2%** |
| loop-sum | pure/amd64 | 47.1ms | 22.3ms | **−52.7%** |
| fib(28) | asm/arm64 | 568.1ms | 284.3ms | **−50.0%** |
| loop-sum | asm/arm64 | 120.1ms | 84.2ms | **−29.8%** |

Context: fib(28) pure/arm64 has gone 579ms → 44ms (**13.2×**) across
P1+P3; go-python is now ~3.5× FASTER than gpython on this workload
(it was 3.77× slower three PRs ago).

**googlesqlite window suite (asm/amd64)**: geomean +0.14% — flat, as
expected: SQL execution is not br_table-dispatch-bound (four of five
queries p>0.2; rank_dense_rank +0.71% p=.026, inside the suite's
documented ~2% noise floor).

## Verification

All exit 0, judged by exit code only:

- wasm2go `go test ./...` on host amd64 AND `GOARCH=arm64`;
  `make lint` 0 issues.
- googlesqlite, bundles regenerated from this branch: full
  `go test -race ./...` on amd64 AND native arm64 (asm mode), plus
  the full pure-mode suite (`-tags purego`).
- go-python: asm 4-config matrix (amd64/arm64 × race on/off) AND
  pure-mode suites on amd64 + arm64.
- Emitted-shape spot check on the regenerated python bundle:
  CPython's eval loop went from a 255-deep `if v328 == k` chain to
  switch statements (257 case clauses; longest remaining equality
  run: 4).

New tests: lowering pin (dedup / TableCases / default on a
shared-target table), pure switch pin, 64-way fixture
(`testdata/cg_brtable64.wat`) diffed against wazero for every
selector 0..70 + payload fallback (pure), the emitted amd64 tree
executed across split paths / extremes / out-of-range / payload
fallback, and log-shape pins for both arch trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
