### PR TITLE
codegen: bail structured emit when break/continue crosses a try closure

### DIFF
--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -53,6 +53,13 @@ type loopFrame struct {
 	// it, so one loop header can be emitted more than once in a function, and
 	// two `for`s carrying the same label do not compile.
 	label string
+	// tryDepth is se.inTryDepth as it stood when the loop was opened. A
+	// break/continue emitted while se.inTryDepth is deeper than this would have
+	// to jump out of an EH try-region closure (emitTryRegion wraps the protected
+	// body in a `func() *wasmExc { ... }()`), but Go labels are function-scoped
+	// and `break`/`continue` cannot cross a func literal — so such a jump bails
+	// to the goto emitter instead (see jump()).
+	tryDepth int
 }
 
 // structEmitter holds the per-function state for structured emission.
@@ -476,7 +483,7 @@ func (se *structEmitter) region(b, stop *ssa.Block) ([]ast.Stmt, bool) {
 		}
 		// Open a `for {}` when b heads a loop we are not already in.
 		if li := se.loops[b.ID]; li != nil && !se.insideLoop(b) {
-			se.ctx = append(se.ctx, loopFrame{header: b, follow: li.follow, switchDepth: se.switchDepth})
+			se.ctx = append(se.ctx, loopFrame{header: b, follow: li.follow, switchDepth: se.switchDepth, tryDepth: se.inTryDepth})
 			forBody, ok := se.region(b, nil)
 			// Read the frame back before popping: jump() names the loop lazily,
 			// from arbitrarily deep inside the body it just emitted.
@@ -700,6 +707,15 @@ func (se *structEmitter) jump(target *ssa.Block) ([]ast.Stmt, bool) {
 		return nil, false
 	}
 	inner := &se.ctx[len(se.ctx)-1]
+	// The jump target is a loop opened outside the try-region closure we are
+	// currently emitting into. A `break`/`continue` — even a labelled one —
+	// cannot leave the `func() *wasmExc { ... }()` the try body lives in, so
+	// abort structured emission and let the goto emitter (which threads control
+	// out of try bodies via return flags, not lexical break) handle this
+	// function. Mirrors the BlockRet-inside-try bail in region().
+	if se.inTryDepth > inner.tryDepth {
+		return nil, false
+	}
 	if target == inner.header {
 		return []ast.Stmt{&ast.BranchStmt{Tok: token.CONTINUE}}, true
 	}

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -707,19 +707,29 @@ func (se *structEmitter) jump(target *ssa.Block) ([]ast.Stmt, bool) {
 		return nil, false
 	}
 	inner := &se.ctx[len(se.ctx)-1]
-	// The jump target is a loop opened outside the try-region closure we are
-	// currently emitting into. A `break`/`continue` — even a labelled one —
-	// cannot leave the `func() *wasmExc { ... }()` the try body lives in, so
-	// abort structured emission and let the goto emitter (which threads control
-	// out of try bodies via return flags, not lexical break) handle this
-	// function. Mirrors the BlockRet-inside-try bail in region().
-	if se.inTryDepth > inner.tryDepth {
-		return nil, false
+	// A jump to a loop opened OUTSIDE the try-region closure we are currently
+	// emitting into cannot be a `break`/`continue` — not even a labelled one.
+	// Go labels are function-scoped and neither statement crosses the
+	// `func() *wasmExc { ... }()` that emitTryRegion wraps the protected body
+	// in. Panic to abort structured emission (emitStructured recovers and falls
+	// back to the goto emitter, which threads control out of try bodies via
+	// return flags rather than lexical break). Mirrors the outer-loop case
+	// below, and the BlockRet-inside-try bail in region().
+	//
+	// The check sits inside each target test, not above them: an ordinary
+	// forward jump inside a try is not a loop jump at all, and must keep
+	// returning ok=false so the caller emits its target inline.
+	crossesTryClosure := func() {
+		if se.inTryDepth > inner.tryDepth {
+			panic("structured emit: break/continue cannot cross a try closure")
+		}
 	}
 	if target == inner.header {
+		crossesTryClosure()
 		return []ast.Stmt{&ast.BranchStmt{Tok: token.CONTINUE}}, true
 	}
 	if inner.follow != nil && target == inner.follow {
+		crossesTryClosure()
 		br := &ast.BranchStmt{Tok: token.BREAK}
 		if se.switchDepth > inner.switchDepth {
 			if inner.label == "" {

--- a/internal/ssa/coverage_test.go
+++ b/internal/ssa/coverage_test.go
@@ -745,6 +745,43 @@ func TestPruneDeadBlocks(t *testing.T) {
 	}
 }
 
+// A catch landing pad has no predecessors — it is entered by unwinding, not by
+// a CFG edge. One that ends the function (return / unreachable / throw) has no
+// successors either, so the isolation rule would sweep it away while the
+// TryRegion kept pointing at it, leaving the emitters to reference a block that
+// no longer exists.
+func TestPruneDeadBlocksCatchLandingPadKept(t *testing.T) {
+	b := NewFuncBuilder("prune_landingpad", FuncSig{Results: []Type{TypeI32}})
+	entry := b.NewBlock(BlockRet)
+	pad := b.NewBlock(BlockRet) // no preds, no succs — reached only by unwinding
+	dead := b.NewBlock(BlockRet)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+	b.FinishRet(b.Const32(1))
+	b.SetCurrent(pad)
+	b.FinishRet(b.Const32(42))
+	b.SetCurrent(dead)
+	b.FinishRet(b.Const32(0))
+	f := b.Func()
+	f.TryRegions = []*TryRegion{{Entry: entry, Post: entry, Handlers: []TryHandler{{Block: pad}}}}
+
+	PruneDeadBlocks(f)
+
+	kept := map[*Block]bool{}
+	for _, blk := range f.Blocks {
+		kept[blk] = true
+	}
+	if !kept[entry] {
+		t.Error("entry block removed by prune")
+	}
+	if !kept[pad] {
+		t.Error("catch landing pad removed by prune")
+	}
+	if kept[dead] {
+		t.Error("genuinely isolated block survived prune")
+	}
+}
+
 func TestPruneDeadBlocksEntryKept(t *testing.T) {
 	// Entry block with no preds and no succs must not be pruned.
 	b := NewFuncBuilder("prune_entry", FuncSig{})

--- a/internal/ssa/verify.go
+++ b/internal/ssa/verify.go
@@ -362,7 +362,8 @@ func blockID(b *Block) BlockID {
 }
 
 // PruneDeadBlocks removes blocks that are fully isolated — zero
-// predecessors and zero successors — and are not the entry block.
+// predecessors and zero successors — and are not the entry block or an
+// EH catch landing pad.
 //
 // Such blocks arise legitimately during structured-control lowering:
 // e.g. a `loop` whose body always branches (br 0 back-edge or br N
@@ -376,13 +377,32 @@ func blockID(b *Block) BlockID {
 // unreachable block can never have acquired a successor edge either.
 // So an isolated block carries no values anyone depends on.
 //
+// A catch landing pad breaks that reasoning: it is entered by unwinding,
+// not by a CFG edge, so it has no predecessors. Usually it also has a
+// successor (the `end` of the try falls through to the region's Post),
+// which is why the pruner did not notice — but a handler that ends in
+// `return`, `unreachable` or a `throw` has neither. Removing it leaves
+// the TryRegion pointing at a block nobody emits: the recover
+// trampoline still generates the `case <id>: goto L<id>` that resumes
+// into the handler, and the resulting Go does not compile
+// ("label L3 not defined"). The structured emitter fares no better —
+// its block-count check fails and the whole function falls back.
+//
 // Run before Verify.
 func PruneDeadBlocks(f *Func) {
+	roots := map[BlockID]bool{}
+	for _, tr := range f.TryRegions {
+		for _, h := range tr.Handlers {
+			if h.Block != nil {
+				roots[h.Block.ID] = true
+			}
+		}
+	}
 	for {
 		removed := false
 		kept := f.Blocks[:0]
 		for _, b := range f.Blocks {
-			if b != f.Entry && len(b.Preds) == 0 && len(b.Succs) == 0 {
+			if b != f.Entry && !roots[b.ID] && len(b.Preds) == 0 && len(b.Succs) == 0 {
 				removed = true
 				continue
 			}

--- a/testdata/eh_catch_returns.wat
+++ b/testdata/eh_catch_returns.wat
@@ -1,0 +1,53 @@
+;; Regression: a catch landing pad that leaves the function directly.
+;;
+;; A landing pad is entered by unwinding, not by a CFG edge, so it has no
+;; predecessors. Usually it also has a successor — the try's `end` falls through
+;; to the region's Post — which is why PruneDeadBlocks, whose rule is "no preds
+;; AND no succs", never touched one. A handler that ends in `return` has neither,
+;; so it was pruned out of Func.Blocks while the TryRegion kept pointing at it.
+;; The recover trampoline then emitted the `case <id>: goto L<id>` that resumes
+;; into the handler for a label nobody defined:
+;;
+;;   p_pure.go:33:10: label L3 not defined
+;;
+;; `plain` is the minimal shape: no loop, no br_table, just a try whose catch
+;; returns. `inLoop` is the same handler inside a loop, which is where it was
+;; first hit — there the pruned handler also made the structured emitter's
+;; block-count check fail, so the whole function fell back to the goto emitter
+;; and produced the uncompilable output above.
+;;
+;; $t throws only for 7.
+(module
+  (tag $e (param i32))
+
+  (func $t (param i32)
+    local.get 0
+    i32.const 7
+    i32.eq
+    if
+      i32.const 99
+      throw $e
+    end)
+
+  ;; plain(0) = 1, plain(7) = 42
+  (func (export "plain") (param $x i32) (result i32)
+    (try
+      (do (call $t (local.get $x)))
+      (catch $e (return (i32.const 42))))
+    (i32.const 1))
+
+  ;; inLoop(0) = 3 (i counts to 3 and the loop exits)
+  ;; inLoop(7) = 42 (throws on the first iteration; the handler returns i + 41)
+  (func (export "inLoop") (param $x i32) (result i32)
+    (local $i i32)
+    (block $done
+      (loop $lp
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (try
+          (do
+            (call $t (local.get $x))
+            (br_if $done (i32.ge_s (local.get $i) (i32.const 3))))
+          (catch $e (return (i32.add (local.get $i) (i32.const 41)))))
+        (br $lp)))
+    (local.get $i))
+)

--- a/testdata/eh_loop_break_in_try.wat
+++ b/testdata/eh_loop_break_in_try.wat
@@ -1,0 +1,44 @@
+;; Regression: a single-exit loop whose TRY BODY contains a br_table that exits
+;; the loop. The structured emitter would open `wlN: for {}` for the loop and,
+;; for the br_table arm that leaves the loop, emit `break wlN` — but that break
+;; sits inside the try region's `func() *wasmExc { … }()` closure, where the
+;; label is out of scope (Go labels are function-scoped). Before the fix this
+;; produced uncompilable Go ("break label not defined"); the emitter must bail
+;; to the goto layout instead.
+;;
+;; run($x): loop increments $i; the try body calls $t (throws only when $x==7),
+;; then br_table on $i: 1 -> continue the loop, otherwise -> exit. catch sets
+;; $r=42. So run(0) exits with $r=0 after i reaches 2; run(7) throws on the
+;; first iteration and catches -> 42.
+(module
+  (tag $e (param i32))
+  (func $t (param i32)
+    local.get 0
+    i32.const 7
+    i32.eq
+    if
+      i32.const 99
+      throw $e
+    end)
+  (func (export "run") (param $x i32) (result i32)
+    (local $r i32)
+    (local $i i32)
+    block $exit
+      loop $lp
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        try
+          local.get $x
+          call $t
+          local.get $i
+          br_table $exit $lp $exit
+        catch $e
+          i32.const 42
+          local.set $r
+          br $exit
+        end
+      end
+    end
+    local.get $r))

--- a/transpile/transpile_test.go
+++ b/transpile/transpile_test.go
@@ -440,6 +440,68 @@ func main() {
 	}
 }
 
+// TestTranspileEHLoopBreakInTry is the regression for the perl.wasm miscompile:
+// a single-exit loop whose TRY BODY holds a br_table that exits the loop. The
+// structured emitter would emit `break wlN` for the loop-exit arm, but that
+// break sits inside the try region's `func() *wasmExc { … }()` closure where the
+// loop label is out of scope, yielding uncompilable Go. jump() must detect the
+// jump crossing the closure and bail to the goto emitter. run(0)=0, run(7)=42.
+func TestTranspileEHLoopBreakInTry(t *testing.T) {
+	bin := testfixture.Wasm(t, "eh_loop_break_in_try")
+	m, err := transpile.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	var buf bytes.Buffer
+	res, err := transpile.Translate(&buf, m, transpile.Options{Package: "pkg", OutputImportPath: "ehl/pkg"})
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+
+	dir := t.TempDir()
+	write := func(rel string, data []byte) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", []byte("module ehl\n\ngo 1.25.0\n"))
+	write("pkg/gen.go", buf.Bytes())
+	for rel, data := range res.Files {
+		write("pkg/"+rel, data)
+	}
+	for name, data := range res.Sidecars {
+		write("pkg/"+name, data)
+	}
+	write("main.go", []byte(`package main
+
+import (
+	"fmt"
+
+	"ehl/pkg"
+)
+
+func main() {
+	m := pkg.New()
+	fmt.Println(m.Run(0), m.Run(7))
+}
+`))
+	// The whole point is that this COMPILES — a `break wlN` across the try
+	// closure would fail `go run` here with "break label not defined".
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed (structured emit likely emitted a break across the try closure): %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "0 42" {
+		t.Fatalf("eh loop break-in-try: got %q, want %q\n%s", got, "0 42", out)
+	}
+}
+
 // TestTranspileEHMultiPackage proves EH try/catch works in MULTI-package
 // output: the wasmExc type + wasm_catch helper live in `base` (exported as
 // WasmExc / Wasm_catch), and the chunk package emitting the try/catch references

--- a/transpile/transpile_test.go
+++ b/transpile/transpile_test.go
@@ -502,6 +502,73 @@ func main() {
 	}
 }
 
+// TestTranspileEHCatchReturns covers a catch landing pad that leaves the
+// function directly. A landing pad has no CFG predecessors (it is entered by
+// unwinding), and one that ends in `return` has no successors either — so
+// PruneDeadBlocks, whose rule is "no preds and no succs", swept it out of
+// Func.Blocks while the TryRegion kept pointing at it. The recover trampoline
+// then emitted `case <id>: goto L<id>` for a label nobody defined and the
+// generated Go did not compile.
+//
+// `plain` is the minimal shape; `inLoop` is where it was first hit, and there
+// the missing block also tripped the structured emitter's block-count check, so
+// the function fell back to the goto emitter — into the same broken output.
+func TestTranspileEHCatchReturns(t *testing.T) {
+	bin := testfixture.Wasm(t, "eh_catch_returns")
+	m, err := transpile.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	var buf bytes.Buffer
+	res, err := transpile.Translate(&buf, m, transpile.Options{Package: "pkg", OutputImportPath: "ehr/pkg"})
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+
+	dir := t.TempDir()
+	write := func(rel string, data []byte) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", []byte("module ehr\n\ngo 1.25.0\n"))
+	write("pkg/gen.go", buf.Bytes())
+	for rel, data := range res.Files {
+		write("pkg/"+rel, data)
+	}
+	for name, data := range res.Sidecars {
+		write("pkg/"+name, data)
+	}
+	write("main.go", []byte(`package main
+
+import (
+	"fmt"
+
+	"ehr/pkg"
+)
+
+func main() {
+	m := pkg.New()
+	fmt.Println(m.Plain(0), m.Plain(7), m.InLoop(0), m.InLoop(7))
+}
+`))
+	// The whole point is that this COMPILES: a pruned landing pad leaves the
+	// trampoline's resume `goto` dangling ("label L3 not defined").
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed (catch landing pad likely pruned): %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "1 42 3 42" {
+		t.Fatalf("eh catch-returns: got %q, want %q\n%s", got, "1 42 3 42", out)
+	}
+}
+
 // TestTranspileEHMultiPackage proves EH try/catch works in MULTI-package
 // output: the wasmExc type + wasm_catch helper live in `base` (exported as
 // WasmExc / Wasm_catch), and the chunk package emitting the try/catch references


### PR DESCRIPTION
## Summary

Fixes a wasm2go miscompile that broke **perl.wasm** transpilation:

```
p1/p1_pure.go: label wl1 defined and not used
p1/p1_pure.go: break label not defined: wl1
```

## Root cause

A loop whose body contains an EH try region is emitted as:

```go
wl1:
for {
    __exc := func() *wasmExc { … }()   // protected body inside a closure
    …
}
```

When a `br_table` inside the **protected body** targets the loop's follow, `jump()` emitted a labelled `break wl1`. But `wl1` labels the outer `for`, and Go labels are function-scoped — `break`/`continue` cannot cross the `func() *wasmExc {…}()` the try body lives in. The generated Go therefore didn't compile.

This is the interaction of two prior PRs: **#22** (setjmp/longjmp) introduced the try-region closure and an `inTryDepth` bail for `BlockRet`, but **not** for the break/continue path; **#25** added the labelled-break (`wl%d`) work. Neither alone triggered it, and the loop-in-try-with-`br_table`-exit shape doesn't occur in the googlesql/python modules — so it only surfaced on perl.

## Fix

Record on each `loopFrame` the `inTryDepth` at which the loop was opened. In `jump()`, bail (abort structured emission → goto emitter) when a break/continue would target a loop opened **outside** the current try closure. The goto emitter threads control out of try bodies via return flags rather than lexical `break`, so it lays the function out correctly. This mirrors the existing `BlockRet`-inside-try bail.

17 lines in `emit_structured.go`; no behavior change for functions without the pattern.

## Tests

- `testdata/eh_loop_break_in_try.wat` + `TestTranspileEHLoopBreakInTry`: a single-exit loop whose try body `br_table`s out of the loop. **Fails on the old emitter** with `break label not defined: wl1`; **passes now** (`run(0)=0`, `run(7)=42`).
- Full `./transpile/`, `./internal/codegen/`, `./internal/gcasm/` suites green.

## End-to-end verification

- **perl**: `buf generate` (runtime=wasm2go) now succeeds; the generated bundle builds `amd64`+`arm64`; **go-perl `go test ./...` passes**.
- **python**: regenerates **byte-identically** (tests cached) — the fix is a no-op where the pattern is absent.
- **googlesql**: unaffected by construction (it transpiled fine without the fix, so it has no closure-crossing loop-exit).

---

## Second bug, same neighbourhood: a pruned catch landing pad

Found while probing whether the bail above can be reached without aborting. It is
independent of this PR's first commit and of #25 — it reproduces on `f08af35`,
i.e. before the labelled-break work.

`ssa.PruneDeadBlocks` drops blocks with no predecessors **and** no successors.
That is sound for the block a `loop` pre-allocates for its `end` and never falls
into: lowering only wires an edge out of the block it is currently emitting, so
an unreachable block cannot have gained a successor either.

A catch landing pad breaks the reasoning. It is entered by **unwinding**, not by
a CFG edge, so it has no predecessors. Usually it has a successor — the try's
`end` falls through to the region's `Post` — which is why the pruner never
noticed. But a handler that leaves the function directly (`return`,
`unreachable`, `throw`) has neither, so it was pruned while the `TryRegion` kept
pointing at it.

Nothing then emits the pad, yet the recover trampoline still generates the
`case <id>: goto L<id>` that resumes into it:

```
p_pure.go:33:10: label L3 not defined
```

The structured emitter is no help: its `len(se.emitted) != len(f.Blocks)` check
fails, the function falls back to the goto emitter, and lands in exactly that
output. That is how it turned up — a loop whose try body branches out of the
loop and whose catch returns, where the fallback was supposed to be the safe
path.

The whole trigger is *a catch that returns*. No loop, no `br_table`:

```wat
(func (export "plain") (param $x i32) (result i32)
  (try
    (do (call $t (local.get $x)))
    (catch $e (return (i32.const 42))))
  (i32.const 1))
```

Fix: treat landing pads as prune roots. Genuinely isolated blocks still go.

`testdata/eh_catch_returns.wat` carries both that shape and the loop shape it was
found in; `TestTranspileEHCatchReturns` compiles and runs the generated Go, and
fails with the dangling label before the fix. `TestPruneDeadBlocksCatchLandingPadKept`
pins the pruner directly.

## A correction to the attribution above

The first commit's message calls the break-across-a-closure bug an interaction of
#22 and #25. It is not: it predates #25. Running the same probe against
`f08af35` — before labelled breaks existed — the structured emitter emits a
**bare** `break` / `continue` inside the `func() *wasmExc { … }()`:

```go
__exc4 := func() (c *wasmExc) {
    defer func() { c = wasm_catch(recover()) }()
    ...
    if int32(3) <= v11 {
        break        // no enclosing for/switch/select — does not compile
    } else {
        continue
    }
}()
```

So the bug arrived with #22, which introduced the closure and added the
`inTryDepth` bail for `BlockRet` but not for the break/continue path. #25 only
changed the diagnostic from "break is not in a loop, switch, or select" to
"break label not defined". The fix in this PR is correct either way.

## On the shape of the bail

`jump()` returning `(nil, false)` does not itself abort structured emission —
`goTo()` reads it as "ordinary block" and keeps emitting from the target. It ends
up aborting anyway, indirectly:

- a jump to the loop's **follow**: emission continues there and reaches the
  function's `return` inside the closure, which the pre-existing
  `inTryDepth > 0` bail on `BlockRet` catches;
- a jump to the loop's **header**: the loop is already open, so `region()`
  duplicates its body into itself until `dupCap` / `nestCap` trips;
- **follow == the try's Post**: `goTo()` sees `target == stop` and emits nothing,
  which is where the fallthrough goes anyway — correct, not a bail.

I could not construct a shape that neither bails nor is correct (five probes:
exit-to-follow, back-edge, `follow == Post`, follow traps, follow spins). So this
is safe as written. It does lean on other bails to catch it, though, and the
sibling case a few lines below — a jump to an *outer* loop — `panic`s to force
the abort. Matching that would make the intent structural rather than
circumstantial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
