### PR TITLE
codegen: route runtime-index large memory offsets through _consts (arm64 FLDPD fix)

### DIFF
--- a/internal/codegen/emit_memops.go
+++ b/internal/codegen/emit_memops.go
@@ -195,7 +195,21 @@ func (em *ssaEmitter) memOffsetExpr(baseExpr ast.Expr, offset uint64) ast.Expr {
 		// to uintptr.
 		addr := ast.Expr(&ast.CallExpr{Fun: newID("uint32"), Args: []ast.Expr{baseExpr}})
 		if offset != 0 {
-			addr = &ast.BinaryExpr{X: addr, Op: token.ADD, Y: uintLit(offset)}
+			var off ast.Expr = uintLit(offset)
+			// A large static offset added to a runtime index must NOT be
+			// emitted as a bare immediate: the gc ARM64 backend fuses
+			// adjacent f64 loads at a common base into an FLDPD (load-pair)
+			// and bakes the offset into its immediate field, whose range
+			// is tiny — a multi-MB offset then fails to assemble
+			// ("constant is not in pool"). Routing the offset through the
+			// _consts table forces a runtime memory load, so the backend
+			// keeps the offset in a register (register-offset LDR) and no
+			// out-of-range immediate is ever formed. uint32(...) preserves
+			// the wasm unsigned-i32 wrap of the index+offset addition.
+			if offset >= largeConstThreshold && em.t != nil {
+				off = &ast.CallExpr{Fun: newID("uint32"), Args: []ast.Expr{em.constsIndexExpr(offset)}}
+			}
+			addr = &ast.BinaryExpr{X: addr, Op: token.ADD, Y: off}
 		}
 		return addr
 	}

--- a/internal/codegen/emit_memops_test.go
+++ b/internal/codegen/emit_memops_test.go
@@ -317,3 +317,32 @@ func constArgExpr(v *ssa.Value) ast.Expr {
 	}
 	return newID("?")
 }
+
+// TestMemOffsetExpr_RuntimeBaseLargeOffset guards the fix for the gc
+// ARM64 "FLDPD ... constant is not in pool" assembly failure. A large
+// static offset added to a RUNTIME index must be routed through the
+// _consts table (a runtime memory load) rather than emitted as a bare
+// immediate: the ARM64 backend fuses adjacent f64 loads at a common base
+// into a load-pair and bakes the offset into its tiny immediate field,
+// so a multi-MB offset otherwise fails to assemble. Small offsets stay
+// inline. (The constant-base path was already covered; this pins the
+// runtime-base path that regressed arm64 for wasmify's simplelib bundle.)
+func TestMemOffsetExpr_RuntimeBaseLargeOffset(t *testing.T) {
+	em := newSSAEmitter(&translator{})
+
+	large := formatExpr(t, em.memOffsetExpr(newID("v160"), 33571920))
+	if !strings.Contains(large, "_consts[") {
+		t.Errorf("large runtime-base offset must route through _consts, got: %s", large)
+	}
+	if strings.Contains(large, "33571920") {
+		t.Errorf("large offset must not appear as a bare immediate, got: %s", large)
+	}
+
+	small := formatExpr(t, em.memOffsetExpr(newID("v160"), 8))
+	if strings.Contains(small, "_consts") {
+		t.Errorf("small runtime-base offset must stay inline, got: %s", small)
+	}
+	if !strings.Contains(small, "8") {
+		t.Errorf("small offset should be an inline literal, got: %s", small)
+	}
+}


### PR DESCRIPTION
## codegen: route runtime-index large memory offsets through `_consts` (arm64 FLDPD fix)

### Regression

After #19 made the **gcasm** backend dual-arch (replacing `internal/asmgen`),
arm64 stopped building for some inputs — most visibly **wasmify's `simplelib`
bundle** (`runtime=wasm2go`). `buf generate` fails during gcasm's arm64 capture:

```
FLDPD 33571920(R7), (F8, F9): constant is not in pool
```

The generated pure Go simply does not compile for `GOARCH=arm64`.

### Root cause

A memory access `*(*float64)(unsafe.Add(mBase, uint32(idx)+off))` with a large
static `off` and a **runtime** `idx` was emitted with `off` as a bare immediate.
gc's ARM64 backend fuses adjacent f64 loads that share a base register into an
`FLDPD` (load-pair) and bakes the offset into its immediate field, whose range is
tiny — a multi-MB offset then can't be assembled.

`memOffsetExpr` **already** routes large *constant-base* offsets through the
package-level `_consts` table (a runtime load → register-offset `LDR`, never an
out-of-range immediate). The **runtime-base** case was the gap.

Why it surfaced now: pre-#19, arm64 shipped `asmgen`'s own-emitter output, which
lowered addresses directly and never fed this Go through gc's ARM64 backend.
gcasm captures gc's `-S`, so it compiles the pure Go for arm64 — exposing this
latent codegen gap. python/googlesql happen not to hit the fusion; the
float-heavy simplelib does.

### Fix

Extend the `_consts` routing to the runtime-base case:
`uint32(idx) + uint32(_consts[N])`. `uint32(...)` preserves wasm's unsigned-i32
index+offset wrap; the table load keeps the offset in a register so no fused
load-pair immediate is ever formed. One-line-ish change in `memOffsetExpr`.

### Verification (judged by exit code)

- **wasmify** `TestE2EWasm2GoBridge_{SinglePkg,MultiPkg}` → PASS (`buf generate`
  runtime=wasm2go → `GOARCH=arm64` build **and** test ok; `gcasm_arm64.s` present
  with 1242 TEXT symbols — arm64 is **asm**, not a pure fallback).
- `go-python` → PASS on amd64 **and** arm64.
- `go-googlesql` → PASS on amd64 **and** arm64.
- `googlesqlite` → arm64 `-race` PASS (35 ok); amd64 (no `-race`) PASS (35 ok).
  (amd64 `-race` flags a **pre-existing** data race in googlesqlite's own code —
  `sequenceCounters[name]++`, a global map mutated without a lock — unrelated to
  this change.)
- New `TestMemOffsetExpr_RuntimeBaseLargeOffset` pins the runtime-base `_consts`
  routing; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
