### PR TITLE
codegen: cap structured-emit nesting depth, fall back to goto emitter

### DIFF
--- a/internal/codegen/asm_bundle.go
+++ b/internal/codegen/asm_bundle.go
@@ -108,7 +108,13 @@ func isLinknameTrampolineBody(body *ast.BlockStmt) bool {
 // where the asm files supply the function bodies instead.
 func splitForAsm(src []byte, pkg string) (shared, fallback []byte, err error) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "translate.go", src, parser.ParseComments)
+	// SkipObjectResolution: this split only reshuffles top-level decls
+	// and never inspects ident.Obj / file.Scope, so the parser's
+	// (deprecated) identifier resolver is dead work here — and its
+	// hard-coded maxScopeDepth=1000 bailout would reject legitimately
+	// deep control flow (e.g. the nested dispatch setjmp/longjmp
+	// translation emits) that gc itself compiles fine.
+	file, err := parser.ParseFile(fset, "translate.go", src, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse: %w", err)
 	}

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -72,6 +72,17 @@ type structEmitter struct {
 	// reached at depth>0 bails to the recover-trampoline emitter, which threads
 	// returns out of try bodies via return flags.
 	inTryDepth int
+	// depth tracks the current region() nesting (one level per if/else arm,
+	// loop body, or try body). nestCap bounds it: a CFG whose structured form
+	// would nest deeper — e.g. a long chain of non-reconverging conditionals,
+	// as clang emits for some CPython dispatch — aborts structured emission and
+	// falls back to the flat goto emitter. Go's own go/parser (and the protobuf
+	// protogen post-parse the plugin runs) cap identifier resolution at
+	// maxScopeDepth=1000; emitting past that produces source no downstream tool
+	// can re-parse. The cap sits well under 1000 to leave headroom for the extra
+	// scopes gofmt/blocks introduce per level.
+	depth   int
+	nestCap int
 }
 
 // emitStructured renders f as structured Go when the CFG permits.
@@ -107,6 +118,7 @@ func (em *ssaEmitter) emitStructured(f *ssa.Func) (body *ast.BlockStmt, ok bool)
 		emitted:   map[ssa.BlockID]bool{},
 		tryOpened: map[ssa.BlockID]bool{},
 		dupCap:    8*len(f.Blocks) + 64,
+		nestCap:   200,
 	}
 	for _, li := range se.loops {
 		if li.bad {
@@ -403,6 +415,14 @@ func (se *structEmitter) emitTryRegion(tr *ssa.TryRegion) ([]ast.Stmt, bool) {
 }
 
 func (se *structEmitter) region(b, stop *ssa.Block) ([]ast.Stmt, bool) {
+	// Bound structured nesting: past nestCap levels, abort to the goto emitter,
+	// whose output is flat (labels + goto) and so never trips the go/parser /
+	// protogen maxScopeDepth=1000 re-parse limit.
+	se.depth++
+	defer func() { se.depth-- }()
+	if se.depth > se.nestCap {
+		return nil, false
+	}
 	var out []ast.Stmt
 	for b != nil && b != stop {
 		// EH try region: emit the protected body in a closure with

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -385,7 +385,11 @@ type goSigB struct {
 // go/parser (exact, unlike regex parsing).
 func parseSigsAST(src []byte, out map[string]goSigB) error {
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "src.go", src, 0)
+	// SkipObjectResolution: only top-level func signatures are read
+	// below (no ident.Obj / scope use), so the deprecated resolver is
+	// dead work — and its maxScopeDepth=1000 bailout would reject the
+	// deeply nested bodies gc compiles fine (setjmp/longjmp dispatch).
+	f, err := parser.ParseFile(fset, "src.go", src, parser.SkipObjectResolution)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Fixes a bundle-generation degression introduced by #22 (setjmp/longjmp). On the latest `main`, `buf generate` over **python.wasm** fails:

```
transpile wasm: split p0/p0.go: exceeded max scope depth during object resolution
...
p0_pure.go: unparsable Go source: 153088:501: exceeded max scope depth during object resolution
```

## Root cause

#22 extended the structured emitter to handle more CFG shapes structurally. For a long chain of **non-reconverging conditionals** (the shape clang emits for some CPython dispatch), structured reconstruction nests each successive `else` inside the previous one, producing Go source **hundreds of `if/else` levels deep** (≈500 tabs of indentation at the failing site).

`go/parser` caps identifier resolution at `maxScopeDepth = 1000` (`resolver.go:92`). That limit is hit at three re-parse sites:
1. wasm2go's `splitForAsm` (asm_bundle.go)
2. wasm2go's `parseSigsAST` (gcasm/bundle.go)
3. **protobuf `protogen.Content()`** — which `protoc-gen-wasmify-go` runs on *every* emitted file, and which we cannot patch (it's a dependency).

Because (3) is unavoidable, the durable fix must be to **not emit past that depth**.

## Fix

- **Cap structured nesting at 200 levels** (`nestCap`). Past the cap, `region()` aborts structured emission and the function falls back to the existing **goto emitter**, whose output is flat (labels + `goto`) and never trips the limit. This reuses the same bail-to-goto path the `dupCap` guard already uses for pathological CFGs. 200 is well under 1000, leaving headroom for the extra scopes gofmt/blocks add per level.
- **`parser.SkipObjectResolution`** at wasm2go's own two re-parse sites. Both only read top-level decls (never `ident.Obj`/`file.Scope`), so the deprecated resolver is dead work there; skipping it keeps those passes robust to deep bodies independent of the emitter cap.

Net effect on the googlesql run: 2216 of 40573 functions route to goto (the rest stay structured).

## Verification (latest main + this fix, run locally)

| step | result |
|---|---|
| `python-wasm` `buf generate` | exit 0 (bare-arch bundle) |
| `go-python` `go test ./...` | exit 0 |
| `googlesql-wasm` `buf generate` | exit 0 |
| `go-googlesql` `go test ./...` | exit 0 |
| `googlesqlite` `go test ./...` | exit 0 (all packages) |
| generated bundles `go build` amd64 + arm64 | exit 0 |
| `wasm2go` `go test ./...` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
