### PR TITLE
gcasm: emit bundle files with bare arch names matching own-asm

### DIFF
--- a/internal/gcasm/a64fixture_test.go
+++ b/internal/gcasm/a64fixture_test.go
@@ -186,8 +186,8 @@ func a64FixtureGate(t *testing.T, fixture string) {
 		}
 		runFiles["pkg/"+name] = data
 	}
-	runFiles["pkg/gcasm_arm64.s"] = []byte(asmB.String())
-	runFiles["pkg/gcasm_decls_arm64.go"] = []byte(declB.String())
+	runFiles["pkg/arm64.s"] = []byte(asmB.String())
+	runFiles["pkg/decls_arm64.go"] = []byte(declB.String())
 
 	var driver strings.Builder
 	driver.WriteString("package pkg\n\nimport (\n\t\"math\"\n\t\"testing\"\n)\n\nvar _ = math.Float32bits\n\ntype outcome struct{ val int64; panicked bool }\n\nfunc run(f func() int64) (o outcome) {\n\tdefer func() { if recover() != nil { o.panicked = true } }()\n\to.val = f()\n\treturn\n}\n\nfunc TestA64FG(t *testing.T) {\n")

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -523,8 +523,10 @@ func buildPkg(
 	// arch filenames (amd64.s/arm64.s), which — having no prefix
 	// before the arch — get NO implicit GOARCH constraint from the
 	// name (Go 1.4+ only auto-tags files with a non-empty prefix).
-	// The `&& !purego` half keeps the pure-Go escape hatch working.
-	asmB.WriteString("//go:build " + arch.name + " && !purego\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
+	// This is exactly the header the own-asm backend emitted, and
+	// matches the plain `//go:build <arch>` tag on the decls and
+	// keepalive files below.
+	asmB.WriteString("//go:build " + arch.name + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
 	var declFns strings.Builder
 
 	calleeSig := func(sym string) ([]ArgKind, bool, ArgKind, string, bool) {

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -29,8 +29,8 @@ import (
 // OutputImportPath. Output: a file map to MERGE over the translated
 // tree — it re-tags each pure file to `//go:build !amd64`, drops the
 // own-backend .s/decls files (returning empty content marks deletion:
-// callers skip writing empties), and adds gcasm_amd64.s +
-// gcasm_decls_amd64.go per package.
+// callers skip writing empties), and adds amd64.s +
+// decls_amd64.go per package.
 type BuildStats struct {
 	Transformed int
 	Fallback    int
@@ -311,7 +311,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 				kb.WriteString("\t" + call + "\n")
 			}
 			kb.WriteString("}\n")
-			out[prefix+"gcasm_keepalive_"+spec.name+".go"] = []byte(kb.String())
+			out[prefix+"keepalive_"+spec.name+".go"] = []byte(kb.String())
 		}
 	}
 
@@ -476,7 +476,7 @@ var stdlibWrapperTable = map[string]struct {
 }
 
 // buildPkg transforms one package's functions and renders its bundle
-// files (gcasm_amd64.s, gcasm_decls_amd64.go, retagged pure file).
+// files (amd64.s, decls_amd64.go, retagged pure file).
 // archSpec carries the per-architecture transform and its emission
 // details so buildPkg can produce amd64 and arm64 bundles from one
 // code path.
@@ -519,9 +519,12 @@ func buildPkg(
 	pool := &ConstPool{}
 	types := &TypeTable{}
 	var asmB strings.Builder
-	// The filename pins GOARCH; the constraint keeps the pure-Go
-	// escape hatch (`-tags purego`) working on amd64 too.
-	asmB.WriteString("//go:build !purego\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
+	// The build tag pins GOARCH explicitly: the bundle uses bare
+	// arch filenames (amd64.s/arm64.s), which — having no prefix
+	// before the arch — get NO implicit GOARCH constraint from the
+	// name (Go 1.4+ only auto-tags files with a non-empty prefix).
+	// The `&& !purego` half keeps the pure-Go escape hatch working.
+	asmB.WriteString("//go:build " + arch.name + " && !purego\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
 	var declFns strings.Builder
 
 	calleeSig := func(sym string) ([]ArgKind, bool, ArgKind, string, bool) {
@@ -842,8 +845,8 @@ var (
 		prefix = rel + "/"
 	}
 	files := map[string][]byte{
-		prefix + "gcasm_" + arch.name + ".s":        []byte(asmB.String()),
-		prefix + "gcasm_decls_" + arch.name + ".go": []byte(decl.String()),
+		prefix + arch.name + ".s":             []byte(asmB.String()),
+		prefix + "decls_" + arch.name + ".go": []byte(decl.String()),
 	}
 	return files, nil
 }

--- a/internal/gcasm/gate1_test.go
+++ b/internal/gcasm/gate1_test.go
@@ -290,7 +290,7 @@ func gcasmBitsTrailingZeros64(x uint64) int  { return bits.TrailingZeros64(x) }
 			dm[d.Name] = d
 		}
 		var asmB, declB strings.Builder
-		asmB.WriteString("#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
+		asmB.WriteString("//go:build amd64\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
 		declB.WriteString("//go:build amd64\n\npackage pkg\n")
 		declB.WriteString(stdlibWrappers)
 		declB.WriteString("\n")
@@ -426,8 +426,8 @@ var (
 		}
 		runFiles["pkg/"+name] = data
 	}
-	runFiles["pkg/gcasm_amd64.s"] = []byte(asm1)
-	runFiles["pkg/gcasm_decls.go"] = []byte(decls)
+	runFiles["pkg/amd64.s"] = []byte(asm1)
+	runFiles["pkg/decls_amd64.go"] = []byte(decls)
 
 	var driver strings.Builder
 	driver.WriteString(`package pkg
@@ -527,7 +527,7 @@ func TestFixtureGate(t *testing.T) {
 
 	// -unreachable=false: the generated pure bodies trip the
 	// unreachable-code analyzer by design (goto-heavy control flow);
-	// the check that matters here is asmdecl over gcasm_amd64.s.
+	// the check that matters here is asmdecl over amd64.s.
 	cmd := exec.Command("go", "vet", "-unreachable=false", "./pkg/")
 	cmd.Dir = runDir
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary

Drops the redundant `gcasm_` filename prefix from the gcasm backend's emitted bundle so that refreshing the vendored bundle in the consumer repos (`googlesqlwasm2go`, `pythonwasm2go`) is a **clean file replacement** over the previous own-asm layout, instead of an add-new-name / delete-old-name churn.

| before | after |
|---|---|
| `gcasm_amd64.s` / `gcasm_arm64.s` | `amd64.s` / `arm64.s` |
| `gcasm_decls_<arch>.go` | `decls_<arch>.go` |
| `gcasm_keepalive_<arch>.go` | `keepalive_<arch>.go` |

## Build tag

Bare `amd64.s` / `arm64.s` have no prefix before the arch token, so under the Go 1.4+ rule they get **no implicit GOARCH constraint** from the filename (only files with a non-empty prefix like `foo_amd64.s` are auto-tagged). The header therefore carries an explicit `//go:build <arch>` — **exactly the plain header the own-asm backend emitted**, and the same plain form already used by the bundle's `decls_<arch>.go` / `keepalive_<arch>.go` files and the gate1/a64 test fixtures.

(An earlier commit in this branch briefly used `//go:build <arch> && !purego`; the `&& !purego` was dropped in a follow-up commit — it was inconsistent with the plain-tagged decls file it would need to pair with, so it bought nothing for the default build and did not make `-tags purego` work. Plain `//go:build <arch>` matches own-asm and keeps every asm-side file uniformly tagged.)

`decls_<arch>.go` / `keepalive_<arch>.go` keep their implicit constraint from the `_<arch>` suffix as well as the explicit header.

## Verification

- `go build ./...` — exit 0
- `go test ./internal/gcasm/` — exit 0 (65s), incl. `TestGate4Bundle` (full bundle path: emits `amd64.s`+`arm64.s`, builds, runs) and the amd64/arm64 fixture gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
