### PR TITLE
codegen: emit negative-zero float constants via math.Float*frombits

### DIFF
--- a/internal/codegen/cg_matrix_test.go
+++ b/internal/codegen/cg_matrix_test.go
@@ -99,6 +99,7 @@ var allFixtures = []string{
 	"cg_frame.wasm",
 	"cg_indirect.wasm",
 	"cg_specialfp.wasm",
+	"cg_negzero.wasm",
 	"cg_globals.wasm",
 	"cg_globals_nan.wasm",
 	"cg_misc.wasm",

--- a/internal/codegen/const_expr.go
+++ b/internal/codegen/const_expr.go
@@ -66,12 +66,20 @@ func evalConstExprFloat(expr []byte) (float64, error) {
 	return 0, fmt.Errorf("unsupported float const-expr opcode 0x%02x", expr[0])
 }
 
+// floatNeedsBitsEmission reports whether v cannot be reproduced by a Go
+// decimal literal: NaN and ±Inf have no literal syntax, and Go constant
+// arithmetic has no negative zero (`float64(-0)` is +0), so -0 must be
+// materialized via math.Float{32,64}frombits as well.
+func floatNeedsBitsEmission(v float64) bool {
+	return math.IsNaN(v) || math.IsInf(v, 0) || (v == 0 && math.Signbit(v))
+}
+
 // floatInitExpr builds a Go expression for a float global's initial value.
-// Finite values use a decimal literal cast to the target type; NaN/Inf
-// values route through math.Float{32,64}frombits since Go has no NaN/Inf
-// literal syntax. isF32 selects between float32 and float64 emission.
+// Finite values use a decimal literal cast to the target type; NaN/Inf/-0
+// values route through math.Float{32,64}frombits since Go has no literal
+// syntax for them. isF32 selects between float32 and float64 emission.
 func floatInitExpr(v float64, isF32 bool) ast.Expr {
-	special := math.IsNaN(v) || math.IsInf(v, 0)
+	special := floatNeedsBitsEmission(v)
 	if isF32 {
 		if special {
 			return &ast.CallExpr{

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -993,13 +993,13 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 		return goConstI64(v.AuxInt), nil
 	case ssa.OpConstF32:
 		f := math.Float32frombits(uint32(v.AuxInt))
-		if (math.IsNaN(float64(f)) || math.IsInf(float64(f), 0)) && em.t != nil {
+		if floatNeedsBitsEmission(float64(f)) && em.t != nil {
 			em.t.UsePackage("math")
 		}
 		return goConstF32(f), nil
 	case ssa.OpConstF64:
 		f := math.Float64frombits(uint64(v.AuxInt))
-		if (math.IsNaN(f) || math.IsInf(f, 0)) && em.t != nil {
+		if floatNeedsBitsEmission(f) && em.t != nil {
 			em.t.UsePackage("math")
 		}
 		return goConstF64(f), nil
@@ -1327,11 +1327,11 @@ func goConstI64(n int64) ast.Expr {
 }
 
 // goConstF32 renders an f32 constant. Finite values are emitted as
-// float32(<lit>); NaN/Inf bits go through math.Float32frombits because
-// Go has no NaN/Inf literal.
+// float32(<lit>); NaN/Inf/-0 bits go through math.Float32frombits because
+// Go has no literal for them (`float32(-0)` is +0).
 func goConstF32(v float32) ast.Expr {
 	bits := math.Float32bits(v)
-	if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+	if floatNeedsBitsEmission(float64(v)) {
 		return &ast.CallExpr{
 			Fun: &ast.SelectorExpr{X: newID("math"), Sel: newID("Float32frombits")},
 			Args: []ast.Expr{
@@ -1349,10 +1349,11 @@ func goConstF32(v float32) ast.Expr {
 	}
 }
 
-// goConstF64 renders an f64 constant. Same NaN/Inf consideration as goConstF32.
+// goConstF64 renders an f64 constant. Same NaN/Inf/-0 consideration as
+// goConstF32.
 func goConstF64(v float64) ast.Expr {
 	bits := math.Float64bits(v)
-	if math.IsNaN(v) || math.IsInf(v, 0) {
+	if floatNeedsBitsEmission(v) {
 		return &ast.CallExpr{
 			Fun: &ast.SelectorExpr{X: newID("math"), Sel: newID("Float64frombits")},
 			Args: []ast.Expr{

--- a/internal/codegen/fixtures_test.go
+++ b/internal/codegen/fixtures_test.go
@@ -111,6 +111,22 @@ var fixtures = []fixture{
 			{export: "call_method", args: []uint64{48, 1}, argTypes: []wasm.ValType{wasm.ValI32, wasm.ValI32}, resType: wasm.ValI32},
 		},
 	},
+	{
+		// Negative-zero float constants: Go has no -0.0 literal, so every
+		// constant-emission path must go through math.Float*frombits for it.
+		name: "cg_negzero.wasm",
+		calls: []call{
+			{export: "f64_negzero_bits", resType: wasm.ValI64},
+			{export: "f32_negzero_bits", resType: wasm.ValI32},
+			{export: "f64_negzero_call_bits", resType: wasm.ValI64},
+			{export: "f32_negzero_call_bits", resType: wasm.ValI32},
+			{export: "global_f64_negzero_bits", resType: wasm.ValI64},
+			{export: "global_f32_negzero_bits", resType: wasm.ValI32},
+			{export: "f64_negzero_mul1_bits", resType: wasm.ValI64},
+			{export: "f64_min_negzero_bits", resType: wasm.ValI64},
+			{export: "f64_nan_payload_bits", resType: wasm.ValI64},
+		},
+	},
 }
 
 func TestFixtures(t *testing.T) {

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -1477,12 +1477,12 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 				}})
 				continue
 			}
-			if fv == 0 {
-				continue // zero value already correct
+			if fv == 0 && !math.Signbit(fv) {
+				continue // zero value already correct (-0 == 0, but is not it)
 			}
-			// NaN/Inf initializers route through math.Float*frombits, so
+			// NaN/Inf/-0 initializers route through math.Float*frombits, so
 			// the math import must be registered for the emitted file.
-			if math.IsNaN(fv) || math.IsInf(fv, 0) {
+			if floatNeedsBitsEmission(fv) {
 				t.use("math")
 			}
 			if g.Type.Type == wasm.ValF32 {

--- a/testdata/cg_negzero.wat
+++ b/testdata/cg_negzero.wat
@@ -1,0 +1,40 @@
+;; cg_negzero.wat — negative-zero float constants. Go has no -0.0 literal
+;; (constant arithmetic is exact, so `float64(-0)` is +0): every constant
+;; and global-initializer path must preserve the sign bit some other way.
+;; Results are observed as raw bits via reinterpret so the fixture harness
+;; compares them exactly.
+(module
+  ;; Constant emitted inside a function body (SSA OpConstF64/OpConstF32).
+  (func (export "f64_negzero_bits") (result i64)
+    (i64.reinterpret_f64 (f64.const -0)))
+  (func (export "f32_negzero_bits") (result i32)
+    (i32.reinterpret_f32 (f32.const -0)))
+
+  ;; The same constants observed through a call, so a folded reinterpret
+  ;; could not mask a broken literal.
+  (func $nz64 (result f64) (f64.const -0))
+  (func $nz32 (result f32) (f32.const -0))
+  (func (export "f64_negzero_call_bits") (result i64)
+    (i64.reinterpret_f64 (call $nz64)))
+  (func (export "f32_negzero_call_bits") (result i32)
+    (i32.reinterpret_f32 (call $nz32)))
+
+  ;; Global initializers: -0 must not be treated as "zero value already
+  ;; correct", and non-zero negatives must keep their sign.
+  (global $gnz64 f64 (f64.const -0))
+  (global $gnz32 f32 (f32.const -0))
+  (func (export "global_f64_negzero_bits") (result i64)
+    (i64.reinterpret_f64 (global.get $gnz64)))
+  (func (export "global_f32_negzero_bits") (result i32)
+    (i32.reinterpret_f32 (global.get $gnz32)))
+
+  ;; -0 must survive arithmetic identities: x*1, x+(-0), min(-0,+0).
+  (func (export "f64_negzero_mul1_bits") (result i64)
+    (i64.reinterpret_f64 (f64.mul (f64.const -0) (f64.const 1))))
+  (func (export "f64_min_negzero_bits") (result i64)
+    (i64.reinterpret_f64 (f64.min (f64.const -0) (f64.const 0))))
+
+  ;; NaN payload constants keep going through the frombits path.
+  (func (export "f64_nan_payload_bits") (result i64)
+    (i64.reinterpret_f64 (f64.const nan:0x123456)))
+)


### PR DESCRIPTION
## Bug

Go has no negative-zero literal — constant arithmetic is exact rational, so `float64(-0)` is `+0`. wasm2go rendered finite float constants as decimal literals, which collapsed `f64.const -0.0` / `f32.const -0.0` to `+0`, in three places:

- `goConstF64` / `goConstF32` (SSA `OpConstF64`/`OpConstF32`): only NaN/Inf went through `math.Float*frombits`; -0 fell into the decimal-literal branch.
- `floatInitExpr` (float global initializers): same.
- The global-initializer zero-skip in `translate.go`: `if fv == 0 { continue }` is true for -0 (`-0.0 == 0`), so a `-0`-initialized global silently kept the +0 zero value.

Found by go-spidermonkey's test262 run: SpiderMonkey's `CharsToNumber`, fdlibm `atan2`, and `Math.sumPrecise` return the constant `-0.0`, so `Object.is(Number("-0"), -0)` was `false` in the translated engine, and `Math.atan2(-1, Infinity)` / `Math.sumPrecise([-0])` returned `+0`.

## Fix

A shared predicate `floatNeedsBitsEmission` (NaN, ±Inf, or -0) now routes all three sites through the existing `math.Float{32,64}frombits` emission, and the zero-skip only skips +0. The gcasm backend inherits the fix because it compiles the generated Go source and captures the compiler's assembly.

## Verification

- New fixture `testdata/cg_negzero.wat` observes the constants as raw bits (`i64.reinterpret_f64`) through four paths — direct constant, through a call, global initializer, arithmetic identities — plus a NaN-payload constant. It fails against the wazero reference before the fix (`got 0, want -9223372036854775808`) and passes after.
- Also added to the compile matrix (`allFixtures`).
- `go test ./...` exit 0 (codegen 66.7s, gcasm 70.9s, transpile 13.8s — full suite, this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
