### PR TITLE
codegen: fix two miscompiles that surface only on very large wasm modules

### DIFF
--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -1073,7 +1073,7 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 		if v.Op == ssa.OpShrU32 || v.Op == ssa.OpShrU64 {
 			return em.emitShrU(lhs, rhs, v), nil
 		}
-		return wrapBinary(mode, lhs, rhs, tok, v), nil
+		return em.wrapBinary(mode, lhs, rhs, tok, v), nil
 	}
 	return nil, fmt.Errorf("ssa emit: unsupported op %v", v.Op)
 }
@@ -1496,7 +1496,7 @@ func tokenShift(op ssa.Op) token.Token {
 	return token.ILLEGAL
 }
 
-func wrapBinary(mode binaryMode, lhs, rhs ast.Expr, tok token.Token, v *ssa.Value) ast.Expr {
+func (em *ssaEmitter) wrapBinary(mode binaryMode, lhs, rhs ast.Expr, tok token.Token, v *ssa.Value) ast.Expr {
 	isUnsigned := mode&(1<<4) != 0
 	pureMode := mode &^ binaryMode(1<<4)
 	switch pureMode {
@@ -1533,7 +1533,7 @@ func wrapBinary(mode binaryMode, lhs, rhs ast.Expr, tok token.Token, v *ssa.Valu
 		} else {
 			compared = &ast.BinaryExpr{X: lhs, Op: tok, Y: rhs}
 		}
-		return boolToI32(compared)
+		return em.boolToI32(compared)
 	}
 	return &ast.BinaryExpr{X: lhs, Op: tok, Y: rhs}
 }
@@ -1550,27 +1550,16 @@ func (em *ssaEmitter) wrapBinaryUnsignedCmp(lhs, rhs ast.Expr, tok token.Token, 
 		Op: tok,
 		Y:  &ast.CallExpr{Fun: hr, Args: []ast.Expr{rhs}},
 	}
-	return boolToI32(compared)
+	return em.boolToI32(compared)
 }
 
-func boolToI32(cond ast.Expr) ast.Expr {
-	return &ast.CallExpr{
-		Fun: &ast.FuncLit{
-			Type: &ast.FuncType{
-				Params:  &ast.FieldList{},
-				Results: &ast.FieldList{List: []*ast.Field{{Type: newID("int32")}}},
-			},
-			Body: &ast.BlockStmt{List: []ast.Stmt{
-				&ast.IfStmt{
-					Cond: cond,
-					Body: &ast.BlockStmt{List: []ast.Stmt{
-						&ast.ReturnStmt{Results: []ast.Expr{intLit(1)}},
-					}},
-				},
-				&ast.ReturnStmt{Results: []ast.Expr{intLit(0)}},
-			}},
-		},
-	}
+// boolToI32 turns a Go bool expression into the wasm i32 (0 or 1) a comparison
+// leaves on the stack, via the b2i32 helper. It must not emit a func literal:
+// see b2i32's comment in helpers/helpers.go for why an inline IIFE breaks the
+// gcasm backend on large functions.
+func (em *ssaEmitter) boolToI32(cond ast.Expr) ast.Expr {
+	em.useHelper("b2i32")
+	return &ast.CallExpr{Fun: em.helperRef("b2i32"), Args: []ast.Expr{cond}}
 }
 
 var _ = binaryUnsigned // not yet used; reserved for future ops

--- a/internal/codegen/emit_ssa_test.go
+++ b/internal/codegen/emit_ssa_test.go
@@ -92,7 +92,14 @@ func TestEmitSSAComparison(t *testing.T) {
 	if !strings.Contains(got, "ui32(l0) < ui32(l1)") {
 		t.Errorf("lt_u missing ui32 helper cast:\n%s", got)
 	}
-	if !strings.Contains(got, "return 1") || !strings.Contains(got, "return 0") {
-		t.Errorf("lt_u missing bool→i32 wrapping:\n%s", got)
+	// The bool→i32 conversion goes through the named b2i32 helper. It must NOT
+	// be an inline `func() int32 { ... }()`: the Go inliner drops a func literal
+	// once the enclosing function outgrows its budget, and the resulting closure
+	// symbol is a direct call the gcasm backend cannot marshal.
+	if !strings.Contains(got, "b2i32(ui32(l0) < ui32(l1))") {
+		t.Errorf("lt_u missing b2i32 bool→i32 wrapping:\n%s", got)
+	}
+	if strings.Contains(got, "func()") {
+		t.Errorf("lt_u emitted a func literal; gcasm cannot marshal an outlined closure:\n%s", got)
 	}
 }

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -38,6 +38,21 @@ type loopInfo struct {
 type loopFrame struct {
 	header *ssa.Block
 	follow *ssa.Block
+	// switchDepth is se.switchDepth as it stood when the loop was opened. A
+	// `break` emitted while se.switchDepth is deeper than this sits lexically
+	// inside a `switch` that the loop does not contain, so a bare `break` would
+	// leave the switch and fall to the bottom of the loop body instead of
+	// exiting the loop. Such a break must name the loop.
+	switchDepth int
+	// label is the loop's Go label, assigned lazily by jump() the first time a
+	// break needs to name it. Empty means the `for` is emitted unlabelled —
+	// which it must be, because Go rejects a label that nothing uses.
+	//
+	// The name comes from a per-function counter, not from the header block's
+	// ID: region() duplicates a shared forward join into each path that reaches
+	// it, so one loop header can be emitted more than once in a function, and
+	// two `for`s carrying the same label do not compile.
+	label string
 }
 
 // structEmitter holds the per-function state for structured emission.
@@ -52,6 +67,14 @@ type structEmitter struct {
 	loops     map[ssa.BlockID]*loopInfo
 	// ctx is the stack of enclosing loops, innermost last.
 	ctx []loopFrame
+	// switchDepth counts the `switch` statements currently open around the
+	// emission point — one per br_table, one per exception dispatch. Go's
+	// `break` binds to the innermost for/switch/select, so a loop-exit break
+	// emitted at a deeper switch depth than its loop has to be labelled.
+	switchDepth int
+	// labelSeq names those labels. It is per function and monotonic, so a loop
+	// emitted twice (block duplication) gets two distinct labels.
+	labelSeq int
 	// emitted guards against emitting a block twice.
 	emitted map[ssa.BlockID]bool
 	// tryOpened marks try-region entry blocks already wrapped, so the
@@ -379,6 +402,10 @@ func (se *structEmitter) emitTryRegion(tr *ssa.TryRegion) ([]ast.Stmt, bool) {
 	// Dispatch a caught exception to its handler.
 	var clauses []ast.Stmt
 	hasCatchAll := false
+	// Handler bodies land inside the dispatch switch below, so a loop-exit break
+	// in one of them must name its loop (see jump).
+	se.switchDepth++
+	defer func() { se.switchDepth-- }()
 	for _, h := range tr.Handlers {
 		se.em.catchExcVar = excVar
 		hStmts, ok := se.region(h.Block, tr.Post)
@@ -449,13 +476,20 @@ func (se *structEmitter) region(b, stop *ssa.Block) ([]ast.Stmt, bool) {
 		}
 		// Open a `for {}` when b heads a loop we are not already in.
 		if li := se.loops[b.ID]; li != nil && !se.insideLoop(b) {
-			se.ctx = append(se.ctx, loopFrame{header: b, follow: li.follow})
+			se.ctx = append(se.ctx, loopFrame{header: b, follow: li.follow, switchDepth: se.switchDepth})
 			forBody, ok := se.region(b, nil)
+			// Read the frame back before popping: jump() names the loop lazily,
+			// from arbitrarily deep inside the body it just emitted.
+			label := se.ctx[len(se.ctx)-1].label
 			se.ctx = se.ctx[:len(se.ctx)-1]
 			if !ok {
 				return nil, false
 			}
-			out = append(out, &ast.ForStmt{Body: &ast.BlockStmt{List: forBody}})
+			var loop ast.Stmt = &ast.ForStmt{Body: &ast.BlockStmt{List: forBody}}
+			if label != "" {
+				loop = &ast.LabeledStmt{Label: newID(label), Stmt: loop}
+			}
+			out = append(out, loop)
 			b = li.follow
 			continue
 		}
@@ -574,10 +608,14 @@ func (se *structEmitter) region(b, stop *ssa.Block) ([]ast.Stmt, bool) {
 			if err != nil {
 				return nil, false
 			}
+			// The arms are emitted inside the switch, so a loop-exit break in one
+			// of them must name its loop (see jump).
+			se.switchDepth++
 			swBody := &ast.BlockStmt{}
 			for si, e := range b.Succs {
 				arm, ok := se.branch(b, e.Block, e.Index, join)
 				if !ok {
+					se.switchDepth--
 					return nil, false
 				}
 				var caseExprs []ast.Expr
@@ -589,6 +627,7 @@ func (se *structEmitter) region(b, stop *ssa.Block) ([]ast.Stmt, bool) {
 				}
 				swBody.List = append(swBody.List, &ast.CaseClause{List: caseExprs, Body: arm})
 			}
+			se.switchDepth--
 			out = append(out, &ast.SwitchStmt{Tag: sel, Body: swBody})
 			if join == nil {
 				b = nil
@@ -645,19 +684,35 @@ func (se *structEmitter) goTo(target, pred *ssa.Block, predIdx int, stop *ssa.Bl
 // jump returns the `continue` / `break` statement when `target` is the
 // header or follow of an enclosing loop. ok=false means it is an
 // ordinary block. Only the INNERMOST enclosing loop is handled with a
-// bare continue/break; a jump to an outer loop returns ok=false so the
+// continue/break; a jump to an outer loop returns ok=false so the
 // whole function falls back to the goto emitter (labelled loops are a
 // follow-up).
+//
+// A break is labelled when the emission point is inside a `switch` the loop
+// does not contain. Go binds a bare `break` to the innermost for/switch/select,
+// so a bare break under a br_table's switch would leave only the switch and
+// then fall to the bottom of the loop body — silently turning the loop's exit
+// into a back-edge. The induction variable is updated on the OTHER arm, so what
+// results is not a slow loop but a stuck one. `continue` needs no label: it
+// binds to the innermost for regardless of any switch in between.
 func (se *structEmitter) jump(target *ssa.Block) ([]ast.Stmt, bool) {
 	if len(se.ctx) == 0 {
 		return nil, false
 	}
-	inner := se.ctx[len(se.ctx)-1]
+	inner := &se.ctx[len(se.ctx)-1]
 	if target == inner.header {
 		return []ast.Stmt{&ast.BranchStmt{Tok: token.CONTINUE}}, true
 	}
 	if inner.follow != nil && target == inner.follow {
-		return []ast.Stmt{&ast.BranchStmt{Tok: token.BREAK}}, true
+		br := &ast.BranchStmt{Tok: token.BREAK}
+		if se.switchDepth > inner.switchDepth {
+			if inner.label == "" {
+				se.labelSeq++
+				inner.label = fmt.Sprintf("wl%d", se.labelSeq)
+			}
+			br.Label = newID(inner.label)
+		}
+		return []ast.Stmt{br}, true
 	}
 	// A jump to an outer loop's header/follow would need a labelled
 	// continue/break. Signal "not handled" so emitStructured bails.

--- a/internal/codegen/emit_structured_test.go
+++ b/internal/codegen/emit_structured_test.go
@@ -30,9 +30,9 @@ func TestStructuredEmit(t *testing.T) {
 	// structured (no goto): if/else for branches, for {} for loops.
 	structured := []string{"abs", "clamp_if", "early", "deadnest", "ret_nested",
 		"deep", "brblock", "fold_arith", "fold_cse", "fold_dead",
-		"count", "sum", "mul2"}
+		"count", "sum", "mul2", "table_loop_exit"}
 	// loopExports must additionally contain a `for` loop.
-	loopExports := map[string]bool{"count": true, "sum": true, "mul2": true}
+	loopExports := map[string]bool{"count": true, "sum": true, "mul2": true, "table_loop_exit": true}
 
 	// emitOne lowers + optimises an export and runs the structured
 	// emitter. ok2 is false when the function could not be SSA-lowered

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -51,6 +51,27 @@ func ui32(x int32) uint32 { return uint32(x) }
 
 func ui64(x int64) uint64 { return uint64(x) }
 
+// b2i32 materialises a wasm comparison result — an i32 that is 0 or 1 — from
+// the Go bool the comparison expression evaluates to.
+//
+// It exists as a named helper rather than an inline `func() int32 { ... }()`
+// because the gcasm backend requires every direct call left in the compiled
+// output to be either a package-local FnN or something the Go inliner removed.
+// A func literal is normally inlined at its call site, but the inliner gives up
+// once the ENCLOSING function grows past its budget — and a single wasm function
+// can translate to tens of thousands of lines of Go, as an interpreter's
+// bytecode dispatch loop does. The literal is then outlined into a real closure
+// symbol (FnN.funcA.funcB), which reaches the assembler as a direct call gcasm
+// cannot marshal. A named helper this small is always inlined, and if it ever
+// were not, it would fail loudly at its own symbol rather than as a nested
+// closure.
+func b2i32(b bool) int32 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func f32(x float32) float32 { runtime.KeepAlive(&x); return x }
 
 func f64(x float64) float64 { runtime.KeepAlive(&x); return x }

--- a/internal/codegen/helpers/helpers_full_test.go
+++ b/internal/codegen/helpers/helpers_full_test.go
@@ -108,6 +108,15 @@ func TestIdentityHelpers(t *testing.T) {
 	if got := f64(3.14); got != 3.14 {
 		t.Errorf("f64 = %v", got)
 	}
+	// b2i32 carries a wasm comparison result out of a Go bool. The emitter
+	// relies on exactly 0 and 1 — the result feeds arithmetic and bitwise
+	// operators, not just branches.
+	if got := b2i32(true); got != 1 {
+		t.Errorf("b2i32(true) = %d, want 1", got)
+	}
+	if got := b2i32(false); got != 0 {
+		t.Errorf("b2i32(false) = %d, want 0", got)
+	}
 	if got := f32(float32(math.NaN())); !math.IsNaN(float64(got)) {
 		t.Errorf("f32(NaN) should be NaN")
 	}

--- a/internal/codegen/lower_cfdebug_test.go
+++ b/internal/codegen/lower_cfdebug_test.go
@@ -42,6 +42,11 @@ func TestSSAControlFlow(t *testing.T) {
 		{"fold_arith", []int32{0}},
 		{"fold_cse", []int32{0, 3, 7}},
 		{"fold_dead", []int32{0, 5, 41}},
+		// A br_table arm that exits the enclosing loop. The structured emitter
+		// renders the table as a Go `switch`, and Go binds a bare `break` to the
+		// innermost switch — so the exit arm has to name the loop or the generated
+		// code spins forever instead of returning.
+		{"table_loop_exit", []int32{0, 1, 2, 3, 8, 20}},
 	}
 
 	// wazero reference values.

--- a/testdata/ssa_cf.wat
+++ b/testdata/ssa_cf.wat
@@ -156,4 +156,38 @@
         (local.set 1 (i32.add (local.get 1) (i32.const 1)))
         (br 0)))
     (local.get 2))
+
+  ;; --- br_table inside a loop, one arm exiting the loop ---
+  ;; table_loop_exit(n): advance i from n until i is odd and i >= n+3.
+  ;;
+  ;; The loop's exit is a `br $done` nested inside one arm of a br_table. The
+  ;; structured emitter renders the table as a Go `switch`, and every arm here
+  ;; terminates, so nothing follows the switch and the `for` body ends with it.
+  ;; Go binds a bare `break` to the innermost switch — so the exit must NAME
+  ;; the loop. A bare break would leave only the switch and fall off the end of
+  ;; the loop body, which is the back-edge: the loop would never terminate.
+  (func (export "table_loop_exit") (param i32) (result i32)
+    (local i32) ;; 1: i
+    (local.set 1 (local.get 0))
+    (block $done
+      (loop $again
+        (local.set 1 (i32.add (local.get 1) (i32.const 1)))
+        (block $trap
+          (block $odd
+            (block $even
+              ;; selector is 0 or 1, so the default ($trap) arm is dead. It is
+              ;; here to remove the br_table's post-dominator, which is what
+              ;; makes the `switch` the last statement of the loop body — and
+              ;; therefore what makes a mis-bound `break` fall onto the
+              ;; back-edge instead of onto a following statement.
+              (br_table $even $odd $trap
+                (i32.and (local.get 1) (i32.const 1))))
+            ;; even: keep going
+            (br $again))
+          ;; odd: leave once i has caught up with n+5
+          (br_if $done (i32.ge_s (local.get 1) (i32.add (local.get 0) (i32.const 5))))
+          (br $again))
+        (unreachable)))
+    (local.get 1))
+
 )


### PR DESCRIPTION
Two independent codegen bugs, found while transpiling a large real-world engine
(≈6,900 wasm functions, one of which becomes a 40k-line Go function). Both are
silent on small modules; one of them produces Go that compiles and then hangs.

## 1. `bool → i32` was emitted as a func literal

`boolToI32` wrapped every value-consumed comparison in
`func() int32 { if cond { return 1 }; return 0 }()`. The Go inliner normally
erases that, but it gives up once the *enclosing* function outgrows its budget.
The literal is then outlined into a real closure symbol, and gcasm — which
requires every surviving direct call to be a package-local `FnN` or something
the inliner removed — rejects it:

```
transform <pkg>/p0.Fn5528:
  unmarshalled direct call "<pkg>/p0.Fn5528.Fn5528.func54.func142"
```

Replaced with a named `b2i32` helper. Always inlinable; if it ever were not, it
would fail at its own symbol rather than as an anonymous nested closure. It also
removes the nesting a comparison-of-a-comparison produced.

## 2. A `break` out of a loop, from inside a `br_table`'s switch, bound to the switch

Go binds a bare `break` to the innermost `for`/`switch`/`select`. The structured
emitter lowers a `br_table` to a Go `switch`, and lowers a jump to the enclosing
loop's follow to a bare `break`. So a br_table arm that exits its loop emitted a
break that left only the switch.

When the switch is the last statement of the loop body, what follows that break
is the back-edge. The loop's exit became a jump to its own header — and since the
induction variable is advanced on the `continue` arm, not the exit arm, it
re-entered with the counter unchanged. **Not a slow loop: a stuck one.** The
generated Go compiles; the wasm it came from is correct; only the translation
hangs.

The shape is not exotic: every arm terminates, and one arm traps, which removes
the br_table's post-dominator and leaves the switch as the loop body's final
statement. A garbage collector's sweep loop over an array of regions is exactly
this, and it spins forever with its index pinned at 0.

Fix: count the switches open around the emission point, compare against the depth
recorded when each loop was opened, and name the loop when a break has to cross
one. Labels are attached lazily and only where a labelled break names them (Go
rejects unused labels), and they are numbered from a per-function counter rather
than the header block's ID — `region()` duplicates a shared forward join into
every path that reaches it, so one loop header can be emitted twice, and two
`for`s with the same label do not compile. `continue` needs nothing: it already
binds to the innermost `for` across any switch.

## Tests

`testdata/ssa_cf.wat` gains a `table_loop_exit` export that reproduces the exact
shape. Its dead default arm exists to trap: without it the emitter appends a
`break` after the switch that the mis-bound break lands on, which masks the bug —
the obvious "br_table exits a loop" fixture passes even unfixed.

It is asserted twice: on shape (`TestStructuredEmit`) and against wazero
(`TestSSAControlFlow`), where before this change the generated Go hangs and the
test times out.

Full suite green; `emit_ssa_test.go` also gains an assertion that no func literal
is emitted for a comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
