### PR TITLE
ssa: accept bool-typed br_table selectors

### DIFF
--- a/internal/codegen/fixtures_test.go
+++ b/internal/codegen/fixtures_test.go
@@ -112,6 +112,16 @@ var fixtures = []fixture{
 		},
 	},
 	{
+		// br_table selecting on a comparison result (SSA type bool): must
+		// verify and route 0/1 correctly. Mirrors SpiderMonkey's Intl build.
+		name: "cg_brtable_bool.wasm",
+		calls: []call{
+			{export: "pick", args: []uint64{3}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI32},
+			{export: "pick", args: []uint64{5}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI32},
+			{export: "pick", args: []uint64{9}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI32},
+		},
+	},
+	{
 		// Negative-zero float constants: Go has no -0.0 literal, so every
 		// constant-emission path must go through math.Float*frombits for it.
 		name: "cg_negzero.wasm",

--- a/internal/codegen/fixtures_test.go
+++ b/internal/codegen/fixtures_test.go
@@ -112,6 +112,24 @@ var fixtures = []fixture{
 		},
 	},
 	{
+		// Negative zero flowing through non-constant shapes (locals, block
+		// results, phis, select, data segments, arithmetic).
+		name: "cg_negzero_flows.wasm",
+		calls: []call{
+			{export: "via_local", resType: wasm.ValI64},
+			{export: "via_block", resType: wasm.ValI64},
+			{export: "via_phi", args: []uint64{1}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI64},
+			{export: "via_select", args: []uint64{1}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI64},
+			{export: "via_copysign_cc", resType: wasm.ValI64},
+			{export: "via_copysign_cv", resType: wasm.ValI64},
+			{export: "via_copysign_vc", resType: wasm.ValI64},
+			{export: "via_neg_zero", resType: wasm.ValI64},
+			{export: "via_load", resType: wasm.ValI64},
+			{export: "via_add", resType: wasm.ValI64},
+			{export: "via_mul_neg1", resType: wasm.ValI64},
+		},
+	},
+	{
 		// br_table selecting on a comparison result (SSA type bool): must
 		// verify and route 0/1 correctly. Mirrors SpiderMonkey's Intl build.
 		name: "cg_brtable_bool.wasm",

--- a/internal/ssa/verify.go
+++ b/internal/ssa/verify.go
@@ -88,7 +88,12 @@ func Verify(f *Func) error {
 			if b.Control == nil {
 				return fmt.Errorf("verify %s: BrTable b%d has nil Control", f.Name, b.ID)
 			}
-			if b.Control.Type != TypeI32 {
+			// TypeBool is a comparison result: wasm leaves those as i32
+			// 0/1 and may br_table on them directly (SpiderMonkey's Intl
+			// build does, Fn7964). The emitter always materializes bool
+			// values through b2i32, so a bool selector emits as a plain
+			// i32 switch operand.
+			if b.Control.Type != TypeI32 && b.Control.Type != TypeBool {
 				return fmt.Errorf("verify %s: BrTable b%d selector v%d has type %v (want i32)",
 					f.Name, b.ID, b.Control.ID, b.Control.Type)
 			}

--- a/testdata/cg_brtable_bool.wat
+++ b/testdata/cg_brtable_bool.wat
@@ -1,0 +1,14 @@
+;; cg_brtable_bool.wat — br_table whose selector is a comparison result.
+;; wasm comparisons leave i32 0/1 on the stack, so this is valid wasm, but
+;; wasm2go's SSA types comparisons as bool; the BrTable verifier must accept
+;; that (emitters always materialize bool values via b2i32, i.e. as i32).
+;; Shape found in SpiderMonkey's with-Intl build (Fn7964).
+(module
+  (func (export "pick") (param i32) (result i32)
+    (block $b2
+      (block $b1
+        (block $b0
+          (br_table $b0 $b1 $b2 (i32.ge_u (local.get 0) (i32.const 5))))
+        (return (i32.const 10)))
+      (return (i32.const 20)))
+    (i32.const 30)))

--- a/testdata/cg_negzero_flows.wat
+++ b/testdata/cg_negzero_flows.wat
@@ -1,0 +1,38 @@
+;; cg_negzero_flows.wat — negative zero flowing through non-constant shapes:
+;; locals, block results, phi merges, select, and a data segment. Hunts the
+;; path that still loses -0 in SpiderMonkey's Math.sumPrecise after the
+;; f64.const fix (observed on BOTH backends).
+(module
+  (memory (export "memory") 1)
+  (data (i32.const 8) "\00\00\00\00\00\00\00\80")   ;; -0.0 le bytes
+  (func (export "via_local") (result i64)
+    (local f64)
+    (local.set 0 (f64.const -0))
+    (i64.reinterpret_f64 (local.get 0)))
+  (func (export "via_block") (result i64)
+    (i64.reinterpret_f64 (block (result f64) (f64.const -0))))
+  (func (export "via_phi") (param i32) (result i64)
+    (local f64)
+    (if (local.get 0)
+      (then (local.set 1 (f64.const -0)))
+      (else (local.set 1 (f64.const 1))))
+    (i64.reinterpret_f64 (local.get 1)))
+  (func (export "via_select") (param i32) (result i64)
+    (i64.reinterpret_f64
+      (select (f64.const -0) (f64.const 2) (local.get 0))))
+  (func (export "via_copysign_cc") (result i64)
+    (i64.reinterpret_f64 (f64.copysign (f64.const 0) (f64.const -1))))
+  (func (export "via_copysign_cv") (result i64)
+    ;; sign source is a runtime -0 built by neg, not a parameter
+    (i64.reinterpret_f64 (f64.copysign (f64.const 0) (f64.neg (f64.const 0)))))
+  (func (export "via_copysign_vc") (result i64)
+    (i64.reinterpret_f64 (f64.copysign (f64.const 0) (f64.const -1))))
+  (func (export "via_neg_zero") (result i64)
+    (i64.reinterpret_f64 (f64.neg (f64.const 0))))
+  (func (export "via_load") (result i64)
+    (i64.reinterpret_f64 (f64.load (i32.const 8))))
+  (func (export "via_add") (result i64)
+    (i64.reinterpret_f64 (f64.add (f64.const -0) (f64.const -0))))
+  (func (export "via_mul_neg1") (result i64)
+    (i64.reinterpret_f64 (f64.mul (f64.const 0) (f64.const -1))))
+)


### PR DESCRIPTION
## Bug

SpiderMonkey's with-Intl build (7,964 functions) is untranslatable: its `Fn7964` does `br_table` on a comparison result. wasm comparisons leave i32 0/1 on the stack, so that is valid wasm — but wasm2go's SSA types comparison results as `TypeBool`, and the BrTable verifier required `TypeI32`:

```
ssa lowering: unsupported wasm feature: verify Fn7964: BrTable b1936 selector v13429 has type bool (want i32)
```

## Fix

Accept `TypeBool` selectors in the verifier. That is the entire fix: the emitter already materializes every bool value through `b2i32`, so a bool selector emits as a plain i32 switch operand and the 0/1 cases route exactly as wasm semantics require.

## Verification

- New fixture `cg_negzero_flows.wat` rides along (documents that -0 flows through locals/phi/select/copysign/loads emit correctly — groundwork for the remaining engine-shape-dependent -0 hunt).
- New fixture `cg_brtable_bool.wat` reproduces the exact failure in 15 lines; fails before the fix, passes after (differential vs wazero: selectors 0/1 route to the right arms).
- `go test ./...` exit 0.
- **Canonical-pipeline e2e**: a `protoc-gen-wasmify-go` built against this branch translated the full with-Intl SpiderMonkey (previously impossible), and the resulting bundle wired into go-spidermonkey passes its full suite plus the Intl/Temporal/SAB/modules/NUL e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
