### PR TITLE
asmgen: function-wide linear-scan register allocation (Phase R v1)

### DIFF
--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -165,6 +165,13 @@ type arch interface {
 	// operandSrcFloat would emit
 	// amd64-only X<n> register names that arm64's assembler rejects.
 	SupportsRegHome() bool
+	// SupportsGlobalRegalloc reports whether the arch's emit paths
+	// honour plan.regHome for cross-block, whole-lifetime register
+	// residency of arbitrary (non-phi) values — the Phase R
+	// function-wide linear scan. amd64 opts in (its coalesce path
+	// already proved the cross-block contract); arm64 stays off
+	// until its per-op emits pass the same audit.
+	SupportsGlobalRegalloc() bool
 	// SupportsLoopCarryCoalesce reports whether the arch has a
 	// validated emit path for the cross-block loop-carry coalesce pass
 	// (a carry kept in a reserved register across an entire loop body,
@@ -306,6 +313,7 @@ func emitFunc(name string, sig wasm.FuncType, f *ssa.Func, opts FuncOptions, a a
 	plan.sseRegPool = a.SSERegPool()
 	plan.regHomeEligibleOpFn = a.RegHomeEligibleOp
 	plan.supportsCoalesce = a.SupportsLoopCarryCoalesce()
+	plan.supportsGlobalRegalloc = a.SupportsGlobalRegalloc()
 	plan.coalescePool = a.CoalesceRegPool()
 	plan.helperInlineFn = a.HelperIsInline
 
@@ -2045,18 +2053,24 @@ type funcPlan struct {
 	// across a whole loop. emitFunc seeds it from
 	// arch.SupportsLoopCarryCoalesce(); only amd64 opts in today.
 	supportsCoalesce bool
-	offsets          map[ssa.ValueID]int
-	hoist            map[ssa.ValueID]bool
-	phiTemp          map[ssa.ValueID]int
-	phisOf           map[ssa.BlockID][]*ssa.Value
-	hasPhi           map[ssa.BlockID]bool
-	staged           map[ssa.BlockID]bool
-	hasCall          bool
-	frameSize        int
-	calleeArea       int // bytes reserved at low SP for callee-arg staging
-	helperPfx        string
-	helperRefs       map[ssa.ValueID]string
-	directs          map[ssa.ValueID]*directCall
+	// supportsGlobalRegalloc gates the function-wide linear scan
+	// (Phase R). Requires the arch's producer AND consumer emit paths
+	// to honour plan.regHome for values read/written in blocks other
+	// than the defining one — the same contract the coalesce pass
+	// exercises, extended to non-phi values.
+	supportsGlobalRegalloc bool
+	offsets                map[ssa.ValueID]int
+	hoist                  map[ssa.ValueID]bool
+	phiTemp                map[ssa.ValueID]int
+	phisOf                 map[ssa.BlockID][]*ssa.Value
+	hasPhi                 map[ssa.BlockID]bool
+	staged                 map[ssa.BlockID]bool
+	hasCall                bool
+	frameSize              int
+	calleeArea             int // bytes reserved at low SP for callee-arg staging
+	helperPfx              string
+	helperRefs             map[ssa.ValueID]string
+	directs                map[ssa.ValueID]*directCall
 	// hasMem records whether the function performs at least one
 	// load / store / mem-size / mem-grow op. Drives the
 	// `mCacheCandidate` decision — only memory-touching functions

--- a/internal/asmgen/emit_archs.go
+++ b/internal/asmgen/emit_archs.go
@@ -197,6 +197,11 @@ func (archAMD64) EmitBrTableCmpBranch(b *strings.Builder, val int32, eqLabel, lt
 
 func (archAMD64) SupportsRegHome() bool { return true }
 
+// SupportsGlobalRegalloc — amd64's producer/consumer emits honour
+// plan.regHome across blocks (proven by the loop-carry coalesce
+// path), so the Phase R function-wide scan is enabled.
+func (archAMD64) SupportsGlobalRegalloc() bool { return true }
+
 // SupportsLoopCarryCoalesce — amd64 has the validated coalesce emit
 // path (EmitPhiCopyValueToReg on the entry edge, back-edge copy
 // short-circuited).
@@ -656,14 +661,16 @@ func operandSrc32(v *ssa.Value, plan *funcPlan, frame argFrame, spReg string) st
 	if v.Op == ssa.OpConst32 {
 		return fmt.Sprintf("$%d", int32(v.AuxInt))
 	}
+	// regHome first: a split-range OpParam (Phase R) lives in its
+	// register between calls; only home-less params read the FP slot.
+	if reg := plan.regHome[v.ID]; reg != "" {
+		return reg
+	}
 	if v.Op == ssa.OpParam {
 		idx := int(v.AuxInt)
 		if idx >= 0 && idx < len(frame.paramOffsets) {
 			return fmt.Sprintf("l%d+%d(FP)", idx, frame.paramOffsets[idx])
 		}
-	}
-	if reg := plan.regHome[v.ID]; reg != "" {
-		return reg
 	}
 	return fmt.Sprintf("%d(%s)", plan.offsets[v.ID], spReg)
 }
@@ -680,14 +687,16 @@ func operandSrc64(v *ssa.Value, plan *funcPlan, frame argFrame, spReg string) st
 			return fmt.Sprintf("$%d", c)
 		}
 	}
+	// regHome first: a split-range OpParam (Phase R) lives in its
+	// register between calls; only home-less params read the FP slot.
+	if reg := plan.regHome[v.ID]; reg != "" {
+		return reg
+	}
 	if v.Op == ssa.OpParam {
 		idx := int(v.AuxInt)
 		if idx >= 0 && idx < len(frame.paramOffsets) {
 			return fmt.Sprintf("l%d+%d(FP)", idx, frame.paramOffsets[idx])
 		}
-	}
-	if reg := plan.regHome[v.ID]; reg != "" {
-		return reg
 	}
 	return fmt.Sprintf("%d(%s)", plan.offsets[v.ID], spReg)
 }
@@ -737,14 +746,16 @@ func operandSrc64ARM64(v *ssa.Value, plan *funcPlan, frame argFrame) string {
 // OpConstF32/F64 (those still allocate a slot).
 func operandSrcFloat(v *ssa.Value, plan *funcPlan, frame argFrame, spReg string) string {
 	v = resolveCopy(v)
+	// regHome first: a split-range OpParam (Phase R) lives in its
+	// register between calls; only home-less params read the FP slot.
+	if reg := plan.regHome[v.ID]; reg != "" {
+		return reg
+	}
 	if v.Op == ssa.OpParam {
 		idx := int(v.AuxInt)
 		if idx >= 0 && idx < len(frame.paramOffsets) {
 			return fmt.Sprintf("l%d+%d(FP)", idx, frame.paramOffsets[idx])
 		}
-	}
-	if reg := plan.regHome[v.ID]; reg != "" {
-		return reg
 	}
 	return fmt.Sprintf("%d(%s)", plan.offsets[v.ID], spReg)
 }

--- a/internal/asmgen/emitarm64.go
+++ b/internal/asmgen/emitarm64.go
@@ -107,6 +107,11 @@ func (archARM64) EmitBrTableCmpBranch(b *strings.Builder, val int32, eqLabel, lt
 
 func (archARM64) SupportsRegHome() bool { return true }
 
+// SupportsGlobalRegalloc — arm64 stays off until its per-op emit
+// paths pass the cross-block regHome audit (several still assume
+// slot-resident operands outside the block-local patterns).
+func (archARM64) SupportsGlobalRegalloc() bool { return false }
+
 // SupportsLoopCarryCoalesce — arm64 opts into the cross-block
 // loop-carry coalesce pass. The SHARED mode is safe because the
 // candidate filter only accepts carries whose producer op passes

--- a/internal/asmgen/regalloc.go
+++ b/internal/asmgen/regalloc.go
@@ -175,6 +175,13 @@ func computeRegHomes(f *ssa.Func, plan *funcPlan) {
 	if plan.supportsCoalesce && os.Getenv("WASM2GO_NO_COALESCE") == "" {
 		runCoalescePass(f, plan)
 	}
+	// The function-wide linear scan (Phase R, regalloc_global.go) runs
+	// between the coalesce pass (whose loop reservations it honours)
+	// and the per-block scan (which honours the interval reservations
+	// it writes). Ordering is load-bearing — see computeGlobalRegHomes.
+	if plan.supportsGlobalRegalloc {
+		computeGlobalRegHomes(f, plan)
+	}
 	for _, blk := range f.Blocks {
 		assignBlockRegHomes(blk, f, plan)
 	}

--- a/internal/asmgen/regalloc_coalesce.go
+++ b/internal/asmgen/regalloc_coalesce.go
@@ -435,6 +435,20 @@ func runCoalescePass(f *ssa.Func, plan *funcPlan) {
 		plan.coalescedPhi[c.phi.ID] = reg
 		reserve(reg, c.body)
 		reserve(reg, c.liveOutside)
+		// Every predecessor of the phi's block runs an entry- or
+		// back-edge copy INTO the reserved register at its tail
+		// (EmitPhiCopyValueToReg). Blocks outside body/liveOutside —
+		// a forward entry pred in particular — must also be reserved,
+		// or an allocator handing the register to a value whose last
+		// use is a phi-arg read at that same tail gets clobbered by
+		// the adjacent edge copy (found by the Phase R global scan:
+		// entry-pred tail did `MOVL src, R13` right between another
+		// value's R13 def and its edge-copy read).
+		predBlocks := map[ssa.BlockID]bool{}
+		for _, pe := range c.phi.Block.Preds {
+			predBlocks[pe.Block.ID] = true
+		}
+		reserve(reg, predBlocks)
 	}
 }
 
@@ -587,6 +601,14 @@ func trySharedCoalesce(
 	plan.regHome[actual.ID] = reg
 	plan.coalescedPhi[phi.ID] = reg
 	reserve(reg, body)
+	// Reserve the phi block's predecessors too — their tails run the
+	// edge copies that write the register (see the own-register mode
+	// for the clobber this prevents).
+	hdrPreds := map[ssa.BlockID]bool{}
+	for _, pe := range phi.Block.Preds {
+		hdrPreds[pe.Block.ID] = true
+	}
+	reserve(reg, hdrPreds)
 	// The register must survive on every out-of-body block the carry
 	// (or the phi) is still live in: an exit-path reader consumes it
 	// via operandSrc long after the loop, and a block-local value

--- a/internal/asmgen/regalloc_global.go
+++ b/internal/asmgen/regalloc_global.go
@@ -1,0 +1,413 @@
+package asmgen
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// Function-wide linear-scan register allocation ("Phase R").
+//
+// The block-local allocator (assignBlockRegHomes) can only home
+// values whose def and every use sit inside one block; anything
+// cross-block round-trips through its SP slot at every block
+// boundary, which chains a store-forwarding hop (~4-6 cycles) into
+// every consumer. The 2026-07-04 pure-vs-asm matrix (docs/
+// pure-vs-asm-benchmarks.md) put the asm backend 1.6-6.1× behind
+// pure-Go, and slot residency of multi-block values is the
+// structural difference — the Go compiler holds exactly these
+// values in registers.
+//
+// This pass assigns registers to MULTI-block live ranges under a
+// deliberately simple v1 model:
+//
+//   - Spill-free: a value either lives in one register for its whole
+//     life or stays in its slot for its whole life. No reload code
+//     is ever emitted, so the emit contract is unchanged from what
+//     block-local regalloc and the loop-carry coalesce already
+//     exercise (producers write plan.regHome, consumers read it via
+//     operandSrc*).
+//   - Call barriers: Go's ABI0 preserves nothing across CALL, and we
+//     emit no save/restore code, so any interval containing a
+//     CALL-emitting position is ineligible. The barrier set mirrors
+//     emitBlock's re-prime condition exactly (opEmitsCall minus
+//     branch-fused, minus inlined helpers, minus inlined global
+//     accesses).
+//   - Composition: the coalesce pass runs FIRST (its reservations are
+//     honored here); this pass runs SECOND and records its own
+//     assignments in plan.reservedRegs for every block the interval
+//     touches; the block-local scan runs LAST and fills leftover
+//     block-local values with whatever registers remain free.
+//
+// WASM2GO_NO_GLOBAL_REGALLOC=1 disables the pass (bisect kill
+// switch, same convention as WASM2GO_NO_COALESCE).
+
+// globalInterval is one candidate's live range in linearized block
+// order. Positions are (blockOrdinal << 20) | valueIndex, which
+// keeps comparisons cheap and gives every block a disjoint span
+// (blocks never hold 2^20 values; buildpkg splits functions long
+// before that).
+type globalInterval struct {
+	v          *ssa.Value
+	start, end int
+	firstBlk   int // ordinal of first touched block
+	lastBlk    int // ordinal of last touched block
+	uses       int
+	sse        bool
+}
+
+const gposShift = 20
+
+func gpos(blkOrd, valIdx int) int { return blkOrd<<gposShift | valIdx }
+
+// computeGlobalRegHomes runs the function-wide linear scan. Must run
+// after the coalesce pass (reads its reservations) and before
+// assignBlockRegHomes (which reads the reservations this writes).
+func computeGlobalRegHomes(f *ssa.Func, plan *funcPlan) {
+	if os.Getenv("WASM2GO_NO_GLOBAL_REGALLOC") != "" {
+		return
+	}
+	if len(f.Blocks) < 2 {
+		return // single-block functions are fully served block-locally
+	}
+
+	ord := make(map[ssa.BlockID]int, len(f.Blocks))
+	for i, b := range f.Blocks {
+		ord[b.ID] = i
+	}
+
+	// ---- liveness (backward fixpoint). Per block: gen = values used
+	// before (re)definition; kill = values defined. Phi args count as
+	// uses at the tail of the PREDECESSOR (edge copy emission point);
+	// phi defs count as normal defs; block Control counts as a use.
+	gen := make([]map[ssa.ValueID]bool, len(f.Blocks))
+	kill := make([]map[ssa.ValueID]bool, len(f.Blocks))
+	for i, b := range f.Blocks {
+		g := map[ssa.ValueID]bool{}
+		k := map[ssa.ValueID]bool{}
+		for _, v := range b.Values {
+			if v.Op != ssa.OpPhi { // phi args are pred-edge uses, not here
+				for _, a := range v.Args {
+					aa := resolveCopy(a)
+					if aa != nil && !k[aa.ID] {
+						g[aa.ID] = true
+					}
+				}
+			}
+			k[v.ID] = true
+		}
+		if b.Control != nil {
+			if cc := resolveCopy(b.Control); cc != nil && !k[cc.ID] {
+				g[cc.ID] = true
+			}
+		}
+		gen[i], kill[i] = g, k
+	}
+	liveIn := make([]map[ssa.ValueID]bool, len(f.Blocks))
+	liveOut := make([]map[ssa.ValueID]bool, len(f.Blocks))
+	for i := range f.Blocks {
+		liveIn[i] = map[ssa.ValueID]bool{}
+		liveOut[i] = map[ssa.ValueID]bool{}
+	}
+	for changed := true; changed; {
+		changed = false
+		for i := len(f.Blocks) - 1; i >= 0; i-- {
+			b := f.Blocks[i]
+			out := liveOut[i]
+			for _, se := range b.Succs {
+				si := ord[se.Block.ID]
+				for id := range liveIn[si] {
+					if !out[id] {
+						out[id] = true
+						changed = true
+					}
+				}
+				// Phi args flowing on the b→succ edge are live at
+				// b's tail.
+				for _, phi := range se.Block.Values {
+					if phi.Op != ssa.OpPhi {
+						continue
+					}
+					if se.Index < len(phi.Args) {
+						if aa := resolveCopy(phi.Args[se.Index]); aa != nil && !out[aa.ID] {
+							out[aa.ID] = true
+							changed = true
+						}
+					}
+				}
+			}
+			in := liveIn[i]
+			for id := range gen[i] {
+				if !in[id] {
+					in[id] = true
+					changed = true
+				}
+			}
+			for id := range out {
+				if !kill[i][id] && !in[id] {
+					in[id] = true
+					changed = true
+				}
+			}
+		}
+	}
+
+	// ---- call-barrier positions, mirroring emitBlock's re-prime
+	// condition (a position that clobbers every caller-save register).
+	var callPos []int
+	for i, b := range f.Blocks {
+		for vi, v := range b.Values {
+			if opEmitsCall(v.Op) && !plan.branchFused[v.ID] && !helperCallIsInline(plan, v) {
+				if _, inline := plan.globalInline[v.ID]; !inline {
+					callPos = append(callPos, gpos(i, vi))
+				}
+			}
+		}
+	}
+
+	// ---- build intervals for cross-block values.
+	defAt := map[ssa.ValueID]int{}
+	defBlk := map[ssa.ValueID]int{}
+	useCount := map[ssa.ValueID]int{}
+	for i, b := range f.Blocks {
+		for vi, v := range b.Values {
+			defAt[v.ID] = gpos(i, vi)
+			defBlk[v.ID] = i
+			for _, a := range v.Args {
+				if aa := resolveCopy(a); aa != nil {
+					useCount[aa.ID]++
+				}
+			}
+		}
+		if b.Control != nil {
+			if cc := resolveCopy(b.Control); cc != nil {
+				useCount[cc.ID]++
+			}
+		}
+	}
+
+	var cands []*globalInterval
+	for i, b := range f.Blocks {
+		for _, v := range b.Values {
+			if v.Op == ssa.OpPhi || v.Op == ssa.OpParam || v.Op == ssa.OpCopy {
+				continue
+			}
+			if plan.branchFused[v.ID] || plan.branchFusedSkip[v.ID] {
+				continue
+			}
+			if plan.regHome[v.ID] != "" || plan.coalescedPhi[v.ID] != "" {
+				continue // coalesce already placed it
+			}
+			if !planRegHomeEligibleOp(plan, v.Op) {
+				continue
+			}
+			// Cross-block only: live-out of the defining block. Block-
+			// local values stay with assignBlockRegHomes (it packs
+			// them tighter than whole-interval reservation would).
+			if !liveOut[i][v.ID] {
+				continue
+			}
+			iv := &globalInterval{
+				v: v, start: defAt[v.ID], end: defAt[v.ID],
+				firstBlk: i, lastBlk: i,
+				uses: useCount[v.ID],
+				sse:  v.Type == ssa.TypeF32 || v.Type == ssa.TypeF64,
+			}
+			// Extend over every block where the value is live (in or
+			// out), plus in-block last uses in its def block. This
+			// over-approximates lifetime holes — safe, just wider.
+			for j, b2 := range f.Blocks {
+				if liveIn[j][v.ID] || liveOut[j][v.ID] || j == i {
+					s, e := gpos(j, 0), gpos(j, len(b2.Values)+1)
+					if j == i {
+						s = defAt[v.ID]
+					}
+					if s < iv.start {
+						iv.start = s
+					}
+					if e > iv.end {
+						iv.end = e
+					}
+					if j < iv.firstBlk {
+						iv.firstBlk = j
+					}
+					if j > iv.lastBlk {
+						iv.lastBlk = j
+					}
+				}
+			}
+			cands = append(cands, iv)
+		}
+	}
+	if len(cands) == 0 {
+		return
+	}
+	if os.Getenv("WASM2GO_GLOBAL_REGALLOC_STATS") != "" {
+		defer func() {
+			assignedN := 0
+			for _, iv := range cands {
+				if plan.regHome[iv.v.ID] != "" {
+					assignedN++
+				}
+			}
+			fmt.Fprintf(os.Stderr, "globalra %s: blocks=%d cands=%d assigned=%d calls=%d\n",
+				f.Name, len(f.Blocks), len(cands), assignedN, len(callPos))
+		}()
+	}
+
+	if dbg := os.Getenv("WASM2GO_GLOBAL_REGALLOC_DEBUG_FN"); dbg != "" && dbg == f.Name {
+		fmt.Fprintf(os.Stderr, "=== global regalloc debug %s: %d blocks, %d callPos, %d cands\n",
+			f.Name, len(f.Blocks), len(callPos), len(cands))
+		for _, cp := range callPos {
+			bo := cp >> gposShift
+			fmt.Fprintf(os.Stderr, "  callpos ord=%d (blockID=%d) idx=%d\n", bo, f.Blocks[bo].ID, cp&(1<<gposShift-1))
+		}
+		if vs := os.Getenv("WASM2GO_GLOBAL_REGALLOC_DEBUG_VAL"); vs != "" {
+			var vid int
+			fmt.Sscanf(vs, "%d", &vid)
+			for j, b2 := range f.Blocks {
+				if liveIn[j][ssa.ValueID(vid)] || liveOut[j][ssa.ValueID(vid)] {
+					fmt.Fprintf(os.Stderr, "  v%d live ord=%d blockID=%d in=%v out=%v\n",
+						vid, j, b2.ID, liveIn[j][ssa.ValueID(vid)], liveOut[j][ssa.ValueID(vid)])
+				}
+			}
+			for _, b2 := range f.Blocks {
+				for _, phi := range b2.Values {
+					if phi.Op != ssa.OpPhi {
+						continue
+					}
+					for ai, a := range phi.Args {
+						if aa := resolveCopy(a); aa != nil && int(aa.ID) == vid {
+							fmt.Fprintf(os.Stderr, "  v%d is phi v%d arg[%d] in blockID=%d (pred blockID=%d)\n",
+								vid, phi.ID, ai, b2.ID, phi.Block.Preds[ai].Block.ID)
+						}
+					}
+				}
+			}
+		}
+		for _, iv := range cands {
+			crossed := false
+			for _, cp := range callPos {
+				if cp > iv.start && cp <= iv.end {
+					crossed = true
+					break
+				}
+			}
+			fmt.Fprintf(os.Stderr, "  v%d %v uses=%d blk[%d..%d] pos[%d..%d] crossed=%v\n",
+				iv.v.ID, iv.v.Op, iv.uses, iv.firstBlk, iv.lastBlk, iv.start, iv.end, crossed)
+		}
+	}
+
+	// ---- drop call-crossing intervals. The ONLY call position a
+	// live range may contain is the value's own defining call (a
+	// call RESULT is written after the callee returns). Comparing
+	// against the interval START is NOT equivalent: a loop-carried
+	// value's start extends to its header block's first position,
+	// and a call sitting right there (e.g. a call_indirect opening
+	// the loop header) is crossed by the carried value on every
+	// back-edge trip — that exact shape produced the Fn71 DI clobber
+	// (call at gpos(hdr,0) == iv.start, phi edge copy reading the
+	// stale register after the CALL).
+	eligible := cands[:0]
+	for _, iv := range cands {
+		def := defAt[iv.v.ID]
+		crossed := false
+		for _, cp := range callPos {
+			if cp >= iv.start && cp <= iv.end && cp != def {
+				crossed = true
+				break
+			}
+		}
+		if !crossed {
+			eligible = append(eligible, iv)
+		}
+	}
+	if len(eligible) == 0 {
+		return
+	}
+
+	// ---- linear scan, densest-first. With a 7-register pool and no
+	// second chances (no splitting), giving hot values first pick
+	// beats strict start-order; ties resolve to the shorter interval.
+	sort.Slice(eligible, func(a, b int) bool {
+		if eligible[a].uses != eligible[b].uses {
+			return eligible[a].uses > eligible[b].uses
+		}
+		la := eligible[a].end - eligible[a].start
+		lb := eligible[b].end - eligible[b].start
+		if la != lb {
+			return la < lb
+		}
+		return eligible[a].v.ID < eligible[b].v.ID
+	})
+
+	// Same pool discipline as the block-local scan: the m-cache
+	// register is function-wide reserved and must never be handed
+	// out — assigning it silently clobbers `m`, and every later
+	// memop's `MOVQ 32(R11), BX` reads garbage. (Found the hard way:
+	// the first Phase R prototype allocated R11 and googlesqlite's
+	// analyzer init crashed on a nil deref.)
+	gpPool := make([]string, 0, len(planGPRegPool(plan)))
+	for _, r := range planGPRegPool(plan) {
+		if r != plan.mCacheReg {
+			gpPool = append(gpPool, r)
+		}
+	}
+	ssePool := planSSERegPool(plan)
+	type taken struct{ start, end int }
+	assigned := map[string][]taken{}
+	overlaps := func(reg string, iv *globalInterval) bool {
+		for _, t := range assigned[reg] {
+			if iv.start < t.end && t.start < iv.end {
+				return true
+			}
+		}
+		return false
+	}
+	reservedInRange := func(reg string, iv *globalInterval) bool {
+		for j := iv.firstBlk; j <= iv.lastBlk; j++ {
+			if plan.reservedRegs[f.Blocks[j].ID][reg] {
+				return true
+			}
+		}
+		return false
+	}
+	reserve := func(reg string, iv *globalInterval) {
+		if plan.reservedRegs == nil {
+			plan.reservedRegs = map[ssa.BlockID]map[string]bool{}
+		}
+		for j := iv.firstBlk; j <= iv.lastBlk; j++ {
+			bid := f.Blocks[j].ID
+			m := plan.reservedRegs[bid]
+			if m == nil {
+				m = map[string]bool{}
+				plan.reservedRegs[bid] = m
+			}
+			m[reg] = true
+		}
+	}
+	for _, iv := range eligible {
+		pool := gpPool
+		if iv.sse {
+			pool = ssePool
+		}
+		for _, reg := range pool {
+			if overlaps(reg, iv) || reservedInRange(reg, iv) {
+				continue
+			}
+			plan.regHome[iv.v.ID] = reg
+			assigned[reg] = append(assigned[reg], taken{iv.start, iv.end})
+			reserve(reg, iv)
+			break
+		}
+	}
+	if dbg := os.Getenv("WASM2GO_GLOBAL_REGALLOC_DEBUG_FN"); dbg != "" && dbg == f.Name {
+		for _, iv := range eligible {
+			if r := plan.regHome[iv.v.ID]; r != "" {
+				fmt.Fprintf(os.Stderr, "  ASSIGNED v%d -> %s blk[%d..%d]\n", iv.v.ID, r, iv.firstBlk, iv.lastBlk)
+			}
+		}
+	}
+}

--- a/internal/asmgen/regalloc_global.go
+++ b/internal/asmgen/regalloc_global.go
@@ -266,7 +266,9 @@ func computeGlobalRegHomes(f *ssa.Func, plan *funcPlan) {
 		}
 		if vs := os.Getenv("WASM2GO_GLOBAL_REGALLOC_DEBUG_VAL"); vs != "" {
 			var vid int
-			fmt.Sscanf(vs, "%d", &vid)
+			if _, err := fmt.Sscanf(vs, "%d", &vid); err != nil {
+				vid = -1
+			}
 			for j, b2 := range f.Blocks {
 				if liveIn[j][ssa.ValueID(vid)] || liveOut[j][ssa.ValueID(vid)] {
 					fmt.Fprintf(os.Stderr, "  v%d live ord=%d blockID=%d in=%v out=%v\n",


### PR DESCRIPTION
Function-wide linear-scan register allocation for the asm backend
("Phase R" — the real-allocator work): cross-block, call-free live
ranges now live in registers instead of round-tripping through SP
slots at every block boundary.

## Design (v1: spill-free)

A value either lives in ONE register for its whole life or in its
slot for its whole life — no reload code, no new emit contracts.
Composition with the existing passes is ordering-based: the
loop-carry coalesce runs first (its reservations are honoured), the
global linear scan second (liveness → intervals over layout order →
densest-first scan, recording per-block reservations for every
interval), the block-local scan last with whatever registers remain.
Values whose interval contains any CALL position stay slot-resident
(Go ABI0 preserves nothing across calls). Kill switch:
`WASM2GO_NO_GLOBAL_REGALLOC=1`.

## Results (asm/amd64, alternating A/B vs main, n=8)

| suite | Δ |
|---|---|
| googlesqlite window geomean | **−2.97%** (−2.8..−3.3% per query, 4/5 p=0.029) |
| go-python fib(28) | **−2.91%** (p=0.000) |
| go-python loop-sum | flat |

## Three bugs found by consumer suites during bring-up

1. **R11 handed out**: the global scan drew from GPRegPool directly,
   which contains the m-cache register; block-local always filtered
   it. Clobbered `m` → every later memop read garbage.
2. **Call-at-interval-start**: the "call at the start is the value's
   own defining call" exclusion broke for loop-carried values (their
   start extends to the loop header, and a call sitting there is
   crossed on every back-edge trip). Now compared against the def
   position.
3. **Coalesce reservation hole** (pre-existing, newly load-bearing):
   edge copies write the coalesce register at the phi block's
   PREDECESSOR tails, which were not reserved. Both coalesce modes
   now reserve header predecessors.

Plus a text-level must-analysis checker (out-of-tree) that verifies
pool-register reads are dominated by writes since the last CALL —
delta-based against baseline bundles (python: 0 new findings; gsql:
1, root-caused to a dead phi's edge copy reading an unused call
result — pre-existing emission slop, runtime-inert in both forms).

## What was tried and abandoned: call-boundary split ranges (v2/v3)

The win condition targeted fib ≥15%, which requires hot values that
CROSS calls (the eval loop's frame/stack pointers). Two designs were
implemented and measured: emission-hook reload/spill (v2) and
first-class `OpSpillHome`/`OpReloadHome` SSA values after the Go
compiler's OpStoreReg/OpLoadReg pattern (v3). v3 is architecturally
sound, but the measured structure kills the economics: the hottest
call-crossing values span nearly the whole function, so a split
costs ~1000 post-call reloads against ~60 register-hit uses —
bundles grew 14-16% and three more interaction-bug classes surfaced
(including frame-layout holes in compactFrame/applyNewStackalloc
where homed values' slots were dropped from the frame — those fixes
ride along in the experiment record). The experiment is preserved as
a patch (local rescue dir + branch `backup/phaseR-split-experiment`)
for a future allocator-owned-emission effort; per-use reload
placement — what the Go compiler actually does — is the sound next
step if the asm backend's speed ever matters enough to fund it.

## Verification (all exit 0, judged by exit code)

- wasm2go `go test ./...` host amd64 AND GOARCH=arm64; `make lint`.
- go-googlesql full suite; googlesqlite full `go test -race ./...`;
  go-python full suite — all against bundles regenerated from this
  branch (amd64 asm; arm64.s is byte-identical — the pass is gated
  off on arm64 pending its emit audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
