### PR TITLE
ssa/pass: fold width conversions of constants; guard amd64 extends

### DIFF
--- a/internal/asmgen/emit_archs.go
+++ b/internal/asmgen/emit_archs.go
@@ -548,10 +548,23 @@ func emitValueAMD64(b *strings.Builder, v *ssa.Value, plan *funcPlan, frame argF
 
 	// --- Integer extensions / truncation ---
 	case ssa.OpExtend32To64S:
+		// MOVLQSX rejects immediate sources; a constant arg (possible
+		// whenever a pass substitutes constants without a ConstProp
+		// re-run) is extended at generation time instead.
+		if c, ok := inlineableI32(v.Args[0]); ok {
+			fmt.Fprintf(b, "\tMOVQ $%d, AX\n", int64(c))
+			fmt.Fprintf(b, "\tMOVQ AX, %d(SP)\n", plan.offsets[v.ID])
+			return nil
+		}
 		fmt.Fprintf(b, "\tMOVLQSX %s, AX\n", operandSrc32(v.Args[0], plan, frame, "SP"))
 		fmt.Fprintf(b, "\tMOVQ AX, %d(SP)\n", plan.offsets[v.ID])
 		return nil
 	case ssa.OpExtend32To64U:
+		if c, ok := inlineableI32(v.Args[0]); ok {
+			fmt.Fprintf(b, "\tMOVQ $%d, AX\n", int64(uint32(c)))
+			fmt.Fprintf(b, "\tMOVQ AX, %d(SP)\n", plan.offsets[v.ID])
+			return nil
+		}
 		fmt.Fprintf(b, "\tMOVL %s, AX\n", operandSrc32(v.Args[0], plan, frame, "SP"))
 		// MOVL into a 64-bit register zero-extends on amd64.
 		fmt.Fprintf(b, "\tMOVQ AX, %d(SP)\n", plan.offsets[v.ID])

--- a/internal/ssa/pass/constprop.go
+++ b/internal/ssa/pass/constprop.go
@@ -34,6 +34,37 @@ func ConstProp(f *ssa.Func) bool {
 // foldValue rewrites v in place if both of its arguments are known
 // integer constants. Returns true on change.
 func foldValue(v *ssa.Value) bool {
+	// Unary width conversions of a constant. These shapes rarely
+	// survive the wasm frontend on their own, but cross-function
+	// inlining (and any future pass that substitutes constants into
+	// cloned bodies) exposes them — and the amd64 emitter relies on
+	// extend operands never being immediates (`MOVLQSX $-1, AX` is
+	// not encodable), so folding here is a correctness backstop as
+	// well as an optimization.
+	if len(v.Args) == 1 && v.Args[0] != nil {
+		if c, ok := intConst(v.Args[0]); ok {
+			switch v.Op {
+			case ssa.OpExtend32To64S:
+				v.Op = ssa.OpConst64
+				v.Type = ssa.TypeI64
+				v.AuxInt = int64(int32(c))
+			case ssa.OpExtend32To64U:
+				v.Op = ssa.OpConst64
+				v.Type = ssa.TypeI64
+				v.AuxInt = int64(uint32(c))
+			case ssa.OpTrunc64To32:
+				v.Op = ssa.OpConst32
+				v.Type = ssa.TypeI32
+				v.AuxInt = int64(int32(c))
+			default:
+				return false
+			}
+			v.Args = nil
+			v.Aux = nil
+			return true
+		}
+		return false
+	}
 	if len(v.Args) != 2 {
 		return false
 	}

--- a/internal/ssa/pass/constprop_test.go
+++ b/internal/ssa/pass/constprop_test.go
@@ -80,3 +80,58 @@ func TestConstPropLeavesUnknownAlone(t *testing.T) {
 		t.Errorf("OpAdd32 disappeared:\n%s", dump)
 	}
 }
+
+// TestConstPropFoldsWidthConversions pins the unary folds: extends
+// and truncations of integer constants become constants. The shapes
+// rarely survive the wasm frontend alone but appear as soon as any
+// pass substitutes a constant into an existing expression — and the
+// amd64 emitter cannot encode `MOVLQSX $imm, reg`, so the fold
+// doubles as a correctness backstop.
+func TestConstPropFoldsWidthConversions(t *testing.T) {
+	cases := []struct {
+		op   ssa.Op
+		in   int64
+		out  int64
+		outT ssa.Type
+	}{
+		{ssa.OpExtend32To64S, -1, -1, ssa.TypeI64},
+		{ssa.OpExtend32To64S, 0x7FFFFFFF, 0x7FFFFFFF, ssa.TypeI64},
+		{ssa.OpExtend32To64U, -1, 0xFFFFFFFF, ssa.TypeI64},
+		{ssa.OpTrunc64To32, 0x1_0000_0005, 5, ssa.TypeI32},
+		{ssa.OpTrunc64To32, -1, -1, ssa.TypeI32},
+	}
+	for _, tc := range cases {
+		bb := ssa.NewFuncBuilder("f", ssa.FuncSig{Results: []ssa.Type{tc.outT}})
+		b0 := bb.NewBlock(ssa.BlockRet)
+		bb.SetEntry(b0)
+		bb.SetCurrent(b0)
+		var c *ssa.Value
+		if tc.op == ssa.OpTrunc64To32 {
+			c = bb.Const64(tc.in)
+		} else {
+			c = bb.Const32(int32(tc.in))
+		}
+		conv := bb.NewValue(tc.op, tc.outT, c)
+		bb.FinishRet(conv)
+		f := bb.Func()
+		if !ConstProp(f) {
+			t.Errorf("%v(%d): no fold", tc.op, tc.in)
+			continue
+		}
+		if conv.Op != ssa.OpConst32 && conv.Op != ssa.OpConst64 {
+			t.Errorf("%v(%d): folded to %v, want a constant", tc.op, tc.in, conv.Op)
+			continue
+		}
+		got := conv.AuxInt
+		if conv.Op == ssa.OpConst32 {
+			got = int64(int32(got))
+		}
+		want := tc.out
+		if tc.outT == ssa.TypeI32 {
+			want = int64(int32(want))
+		}
+		if got != want {
+			t.Errorf("%v(%d) = %d, want %d", tc.op, tc.in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
ConstProp only folded two-operand integer ops, so a unary width
conversion whose argument is a constant — OpExtend32To64S/U,
OpTrunc64To32 — survived to emission. The shape rarely comes out of
the wasm frontend by itself, but any pass that substitutes constants
into existing expressions exposes it; a cross-function inlining
prototype did exactly that and produced

  asm: invalid instruction: MOVLQSX $-1, AX

because the amd64 emitter spells extend operands via operandSrc32,
which inlines OpConst32 as an immediate, and the sign/zero-extending
MOV forms cannot encode immediate sources (the assembler rejects the
file; not a silent miscompile).

Two independent layers:

  - ConstProp folds the three conversions of integer constants
    (sign-extend, zero-extend, truncate), evaluated at generation
    time with the same width rules the runtime ops use.
  - The amd64 OpExtend32To64S/U emitters materialize a constant arg
    via `MOVQ $imm, AX` directly, so the invariant "extend sources
    are never immediates" no longer depends on which passes ran
    before emission. (OpTrunc64To32 already lowers to MOVL, which
    accepts immediates.)

Regenerated bundles are byte-identical for the current consumers
(python.wasm checked) — no shape in today's inputs triggers the fold,
so this is a robustness fix with zero output churn.

Verification (exit 0): go test ./... on host amd64 AND GOARCH=arm64;
make lint; new unit test TestConstPropFoldsWidthConversions covering
sign/zero-extend of negative and INT32_MAX values and truncation of
above-2^32 and negative values.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)