### PR TITLE
threads: atomics + wasi-threads (a wasm thread is a goroutine)

### DIFF
--- a/internal/codegen/cg_matrix_test.go
+++ b/internal/codegen/cg_matrix_test.go
@@ -100,6 +100,7 @@ var allFixtures = []string{
 	"cg_indirect.wasm",
 	"cg_specialfp.wasm",
 	"cg_negzero.wasm",
+	"cg_atomics.wasm",
 	"cg_globals.wasm",
 	"cg_globals_nan.wasm",
 	"cg_misc.wasm",

--- a/internal/codegen/cg_threads_test.go
+++ b/internal/codegen/cg_threads_test.go
@@ -1,0 +1,206 @@
+package codegen_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// TestThreads drives cg_threads.wasm, whose guest spawns real agents through
+// wasi thread-spawn, has them bump a counter with atomics on shared memory and
+// notify, and joins them with memory.atomic.wait. wazero cannot be the
+// reference here (its threads support has no wasi-threads host), so the
+// expectations are the wasm's own deterministic semantics.
+//
+// The generated program is compiled and run with the race detector, which is
+// the real assertion: a wasm thread is a goroutine, so any unsynchronised
+// access to the shared linear memory — above all a grow that relocated it —
+// surfaces as a race, not as a flake.
+func TestThreadsVisibility(t *testing.T) {
+	// A plain store published by an atomic store must be visible to a
+	// goroutine-agent that acquires via an atomic load — the mutex fast-path
+	// pattern every C critical section relies on.
+	bin := testfixture.Wasm(t, "cg_threads_visibility.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	main := "package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n\tfmt.Println(m.Run())\n}\n"
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	if strings.TrimSpace(got) != "4242" {
+		t.Errorf("cross-thread plain-store visibility: got %q, want 4242", got)
+	}
+}
+
+func TestThreadsMainToAgentWake(t *testing.T) {
+	// The main thread notifies a parked agent — the direction a C mutex
+	// handoff uses when main unlocks while an agent sleeps on the futex.
+	bin := testfixture.Wasm(t, "cg_threads_wake_dir.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	main := "package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n\tfmt.Println(m.Run())\n}\n"
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	if strings.TrimSpace(got) != "7777" {
+		t.Errorf("main->agent wake: got %q, want 7777", got)
+	}
+}
+
+func TestThreadsMutexHandoff(t *testing.T) {
+	// Two threads hammer a Drepper futex mutex 50k times each; a lost
+	// waiter-bit observation wedges one side forever.
+	bin := testfixture.Wasm(t, "cg_threads_mutex.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	main := "package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n\tfmt.Println(m.Run())\n}\n"
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	if strings.TrimSpace(got) != "100000" {
+		t.Errorf("mutex handoff: got %q, want 100000", got)
+	}
+}
+
+func TestThreadsMuslLock(t *testing.T) {
+	// musl's 2-int __lock/__unlock: the unlock side reads the waiters counter
+	// with a PLAIN load to decide whether to notify. Preserving wasm's
+	// coherent-plain-access semantics across goroutines is what keeps
+	// wasi-libc's malloc/stdio/internal locks from stranding threads.
+	bin := testfixture.Wasm(t, "cg_threads_musl_lock.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	main := "package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n\tfmt.Println(m.Run())\n}\n"
+	// No -race here: wasm's shared-memory model makes plain cross-agent
+	// access a LEGAL race (coherent, tear-free words); Go's detector would
+	// flag every such access. The assertion is completion + the exact count.
+	got := runGoSnippetNoRace(t, buf.String(), main, res.Sidecars, res.Files)
+	if strings.TrimSpace(got) != "100000" {
+		t.Errorf("musl lock handoff: got %q, want 100000", got)
+	}
+}
+
+func TestThreads(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_threads.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+
+	main := `package main
+
+import (
+	"fmt"
+	"gentest/pkg"
+)
+
+func main() {
+	// The only wasi import (thread-spawn) is goroutine-backed and internal,
+	// so the generated constructor takes no host parameters at all.
+	m := pkg.New()
+	// 8 agents, each +1 on the counter, joined through atomic wait/notify.
+	fmt.Printf("joined -> %d\n", m.SpawnAndJoin(8))
+	// Growing a shared memory must preserve both contents and pointers:
+	// 2 pages * 65536 + 0xbeef = 131072 + 48879.
+	fmt.Printf("grown -> %d\n", m.GrowShared())
+}
+`
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	want := "joined -> 8\ngrown -> 179951\n"
+	if got != want {
+		t.Errorf("output mismatch\n--want--\n%s\n--got--\n%s", want, got)
+	}
+	if strings.Contains(got, "DATA RACE") {
+		t.Errorf("race detected:\n%s", got)
+	}
+}
+
+// runGoSnippetNoRace runs the generated program without the race detector —
+// for wasm whose SHARED-memory plain accesses are legal wasm races that the
+// Go detector would (correctly, but unhelpfully) flag.
+func runGoSnippetNoRace(t *testing.T, generated, mainSrc string, sidecars map[string][]byte, auxFiles map[string][]byte) string {
+	t.Helper()
+	return runGoSnippetThreads(t, generated, mainSrc, sidecars, auxFiles, false)
+}
+
+// runGoSnippetRaceDetector is runGoSnippetWithAux with -race: a wasm thread is
+// a goroutine, so the detector is the assertion that the shared-memory model
+// (fixed slice header, atomic memSize, relocation-free grow) actually holds.
+func runGoSnippetRaceDetector(t *testing.T, generated, mainSrc string, sidecars map[string][]byte, auxFiles map[string][]byte) string {
+	t.Helper()
+	return runGoSnippetThreads(t, generated, mainSrc, sidecars, auxFiles, true)
+}
+
+func runGoSnippetThreads(t *testing.T, generated, mainSrc string, sidecars map[string][]byte, auxFiles map[string][]byte, race bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module gentest\n\ngo 1.25.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "pkg"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pkg", "gen.go"), []byte(generated), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, set := range []map[string][]byte{sidecars, auxFiles} {
+		for name, data := range set {
+			p := filepath.Join(dir, "pkg", name)
+			if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, stripPureGuard(data), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainSrc), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runArgs := []string{"run"}
+	if race {
+		runArgs = append(runArgs, "-race")
+	}
+	runArgs = append(runArgs, ".")
+	cmd := exec.Command("go", runArgs...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed: %v\noutput:\n%s\ngenerated:\n%s", err, out, generated)
+	}
+	return string(out)
+}

--- a/internal/codegen/emit_memops.go
+++ b/internal/codegen/emit_memops.go
@@ -72,11 +72,44 @@ func (em *ssaEmitter) emitMemLoadExpr(v *ssa.Value, emitExpr func(*ssa.Value) (a
 	if err != nil {
 		return nil, err
 	}
-	expr := em.unsafeDerefExpr(spec, baseExpr, uint64(v.AuxInt))
+	var expr ast.Expr
+	if em.t != nil && em.t.memIsShared() {
+		// SHARED memory: another agent's stores must stay visible to plain
+		// reads — wasm gives non-atomic accesses hardware-like coherence,
+		// but the Go compiler is free to CSE or hoist an ordinary *ptr
+		// read (musl's __lock/__unlock decides whether to WAKE a futex
+		// waiter from a plain read of the waiters word; a cached read
+		// skips the wake and strands the waiter forever). Route the read
+		// through a //go:noinline helper so every executed load really
+		// touches memory; the CPU's coherence does the rest. Non-shared
+		// modules keep the direct dereference.
+		expr = em.sharedLoadExpr(spec, baseExpr, uint64(v.AuxInt))
+	} else {
+		expr = em.unsafeDerefExpr(spec, baseExpr, uint64(v.AuxInt))
+	}
 	if spec.outerCast != "" {
 		expr = &ast.CallExpr{Fun: newID(spec.outerCast), Args: []ast.Expr{expr}}
 	}
 	return expr, nil
+}
+
+// sharedLoadExpr renders `memLoad<T>(mBase, uintptr(ea))` — the
+// noinline-helper form of unsafeDerefExpr used for shared memories.
+func (em *ssaEmitter) sharedLoadExpr(spec memOpSpec, baseExpr ast.Expr, offset uint64) ast.Expr {
+	helper := map[string]string{
+		"uint8": "memLoad8", "int8": "memLoad8S",
+		"uint16": "memLoad16", "int16": "memLoad16S",
+		"uint32": "memLoad32U", "int32": "memLoad32",
+		"int64":   "memLoad64",
+		"float32": "memLoadF32", "float64": "memLoadF64",
+	}[spec.elemType]
+	em.useHelper(helper)
+	return &ast.CallExpr{
+		Fun: em.helperRef(helper),
+		Args: []ast.Expr{newID("m"), &ast.CallExpr{
+			Fun: newID("uint32"), Args: []ast.Expr{em.memOffsetExpr(baseExpr, offset)},
+		}},
+	}
 }
 
 // emitMemStoreStmt renders an OpStore* as one assignment statement:
@@ -104,6 +137,31 @@ func (em *ssaEmitter) emitMemStoreStmt(v *ssa.Value, emitExpr func(*ssa.Value) (
 	valExpr, err := emitExpr(v.Args[1])
 	if err != nil {
 		return nil, err
+	}
+	if em.t != nil && em.t.memIsShared() {
+		rhs := valExpr
+		if spec.elemType != spec.valSrcType {
+			// The helpers take 32-bit-or-wider values (gcasm marshalling
+			// vocabulary); sub-word truncation happens inside the helper.
+			castTo := spec.elemType
+			if castTo == "uint8" || castTo == "uint16" {
+				castTo = "uint32"
+			}
+			rhs = &ast.CallExpr{Fun: newID(castTo), Args: []ast.Expr{rhs}}
+		}
+		helper := map[string]string{
+			"uint8": "memStore8", "uint16": "memStore16",
+			"uint32": "memStore32U", "int32": "memStore32",
+			"int64":   "memStore64",
+			"float32": "memStoreF32", "float64": "memStoreF64",
+		}[spec.elemType]
+		em.useHelper(helper)
+		return &ast.ExprStmt{X: &ast.CallExpr{
+			Fun: em.helperRef(helper),
+			Args: []ast.Expr{newID("m"), &ast.CallExpr{
+				Fun: newID("uint32"), Args: []ast.Expr{em.memOffsetExpr(baseExpr, uint64(v.AuxInt))},
+			}, rhs},
+		}}, nil
 	}
 	dst := em.unsafeDerefExpr(spec, baseExpr, uint64(v.AuxInt))
 	rhs := valExpr

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -71,7 +71,10 @@ func (em *ssaEmitter) emitFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
 	// that ever relocate the backing array — re-read it. The refresh
 	// statements are inserted by both block emitters right after each
 	// such value; see maybeMemBaseRefresh.
-	em.memBaseHoisted = funcTouchesMemory(f)
+	// Shared memories route plain accesses through module-aware helpers
+	// (no raw base pointer at the access site), so hoisting mBase would
+	// only leave an unused local behind.
+	em.memBaseHoisted = funcTouchesMemory(f) && (em.t == nil || !em.t.memIsShared())
 
 	// EH in multi-package output: the wasmExc type + wasm_catch helper live in
 	// the base package (exported as WasmExc / Wasm_catch); the generated body
@@ -1034,6 +1037,23 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 		return em.emitCallIndirect(v, emit)
 	case ssa.OpHelperCall:
 		return em.emitHelperCall(v, emit)
+	case ssa.OpAtomicCall:
+		// Module-aware helper: helper(m, args...). The helpers live with
+		// memoryCopy et al and go through useHelper/helperRef.
+		name, ok := v.Aux.(string)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("ssa emit: OpAtomicCall without name aux")
+		}
+		em.useHelper(name)
+		args := []ast.Expr{newID("m")}
+		for _, a := range v.Args {
+			e, err := emit(a)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, e)
+		}
+		return &ast.CallExpr{Fun: em.helperRef(name), Args: args}, nil
 	case ssa.OpMemSize:
 		em.useHelper("memorySize")
 		return &ast.CallExpr{Fun: em.helperRef("memorySize"), Args: []ast.Expr{newID("m")}}, nil
@@ -1156,14 +1176,29 @@ func (em *ssaEmitter) emitSideEffectStmt(v *ssa.Value, emit func(*ssa.Value) (as
 			Fun:  em.helperRef("memoryFill"),
 			Args: []ast.Expr{newID("m"), dst, val, n},
 		}}, nil
-	case ssa.OpMemoryInit, ssa.OpDataDrop:
-		// Bulk-memory data-segment ops are not yet implemented; the
-		// generator emits a panic-stub so any caller hitting this at
-		// runtime fails loudly rather than silently producing wrong
-		// behaviour.
+	case ssa.OpMemoryInit:
+		em.useHelper("memoryInit")
+		dst, err := emit(v.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		src, err := emit(v.Args[1])
+		if err != nil {
+			return nil, err
+		}
+		n, err := emit(v.Args[2])
+		if err != nil {
+			return nil, err
+		}
 		return &ast.ExprStmt{X: &ast.CallExpr{
-			Fun:  newID("panic"),
-			Args: []ast.Expr{stringLit(fmt.Sprintf("wasm2go: %v not implemented", v.Op))},
+			Fun:  em.helperRef("memoryInit"),
+			Args: []ast.Expr{newID("m"), intLit(v.AuxInt), dst, src, n},
+		}}, nil
+	case ssa.OpDataDrop:
+		em.useHelper("dataDrop")
+		return &ast.ExprStmt{X: &ast.CallExpr{
+			Fun:  em.helperRef("dataDrop"),
+			Args: []ast.Expr{newID("m"), intLit(v.AuxInt)},
 		}}, nil
 	}
 	expr, err := em.emitOp(v, emit)
@@ -1223,6 +1258,23 @@ func (em *ssaEmitter) emitCallImport(v *ssa.Value, emit func(*ssa.Value) (ast.Ex
 		return nil, fmt.Errorf("ssa emit: CallImport needs translator binding")
 	}
 	imp := em.t.Module().Imports[v.AuxInt]
+	// wasi-threads: thread-spawn is not a host call at all — a wasm thread is
+	// a goroutine, so it lowers to the threadSpawn helper, which starts the
+	// guest's own wasi_thread_start on one. Keeping it out of the host
+	// interface means an embedder gets threads without implementing anything.
+	if imp.Module == "wasi" && imp.Name == "thread-spawn" ||
+		imp.Module == "wasi_snapshot_preview1" && imp.Name == "thread_spawn" {
+		em.useHelper("threadSpawn")
+		args := []ast.Expr{newID("m")}
+		for _, a := range v.Args {
+			ae, err := emit(a)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, ae)
+		}
+		return &ast.CallExpr{Fun: em.helperRef("threadSpawn"), Args: args}, nil
+	}
 	args := []ast.Expr{newID("m")}
 	for _, a := range v.Args {
 		ae, err := emit(a)

--- a/internal/codegen/fixtures_test.go
+++ b/internal/codegen/fixtures_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goccy/wasm2go/internal/wasm"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
 )
 
 // u32 packs a signed int32 into the low bits of a uint64 (wazero call ABI).
@@ -30,6 +31,9 @@ type call struct {
 type fixture struct {
 	name  string
 	calls []call
+	// threads enables wazero's experimental threads feature for the
+	// reference run (shared memories + atomics).
+	threads bool
 }
 
 var fixtures = []fixture{
@@ -130,6 +134,35 @@ var fixtures = []fixture{
 		},
 	},
 	{
+		// Passive data segments (the shape LLVM emits for every shared-memory
+		// build): a start function memory.inits them, data.drop discards, a
+		// dropped segment traps on re-init but tolerates n == 0.
+		name:    "cg_passive_data.wasm",
+		threads: true,
+		calls: []call{
+			{export: "read_at", args: []uint64{16}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI32},
+			{export: "read_at", args: []uint64{21}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI32},
+			{export: "read_at", args: []uint64{27}, argTypes: []wasm.ValType{wasm.ValI32}, resType: wasm.ValI32},
+			{export: "reinit_zero_len"},
+		},
+	},
+	{
+		// Threads-proposal atomics in a single agent: loads/stores, every
+		// RMW family incl. subword lanes, cmpxchg, fence, wait/notify.
+		name:    "cg_atomics.wasm",
+		threads: true,
+		calls: []call{
+			{export: "rmw32", resType: wasm.ValI32},
+			{export: "rmw64", resType: wasm.ValI64},
+			{export: "xchg", resType: wasm.ValI32},
+			{export: "cmpxchg", resType: wasm.ValI32},
+			{export: "subword", resType: wasm.ValI32},
+			{export: "subword_cmpxchg", resType: wasm.ValI32},
+			{export: "wait_notify", resType: wasm.ValI32},
+			{export: "fenced_load", resType: wasm.ValI32},
+		},
+	},
+	{
 		// br_table selecting on a comparison result (SSA type bool): must
 		// verify and route 0/1 correctly. Mirrors SpiderMonkey's Intl build.
 		name: "cg_brtable_bool.wasm",
@@ -172,7 +205,11 @@ func runFixture(t *testing.T, fx fixture) {
 
 	// Reference: wazero.
 	ctx := context.Background()
-	r := wazero.NewRuntime(ctx)
+	cfg := wazero.NewRuntimeConfig()
+	if fx.threads {
+		cfg = cfg.WithCoreFeatures(api.CoreFeaturesV2 | experimental.CoreFeaturesThreads)
+	}
+	r := wazero.NewRuntimeWithConfig(ctx, cfg)
 	t.Cleanup(func() {
 		if err := r.Close(ctx); err != nil {
 			t.Errorf("wazero runtime close: %v", err)

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -6,11 +6,14 @@
 package helpers
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 	"math/bits"
 	"runtime"
 	"sync"
+	"sync/atomic"
+	"time"
 	"unsafe"
 )
 
@@ -28,7 +31,40 @@ type Module struct {
 	// writers — see memoryGrow and accessMemory. Generated output
 	// declares the same field at the END of its Module struct so the
 	// memory/maxMem/M offsets the asm hardcodes stay put.
-	memMu sync.Mutex
+	//
+	// memMu/memSize/threads are POINTERS because a wasi-threads agent runs
+	// on a struct COPY of the Module: wasm's threads model shares the memory
+	// but gives every agent its own GLOBALS (the stack pointer above all —
+	// two agents sharing one SP global scribble over each other's stacks).
+	// A struct copy duplicates the global fields; the pointered state stays
+	// genuinely shared.
+	memMu *sync.Mutex
+	// memSize is the size the guest sees, in bytes — the single source of
+	// truth for memory.size, growth and every bounds check. For a shared
+	// memory the slice header stays fixed at the declared maximum and this
+	// is the only thing growth moves.
+	memSize *atomic.Uint64
+	// memShared records that the memory was declared shared (threads).
+	memShared bool
+	// dataSegs holds passive data segments by original index (nil = active
+	// or dropped); memory.init copies out of them, data.drop nils them.
+	dataSegs [][]byte
+	// dataEnd is the highest offset any memory.init has written to — the end
+	// of the data segments, which is where BSS begins. Learned at run time
+	// (see memoryInit) because the offsets are wasm constants the host never
+	// sees otherwise. An embedding that shares an initialized memory image
+	// needs it: the image may carry everything BELOW this line and must carry
+	// zeros above it. Zero until the start section has run.
+	dataEnd uint32
+	// threadStart runs the guest's wasi_thread_start export. New() assigns it
+	// when the wasm exports one. A field (not an interface assertion on the
+	// Module) because multi-package output emits exports as FREE FUNCTIONS in
+	// the main package — there is no method for an assertion to find, and
+	// base cannot import the main package to call it directly. It takes the
+	// Module explicitly so threadSpawn can hand the AGENT'S clone to it.
+	threadStart func(m *Module, tid int32, arg int32)
+	// threads tracks agents spawned through wasi_thread_spawn.
+	threads *threadPool
 }
 
 // ----- Opaque identity helpers ---------------------------------------------
@@ -101,6 +137,9 @@ func wasm_trap_memfill_oob() { panic("wasm: memory.fill out of bounds") }
 
 //go:noinline
 func wasm_trap_memcopy_oob() { panic("wasm: memory.copy out of bounds") }
+
+//go:noinline
+func wasm_trap_meminit_oob() { panic("wasm: memory.init out of bounds") }
 
 // ----- Exception handling (EH proposal / setjmp-longjmp) --------------------
 //
@@ -757,7 +796,7 @@ func b32(b bool) int32 {
 // memorySize returns the current size of m.memory in wasm pages (each
 // page is 64 KiB).
 func memorySize(m *Module) int32 {
-	return int32(len(m.memory) >> 16)
+	return int32(m.memSize.Load() >> 16)
 }
 
 // memoryGrow grows m.memory by n wasm pages (64 KiB each). Returns the
@@ -772,28 +811,35 @@ func memorySize(m *Module) int32 {
 // capacity makes the common grow a zero-copy reslice and amortizes the
 // reallocations to O(n).
 func memoryGrow(m *Module, n int32) int32 {
-	// The slice-header rewrite below (and the backing-array relocation
-	// on the slow path) must not run concurrently with an out-of-band
-	// accessMemory: a host goroutine writing through the old header
-	// mid-relocation would land its write in the abandoned array. The
-	// guest's own loads/stores never take this lock — only grow does,
-	// so the hot memory path is unaffected and the cost is one
-	// uncontended lock per memory.grow call.
+	// Serialise growers against each other and against out-of-band
+	// accessMemory. Guest loads/stores never take this lock.
 	m.memMu.Lock()
 	defer m.memMu.Unlock()
-	prev := int32(len(m.memory) >> 16)
+	cur := m.memSize.Load()
+	prev := int32(cur >> 16)
 	if n == 0 {
 		return prev
 	}
 	if n < 0 {
 		return -1
 	}
-	want := uint64(len(m.memory)) + uint64(n)*65536
+	want := cur + uint64(n)*65536
 	if m.maxMem != 0 && want > m.maxMem {
 		return -1
 	}
 	if want > 1<<32 {
 		return -1
+	}
+	if m.memShared {
+		// The backing array already spans the declared maximum (New
+		// reserved it; untouched pages are not resident). Growth is a
+		// single atomic store: no copy, no reslice, and above all no
+		// relocation — other agents hold m.M and deref it concurrently.
+		if want > uint64(len(m.memory)) {
+			return -1
+		}
+		m.memSize.Store(want)
+		return prev
 	}
 	if want <= uint64(cap(m.memory)) {
 		// Spare capacity already covers the new size. The bytes in
@@ -801,6 +847,7 @@ func memoryGrow(m *Module, n int32) int32 {
 		// allocated and are unreachable until now, so the freshly
 		// exposed pages are correctly zero — no copy, no clear.
 		m.memory = m.memory[:want]
+		m.memSize.Store(want)
 		return prev
 	}
 	// Reallocate with at least double the current capacity so the next
@@ -818,6 +865,7 @@ func memoryGrow(m *Module, n int32) int32 {
 	grown := make([]byte, want, newCap)
 	copy(grown, m.memory)
 	m.memory = grown
+	m.memSize.Store(want)
 	// Reallocate moved the backing array, so the cached m.M pointer
 	// is now stale. Reslice grows (the early-return path above) leave
 	// the data pointer untouched so don't need this refresh.
@@ -1036,12 +1084,156 @@ func i64_extend32_s(x int64) int64 { return int64(int32(x)) }
 // builtins are far faster than a byte loop and propagate the same
 // out-of-bounds trap shape (via runtime panic) that the spec demands.
 
+// memoryInit implements memory.init: copy n bytes from passive data segment
+// seg at src into memory at dst. Out-of-bounds on either side traps, as does
+// naming a dropped (or active) segment with n > 0. The bounds check consults
+// memSize (not len(m.M)) so a shared memory's reserved-but-ungrown tail stays
+// out of reach, mirroring memoryFill/memoryCopy.
+// Shared-memory plain access helpers. wasm's threads memory model gives
+// NON-atomic loads/stores hardware-like coherence between agents; Go's
+// compiler, free of any such contract, may CSE or hoist a plain *ptr access
+// (musl's __unlock skips the futex wake when its plain read of the waiters
+// word looks stale — stranding the waiter forever). noinline forces every
+// executed access to really touch memory; CPU cache coherence supplies the
+// cross-goroutine freshness, exactly as it does for native threads.
+//
+// Signatures stick to the gcasm marshaller's vocabulary (int32/uint32/
+// int64/float32/float64 plus *Module): sub-word widths are widened here,
+// not at the call site.
+//
+//go:noinline
+func memLoad8(m *Module, ea uint32) uint32 {
+	return uint32(*(*uint8)(unsafe.Add(m.M, uintptr(ea))))
+}
+
+//go:noinline
+func memLoad8S(m *Module, ea uint32) int32 {
+	return int32(*(*int8)(unsafe.Add(m.M, uintptr(ea))))
+}
+
+//go:noinline
+func memLoad16(m *Module, ea uint32) uint32 {
+	return uint32(*(*uint16)(unsafe.Add(m.M, uintptr(ea))))
+}
+
+//go:noinline
+func memLoad16S(m *Module, ea uint32) int32 {
+	return int32(*(*int16)(unsafe.Add(m.M, uintptr(ea))))
+}
+
+//go:noinline
+func memLoad32(m *Module, ea uint32) int32 {
+	return *(*int32)(unsafe.Add(m.M, uintptr(ea)))
+}
+
+//go:noinline
+func memLoad32U(m *Module, ea uint32) uint32 {
+	return *(*uint32)(unsafe.Add(m.M, uintptr(ea)))
+}
+
+//go:noinline
+func memLoad64(m *Module, ea uint32) int64 {
+	return *(*int64)(unsafe.Add(m.M, uintptr(ea)))
+}
+
+//go:noinline
+func memLoadF32(m *Module, ea uint32) float32 {
+	return *(*float32)(unsafe.Add(m.M, uintptr(ea)))
+}
+
+//go:noinline
+func memLoadF64(m *Module, ea uint32) float64 {
+	return *(*float64)(unsafe.Add(m.M, uintptr(ea)))
+}
+
+//go:noinline
+func memStore8(m *Module, ea uint32, v uint32) {
+	*(*uint8)(unsafe.Add(m.M, uintptr(ea))) = uint8(v)
+}
+
+//go:noinline
+func memStore16(m *Module, ea uint32, v uint32) {
+	*(*uint16)(unsafe.Add(m.M, uintptr(ea))) = uint16(v)
+}
+
+//go:noinline
+func memStore32(m *Module, ea uint32, v int32) {
+	*(*int32)(unsafe.Add(m.M, uintptr(ea))) = v
+}
+
+//go:noinline
+func memStore32U(m *Module, ea uint32, v uint32) {
+	*(*uint32)(unsafe.Add(m.M, uintptr(ea))) = v
+}
+
+//go:noinline
+func memStore64(m *Module, ea uint32, v int64) {
+	*(*int64)(unsafe.Add(m.M, uintptr(ea))) = v
+}
+
+//go:noinline
+func memStoreF32(m *Module, ea uint32, v float32) {
+	*(*float32)(unsafe.Add(m.M, uintptr(ea))) = v
+}
+
+//go:noinline
+func memStoreF64(m *Module, ea uint32, v float64) {
+	*(*float64)(unsafe.Add(m.M, uintptr(ea))) = v
+}
+
+//go:noinline
+func memoryInit(m *Module, seg int, dst int32, src int32, n int32) {
+	data := m.dataSegs[seg]
+	if n == 0 {
+		return
+	}
+	if data == nil ||
+		uint64(uint32(src))+uint64(uint32(n)) > uint64(len(data)) ||
+		uint64(uint32(dst))+uint64(uint32(n)) > m.memSize.Load() {
+		wasm_trap_meminit_oob()
+	}
+	// Record where the data segments land. The END of that region is where BSS
+	// begins, and an embedding sharing an initialized memory image has to know
+	// it: the image may carry the data segments (identical everywhere) but must
+	// NOT carry BSS (the start section's "already ran" flag and the C++ static
+	// state — inheriting either is fatal). The offsets are only known here, at
+	// the memory.init that installs them.
+	if end := uint32(dst) + uint32(n); end > m.dataEnd {
+		m.dataEnd = end
+	}
+	d := m.memory[uint32(dst) : uint32(dst)+uint32(n)]
+	s := data[uint32(src) : uint32(src)+uint32(n)]
+	// Write only what differs. An embedding may hand New a linear memory that
+	// ALREADY holds this segment — a copy-on-write map of an image shared by
+	// every instance (the data segments of a big engine run to tens of MB and
+	// are identical everywhere). Copying identical bytes over it would fault a
+	// private copy of every page and throw the sharing away; comparing only
+	// reads, so the pages stay shared. When the memory is blank, as it is for
+	// an ordinary instance, the compare fails immediately and this costs
+	// nothing measurable against the copy that follows.
+	if bytes.Equal(d, s) {
+		return
+	}
+	copy(d, s)
+}
+
+// dataDrop implements data.drop: discard passive segment seg. A later
+// memory.init naming it traps (nil view); double-drop is a no-op per spec.
+// dataDrop stays out of line: inlined into a gcasm-transformed function, the
+// pointer write (a nil store into dataSegs) would drag runtime.gcWriteBarrier
+// into the asm body, which the transformer rejects.
+//
+//go:noinline
+func dataDrop(m *Module, seg int) {
+	m.dataSegs[seg] = nil
+}
+
 func memoryFill(m *Module, dst int32, val int32, n int32) {
 	if n == 0 {
 		return
 	}
 	end := uint64(uint32(dst)) + uint64(uint32(n))
-	if end > uint64(len(m.memory)) {
+	if end > m.memSize.Load() {
 		wasm_trap_memfill_oob()
 	}
 	b := m.memory[uint32(dst):uint32(end)]
@@ -1070,8 +1262,679 @@ func memoryCopy(m *Module, dst int32, src int32, n int32) {
 	}
 	srcEnd := uint64(uint32(src)) + uint64(uint32(n))
 	dstEnd := uint64(uint32(dst)) + uint64(uint32(n))
-	if srcEnd > uint64(len(m.memory)) || dstEnd > uint64(len(m.memory)) {
+	if size := m.memSize.Load(); srcEnd > size || dstEnd > size {
 		wasm_trap_memcopy_oob()
 	}
 	copy(m.memory[uint32(dst):uint32(dstEnd)], m.memory[uint32(src):uint32(srcEnd)])
 }
+
+// ----- Threads-proposal atomics ---------------------------------------------
+//
+// Module-aware helpers behind OpAtomicCall (helper(m, addr, offset, ...)).
+// Effective addresses are computed in uint64 so base+offset cannot wrap;
+// misalignment traps, as the proposal requires (unlike plain loads/stores,
+// which tolerate it). 8/16-bit RMWs emulate subword atomicity with a CAS
+// loop on the containing aligned 32-bit word — little-endian hosts only,
+// which is every architecture wasm2go targets.
+
+//go:noinline
+func wasm_trap_atomic_oob() { panic("wasm: atomic access out of bounds") }
+
+//go:noinline
+func wasm_trap_atomic_unaligned() { panic("wasm: unaligned atomic access") }
+
+//go:noinline
+func wasm_trap_atomic_wait_forever() {
+	panic("wasm: blocking atomic wait with no other agents (wasi-threads not enabled)")
+}
+
+// atomicEA bounds- and alignment-checks an atomic access and returns the
+// effective address.
+// Atomic and thread helpers are all //go:noinline: several take func-literal
+// operands (the subword CAS loops, the RMW families), and if the compiler
+// inlines such a helper into a gcasm-transformed generated function the
+// closure becomes a cross-package symbol ("pN.FnX.AtomicRmwOr32.func4") the
+// asm bundler cannot represent. Out-of-line, the closure stays homed in base.
+//
+//go:noinline
+func atomicEA(m *Module, addr int32, offset int32, size uint64) uint64 {
+	ea := uint64(uint32(addr)) + uint64(uint32(offset))
+	// memSize, not len(m.memory): a shared memory's slice spans the whole
+	// declared maximum from the start, so only memSize says how much of it
+	// the guest may touch — and reading it atomically is what keeps growth
+	// race-free without a lock on this path.
+	if ea+size > m.memSize.Load() {
+		wasm_trap_atomic_oob()
+	}
+	if ea&(size-1) != 0 {
+		wasm_trap_atomic_unaligned()
+	}
+	return ea
+}
+
+//go:noinline
+func atomicPtr32(m *Module, addr int32, offset int32) *uint32 {
+	ea := atomicEA(m, addr, offset, 4)
+	return (*uint32)(unsafe.Pointer(&m.memory[ea]))
+}
+
+//go:noinline
+func atomicPtr64(m *Module, addr int32, offset int32) *uint64 {
+	ea := atomicEA(m, addr, offset, 8)
+	return (*uint64)(unsafe.Pointer(&m.memory[ea]))
+}
+
+// atomicSubword32 runs op on the byte lanes [shift, shift+bits) of the
+// aligned 32-bit word containing ea, via a CAS loop; returns the OLD lane
+// value zero-extended. Little-endian lane math.
+//
+//go:noinline
+func atomicSubword32(m *Module, ea uint64, bits uint, op func(old uint32) uint32) uint32 {
+	word := (*uint32)(unsafe.Pointer(&m.memory[ea&^3]))
+	shift := uint(ea&3) * 8
+	mask := uint32(1)<<bits - 1
+	for {
+		cur := atomic.LoadUint32(word)
+		lane := (cur >> shift) & mask
+		next := (cur &^ (mask << shift)) | ((op(lane) & mask) << shift)
+		if atomic.CompareAndSwapUint32(word, cur, next) {
+			return lane
+		}
+	}
+}
+
+//go:noinline
+func atomicLoad32(m *Module, addr int32, offset int32) int32 {
+	return int32(atomic.LoadUint32(atomicPtr32(m, addr, offset)))
+}
+
+//go:noinline
+func atomicLoad64(m *Module, addr int32, offset int32) int64 {
+	return int64(atomic.LoadUint64(atomicPtr64(m, addr, offset)))
+}
+
+//go:noinline
+func atomicLoad32_8u(m *Module, addr int32, offset int32) int32 {
+	ea := atomicEA(m, addr, offset, 1)
+	return int32(atomicSubword32(m, ea, 8, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad32_16u(m *Module, addr int32, offset int32) int32 {
+	ea := atomicEA(m, addr, offset, 2)
+	return int32(atomicSubword32(m, ea, 16, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_8u(m *Module, addr int32, offset int32) int64 {
+	ea := atomicEA(m, addr, offset, 1)
+	return int64(atomicSubword32(m, ea, 8, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_16u(m *Module, addr int32, offset int32) int64 {
+	ea := atomicEA(m, addr, offset, 2)
+	return int64(atomicSubword32(m, ea, 16, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_32u(m *Module, addr int32, offset int32) int64 {
+	return int64(atomic.LoadUint32(atomicPtr32(m, addr, offset)))
+}
+
+//go:noinline
+func atomicStore32(m *Module, addr int32, offset int32, v int32) int32 {
+	atomic.StoreUint32(atomicPtr32(m, addr, offset), uint32(v))
+	return 0
+}
+
+//go:noinline
+func atomicStore64(m *Module, addr int32, offset int32, v int64) int32 {
+	atomic.StoreUint64(atomicPtr64(m, addr, offset), uint64(v))
+	return 0
+}
+
+//go:noinline
+func atomicStore32_8(m *Module, addr int32, offset int32, v int32) int32 {
+	ea := atomicEA(m, addr, offset, 1)
+	atomicSubword32(m, ea, 8, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore32_16(m *Module, addr int32, offset int32, v int32) int32 {
+	ea := atomicEA(m, addr, offset, 2)
+	atomicSubword32(m, ea, 16, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_8(m *Module, addr int32, offset int32, v int64) int32 {
+	ea := atomicEA(m, addr, offset, 1)
+	atomicSubword32(m, ea, 8, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_16(m *Module, addr int32, offset int32, v int64) int32 {
+	ea := atomicEA(m, addr, offset, 2)
+	atomicSubword32(m, ea, 16, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_32(m *Module, addr int32, offset int32, v int64) int32 {
+	atomic.StoreUint32(atomicPtr32(m, addr, offset), uint32(v))
+	return 0
+}
+
+//go:noinline
+func atomicRmw32(m *Module, addr int32, offset int32, op func(old uint32) uint32) int32 {
+	p := atomicPtr32(m, addr, offset)
+	for {
+		cur := atomic.LoadUint32(p)
+		if atomic.CompareAndSwapUint32(p, cur, op(cur)) {
+			return int32(cur)
+		}
+	}
+}
+
+//go:noinline
+func atomicRmw64(m *Module, addr int32, offset int32, op func(old uint64) uint64) int64 {
+	p := atomicPtr64(m, addr, offset)
+	for {
+		cur := atomic.LoadUint64(p)
+		if atomic.CompareAndSwapUint64(p, cur, op(cur)) {
+			return int64(cur)
+		}
+	}
+}
+
+//go:noinline
+func atomicRmwAdd32(m *Module, addr, offset, v int32) int32 {
+	return int32(atomic.AddUint32(atomicPtr32(m, addr, offset), uint32(v)) - uint32(v))
+}
+
+//go:noinline
+func atomicRmwSub32(m *Module, addr, offset, v int32) int32 {
+	return int32(atomic.AddUint32(atomicPtr32(m, addr, offset), -uint32(v)) + uint32(v))
+}
+
+//go:noinline
+func atomicRmwAnd32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o & uint32(v) })
+}
+
+//go:noinline
+func atomicRmwOr32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o | uint32(v) })
+}
+
+//go:noinline
+func atomicRmwXor32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o ^ uint32(v) })
+}
+
+//go:noinline
+func atomicRmwXchg32(m *Module, addr, offset, v int32) int32 {
+	return int32(atomic.SwapUint32(atomicPtr32(m, addr, offset), uint32(v)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg32(m *Module, addr, offset, expected, replacement int32) int32 {
+	p := atomicPtr32(m, addr, offset)
+	for {
+		cur := atomic.LoadUint32(p)
+		if cur != uint32(expected) {
+			return int32(cur)
+		}
+		if atomic.CompareAndSwapUint32(p, cur, uint32(replacement)) {
+			return int32(cur)
+		}
+	}
+}
+
+//go:noinline
+func atomicRmwAdd64(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomic.AddUint64(atomicPtr64(m, addr, offset), uint64(v)) - uint64(v))
+}
+
+//go:noinline
+func atomicRmwSub64(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomic.AddUint64(atomicPtr64(m, addr, offset), -uint64(v)) + uint64(v))
+}
+
+//go:noinline
+func atomicRmwAnd64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmw64(m, addr, offset, func(o uint64) uint64 { return o & uint64(v) })
+}
+
+//go:noinline
+func atomicRmwOr64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmw64(m, addr, offset, func(o uint64) uint64 { return o | uint64(v) })
+}
+
+//go:noinline
+func atomicRmwXor64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmw64(m, addr, offset, func(o uint64) uint64 { return o ^ uint64(v) })
+}
+
+//go:noinline
+func atomicRmwXchg64(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomic.SwapUint64(atomicPtr64(m, addr, offset), uint64(v)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64(m *Module, addr, offset int32, expected, replacement int64) int64 {
+	p := atomicPtr64(m, addr, offset)
+	for {
+		cur := atomic.LoadUint64(p)
+		if cur != uint64(expected) {
+			return int64(cur)
+		}
+		if atomic.CompareAndSwapUint64(p, cur, uint64(replacement)) {
+			return int64(cur)
+		}
+	}
+}
+
+//go:noinline
+func atomicRmwSubword(m *Module, addr, offset int32, size uint64, bits uint, op func(old uint32) uint32) uint32 {
+	ea := atomicEA(m, addr, offset, size)
+	return atomicSubword32(m, ea, bits, op)
+}
+
+//go:noinline
+func atomicRmwAdd32_8u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAdd32_16u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub32_8u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub32_16u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd32_8u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd32_16u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr32_8u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr32_16u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor32_8u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor32_16u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg32_8u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg32_16u(m *Module, addr, offset, v int32) int32 {
+	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicCmpxchgSubword(m *Module, addr, offset int32, size uint64, bits uint, expected, replacement uint32) uint32 {
+	ea := atomicEA(m, addr, offset, size)
+	word := (*uint32)(unsafe.Pointer(&m.memory[ea&^3]))
+	shift := uint(ea&3) * 8
+	mask := uint32(1)<<bits - 1
+	for {
+		cur := atomic.LoadUint32(word)
+		lane := (cur >> shift) & mask
+		if lane != expected&mask {
+			return lane
+		}
+		next := (cur &^ (mask << shift)) | ((replacement & mask) << shift)
+		if atomic.CompareAndSwapUint32(word, cur, next) {
+			return lane
+		}
+	}
+}
+
+//go:noinline
+func atomicRmwCmpxchg32_8u(m *Module, addr, offset, expected, replacement int32) int32 {
+	return int32(atomicCmpxchgSubword(m, addr, offset, 1, 8, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg32_16u(m *Module, addr, offset, expected, replacement int32) int32 {
+	return int32(atomicCmpxchgSubword(m, addr, offset, 2, 16, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwAdd64_8u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAdd64_16u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAdd64_32u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomic.AddUint32(atomicPtr32(m, addr, offset), uint32(v)) - uint32(v))
+}
+
+//go:noinline
+func atomicRmwSub64_8u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub64_16u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub64_32u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomic.AddUint32(atomicPtr32(m, addr, offset), -uint32(v)) + uint32(v))
+}
+
+//go:noinline
+func atomicRmwAnd64_8u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd64_16u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd64_32u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o & uint32(v) })) & 0xffffffff
+}
+
+//go:noinline
+func atomicRmwOr64_8u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr64_16u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr64_32u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o | uint32(v) })) & 0xffffffff
+}
+
+//go:noinline
+func atomicRmwXor64_8u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor64_16u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor64_32u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o ^ uint32(v) })) & 0xffffffff
+}
+
+//go:noinline
+func atomicRmwXchg64_8u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg64_16u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg64_32u(m *Module, addr, offset int32, v int64) int64 {
+	return int64(atomic.SwapUint32(atomicPtr32(m, addr, offset), uint32(v)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_8u(m *Module, addr, offset int32, expected, replacement int64) int64 {
+	return int64(atomicCmpxchgSubword(m, addr, offset, 1, 8, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_16u(m *Module, addr, offset int32, expected, replacement int64) int64 {
+	return int64(atomicCmpxchgSubword(m, addr, offset, 2, 16, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_32u(m *Module, addr, offset int32, expected, replacement int64) int64 {
+	p := atomicPtr32(m, addr, offset)
+	for {
+		cur := atomic.LoadUint32(p)
+		if cur != uint32(expected) {
+			return int64(cur)
+		}
+		if atomic.CompareAndSwapUint32(p, cur, uint32(replacement)) {
+			return int64(cur)
+		}
+	}
+}
+
+// atomicFence is a sequentially consistent full barrier. Locking any mutex
+// provides one under the Go memory model, and memMu is always present.
+//
+//go:noinline
+func atomicFence(m *Module) int32 {
+	m.memMu.Lock()
+	m.memMu.Unlock() //nolint:staticcheck // empty critical section IS the fence
+	return 0
+}
+
+// atomicNotify wakes up to count agents waiting on the address and reports
+// how many it woke (0 when none are parked, which is also the single-agent
+// answer).
+//
+//go:noinline
+func atomicNotify(m *Module, addr int32, offset int32, count int32) int32 {
+	ea := atomicEA(m, addr, offset, 4)
+	return m.threads.wake(ea, count)
+}
+
+// atomicWait32/64 implement memory.atomic.wait: compare-and-park. The compare
+// happens under the parking-lot lock a notifier must also take, so a notify
+// that lands between the compare and the park cannot be missed.
+//
+// Returns 0 = woken, 1 = not-equal, 2 = timed-out. A negative timeout means
+// wait forever; with no other agent able to notify, that is a guaranteed
+// deadlock, so it traps rather than hanging the process.
+//
+//go:noinline
+func atomicWait32(m *Module, addr int32, offset int32, expected int32, timeout int64) int32 {
+	ea := atomicEA(m, addr, offset, 4)
+	p := (*uint32)(unsafe.Pointer(&m.memory[ea]))
+	return atomicWait(m, ea, timeout, func() bool {
+		return int32(atomic.LoadUint32(p)) == expected
+	})
+}
+
+//go:noinline
+func atomicWait64(m *Module, addr int32, offset int32, expected int64, timeout int64) int32 {
+	ea := atomicEA(m, addr, offset, 8)
+	p := (*uint64)(unsafe.Pointer(&m.memory[ea]))
+	return atomicWait(m, ea, timeout, func() bool {
+		return int64(atomic.LoadUint64(p)) == expected
+	})
+}
+
+//go:noinline
+func atomicWait(m *Module, ea uint64, timeout int64, stillEqual func() bool) int32 {
+	if !m.memShared {
+		// Waiting on a non-shared memory is a validation error upstream;
+		// treat it as not-equal rather than parking forever.
+		return 1
+	}
+	m.threads.parkMu.Lock()
+	if !stillEqual() {
+		m.threads.parkMu.Unlock()
+		return 1
+	}
+	ch := make(chan struct{})
+	if m.threads.parked == nil {
+		m.threads.parked = make(map[uint64][]chan struct{})
+	}
+	m.threads.parked[ea] = append(m.threads.parked[ea], ch)
+	m.threads.parkMu.Unlock()
+
+	unpark := func() {
+		m.threads.parkMu.Lock()
+		defer m.threads.parkMu.Unlock()
+		waiters := m.threads.parked[ea]
+		for i, c := range waiters {
+			if c == ch {
+				m.threads.parked[ea] = append(waiters[:i], waiters[i+1:]...)
+				break
+			}
+		}
+		if len(m.threads.parked[ea]) == 0 {
+			delete(m.threads.parked, ea)
+		}
+	}
+
+	if timeout < 0 {
+		if m.threads.nextTID.Load() == 0 {
+			// Nobody else exists to notify us: an infinite wait here can
+			// only deadlock. Trap loudly instead of hanging.
+			unpark()
+			wasm_trap_atomic_wait_forever()
+		}
+		<-ch
+		return 0
+	}
+	// +1ms: a guest measures its own wait with millisecond-granularity clocks
+	// (test262 asserts lapse >= timeout), so a timer that fires at exactly the
+	// requested nanosecond can look EARLY once both ends truncate. Late by a
+	// millisecond is spec-legal; early is not.
+	timer := time.NewTimer(time.Duration(timeout) + time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ch:
+		return 0
+	case <-timer.C:
+		unpark()
+		return 2
+	}
+}
+
+// ----- wasi-threads ---------------------------------------------------------
+//
+// A wasm thread is a goroutine. wasi_thread_spawn hands the guest a TID and
+// starts wasi_thread_start(tid, arg) — the entry wasi-libc exports — on a
+// fresh goroutine; that entry sets up the thread's stack and TLS INSIDE
+// linear memory (the guest allocated them before spawning), so the Go side
+// owns nothing but the goroutine. Growth cannot relocate a shared memory
+// (see memoryGrow), so every agent's cached m.M stays valid for its lifetime.
+//
+// threadPool stays deliberately small: a TID counter, a WaitGroup so a host
+// can await quiescence, and the wait/notify parking lot — whose map is only
+// allocated if an agent actually blocks.
+type threadPool struct {
+	nextTID atomic.Int32
+	wg      sync.WaitGroup
+
+	parkMu sync.Mutex
+	parked map[uint64][]chan struct{}
+}
+
+// wake releases up to count waiters on ea and reports how many it woke.
+func (p *threadPool) wake(ea uint64, count int32) int32 {
+	p.parkMu.Lock()
+	defer p.parkMu.Unlock()
+	waiters := p.parked[ea]
+	n := int32(len(waiters))
+	if count >= 0 && count < n {
+		n = count
+	}
+	for _, ch := range waiters[:n] {
+		close(ch)
+	}
+	if int(n) == len(waiters) {
+		delete(p.parked, ea)
+	} else {
+		p.parked[ea] = waiters[n:]
+	}
+	return n
+}
+
+// threadSpawn implements the wasi_thread_spawn import: run the guest's thread
+// entry on a goroutine, return the new TID (negative means "cannot spawn").
+//
+//go:noinline
+func threadSpawn(m *Module, arg int32) int32 {
+	start := m.threadStart
+	if start == nil {
+		return -1 // module exports no wasi_thread_start: nothing to run
+	}
+	tid := m.threads.nextTID.Add(1)
+	m.threads.wg.Add(1)
+	// The agent runs on a struct COPY: same memory (the slice header is
+	// immutable for a shared memory), same pointered shared state
+	// (memSize/memMu/threads/host imports), but its OWN globals — the wasm
+	// threads model in one assignment. wasi_thread_start's first act is to
+	// point the clone's stack-pointer global at the stack pthread_create
+	// malloc'ed inside the shared memory.
+	child := new(Module)
+	*child = *m
+	go func() {
+		defer m.threads.wg.Done()
+		// A trap on any wasm thread traps the whole instance (wasi-threads
+		// semantics): surface WHERE it happened, then let it take the
+		// process down instead of silently unwinding the goroutine.
+		defer func() {
+			if r := recover(); r != nil {
+				println("wasm2go: wasi thread", tid, "trapped:")
+				switch v := r.(type) {
+				case error:
+					println("  ", v.Error())
+				case string:
+					println("  ", v)
+				}
+				panic(r)
+			}
+		}()
+		start(child, tid, arg)
+	}()
+	return tid
+}
+
+// ThreadsWait blocks until every spawned agent has returned. Hosts call it
+// before tearing an instance down; the guest never sees it.
+//
+//go:noinline
+func ThreadsWait(m *Module) { m.threads.wg.Wait() }

--- a/internal/codegen/helpers/helpers_accessmemory_test.go
+++ b/internal/codegen/helpers/helpers_accessmemory_test.go
@@ -16,7 +16,7 @@ import (
 // live array or is carried into the next one by the relocation copy.
 func TestAccessMemoryConcurrentGrow(t *testing.T) {
 	const flagAddr = 64 // low static-region word, always < initial len
-	m := &Module{memory: make([]byte, 1<<16, 1<<17)}
+	m := newTestModule(make([]byte, 1<<16, 1<<17))
 	m.M = unsafe.Pointer(unsafe.SliceData(m.memory))
 
 	var wg sync.WaitGroup
@@ -63,7 +63,7 @@ func TestAccessMemoryConcurrentGrow(t *testing.T) {
 func TestMemoryFillPaths(t *testing.T) {
 	for _, n := range []int32{1, 2, 3, 7, 8, 9, 1000, 4096, 65537} {
 		for _, val := range []int32{0, 0xA5} {
-			m := &Module{memory: make([]byte, 70000)}
+			m := newTestModule(make([]byte, 70000))
 			for i := range m.memory {
 				m.memory[i] = 0xEE
 			}
@@ -80,7 +80,7 @@ func TestMemoryFillPaths(t *testing.T) {
 		}
 	}
 	// Out-of-bounds still panics.
-	m := &Module{memory: make([]byte, 64)}
+	m := newTestModule(make([]byte, 64))
 	func() {
 		defer func() {
 			if recover() == nil {

--- a/internal/codegen/helpers/helpers_atomic_matrix_test.go
+++ b/internal/codegen/helpers/helpers_atomic_matrix_test.go
@@ -1,0 +1,253 @@
+package helpers
+
+import (
+	"runtime"
+	"testing"
+)
+
+// The atomic RMW matrix and the wait/notify parking lot. These helpers are
+// emitted into generated output for the threads proposal's full set of
+// read-modify-write, compare-exchange, and wait/notify operations across widths
+// (8/16/32/64) and lane sizes. Codegen selects them by name, so only a test
+// links them — and gives them regression coverage.
+
+// seedLane writes val into the low `bits`-wide lane at offset 0 of a cleared
+// word, and readLane reads it back. Both go through the mem-access helpers, so
+// the atomic helpers under test are checked against an independent path.
+func seedLane(m *Module, bits int, val int64) {
+	memStore64(m, 0, 0)
+	switch bits {
+	case 8:
+		memStore8(m, 0, uint32(val))
+	case 16:
+		memStore16(m, 0, uint32(val))
+	case 32:
+		memStore32(m, 0, int32(val))
+	case 64:
+		memStore64(m, 0, val)
+	}
+}
+
+func readLane(m *Module, bits int) int64 {
+	switch bits {
+	case 8:
+		return int64(memLoad8(m, 0))
+	case 16:
+		return int64(memLoad16(m, 0))
+	case 32:
+		return int64(memLoad32U(m, 0))
+	default:
+		return memLoad64(m, 0)
+	}
+}
+
+// TestAtomicRmw32Matrix covers the int32-valued RMW helpers (full 32-bit lane
+// plus the 8- and 16-bit sub-word forms). Each returns the OLD lane value and
+// leaves op(old, v) behind.
+func TestAtomicRmw32Matrix(t *testing.T) {
+	cases := []struct {
+		name          string
+		fn            func(m *Module, a, o, v int32) int32
+		bits          int
+		old, v, newLo int64
+	}{
+		{"Xchg32", atomicRmwXchg32, 32, 100, 7, 7},
+		{"Add32_8u", atomicRmwAdd32_8u, 8, 100, 5, 105},
+		{"Sub32_8u", atomicRmwSub32_8u, 8, 100, 5, 95},
+		{"And32_8u", atomicRmwAnd32_8u, 8, 0xF0, 0x3C, 0x30},
+		{"Or32_8u", atomicRmwOr32_8u, 8, 0xF0, 0x0F, 0xFF},
+		{"Xor32_8u", atomicRmwXor32_8u, 8, 0xFF, 0x0F, 0xF0},
+		{"Xchg32_8u", atomicRmwXchg32_8u, 8, 100, 7, 7},
+		{"Add32_16u", atomicRmwAdd32_16u, 16, 1000, 5, 1005},
+		{"Sub32_16u", atomicRmwSub32_16u, 16, 1000, 5, 995},
+		{"And32_16u", atomicRmwAnd32_16u, 16, 0xFF00, 0x3C00, 0x3C00},
+		{"Or32_16u", atomicRmwOr32_16u, 16, 0xF000, 0x0F00, 0xFF00},
+		{"Xor32_16u", atomicRmwXor32_16u, 16, 0xFF00, 0x0F00, 0xF000},
+		{"Xchg32_16u", atomicRmwXchg32_16u, 16, 1000, 7, 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newMemModuleM(64)
+			seedLane(m, tc.bits, tc.old)
+			if old := int64(tc.fn(m, 0, 0, int32(tc.v))); old != tc.old {
+				t.Errorf("%s old = %d, want %d", tc.name, old, tc.old)
+			}
+			if got := readLane(m, tc.bits); got != tc.newLo {
+				t.Errorf("%s new = %d, want %d", tc.name, got, tc.newLo)
+			}
+		})
+	}
+}
+
+// TestAtomicRmw64Matrix covers the int64-valued RMW helpers (full 64-bit lane
+// plus the 8/16/32-bit sub-word forms).
+func TestAtomicRmw64Matrix(t *testing.T) {
+	cases := []struct {
+		name          string
+		fn            func(m *Module, a, o int32, v int64) int64
+		bits          int
+		old, v, newLo int64
+	}{
+		{"Add64", atomicRmwAdd64, 64, 100, 5, 105},
+		{"Sub64", atomicRmwSub64, 64, 100, 5, 95},
+		{"And64", atomicRmwAnd64, 64, 0xF0, 0x3C, 0x30},
+		{"Or64", atomicRmwOr64, 64, 0xF0, 0x0F, 0xFF},
+		{"Xor64", atomicRmwXor64, 64, 0xFF, 0x0F, 0xF0},
+		{"Xchg64", atomicRmwXchg64, 64, 100, 7, 7},
+		{"Add64_8u", atomicRmwAdd64_8u, 8, 100, 5, 105},
+		{"Xchg64_8u", atomicRmwXchg64_8u, 8, 100, 7, 7},
+		{"And64_8u", atomicRmwAnd64_8u, 8, 0xF0, 0x3C, 0x30},
+		{"Or64_8u", atomicRmwOr64_8u, 8, 0xF0, 0x0F, 0xFF},
+		{"Sub64_8u", atomicRmwSub64_8u, 8, 100, 5, 95},
+		{"Xor64_8u", atomicRmwXor64_8u, 8, 0xFF, 0x0F, 0xF0},
+		{"Add64_16u", atomicRmwAdd64_16u, 16, 1000, 5, 1005},
+		{"Xchg64_16u", atomicRmwXchg64_16u, 16, 1000, 7, 7},
+		{"And64_16u", atomicRmwAnd64_16u, 16, 0xFF00, 0x3C00, 0x3C00},
+		{"Or64_16u", atomicRmwOr64_16u, 16, 0xF000, 0x0F00, 0xFF00},
+		{"Sub64_16u", atomicRmwSub64_16u, 16, 1000, 5, 995},
+		{"Xor64_16u", atomicRmwXor64_16u, 16, 0xFF00, 0x0F00, 0xF000},
+		{"Add64_32u", atomicRmwAdd64_32u, 32, 100000, 5, 100005},
+		{"Xchg64_32u", atomicRmwXchg64_32u, 32, 100000, 7, 7},
+		{"And64_32u", atomicRmwAnd64_32u, 32, 0xFF0000, 0x3C0000, 0x3C0000},
+		{"Or64_32u", atomicRmwOr64_32u, 32, 0xF00000, 0x0F0000, 0xFF0000},
+		{"Sub64_32u", atomicRmwSub64_32u, 32, 100000, 5, 99995},
+		{"Xor64_32u", atomicRmwXor64_32u, 32, 0xFF0000, 0x0F0000, 0xF00000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newMemModuleM(64)
+			seedLane(m, tc.bits, tc.old)
+			if old := tc.fn(m, 0, 0, tc.v); old != tc.old {
+				t.Errorf("%s old = %d, want %d", tc.name, old, tc.old)
+			}
+			if got := readLane(m, tc.bits); got != tc.newLo {
+				t.Errorf("%s new = %d, want %d", tc.name, got, tc.newLo)
+			}
+		})
+	}
+}
+
+// TestAtomicCmpxchgMatrix covers compare-exchange across widths: on a match the
+// lane takes the replacement and the old value is returned; on a mismatch the
+// lane is left alone and the (unequal) current value is returned.
+func TestAtomicCmpxchgMatrix(t *testing.T) {
+	t.Run("32", func(t *testing.T) {
+		cases := []struct {
+			name string
+			fn   func(m *Module, a, o, expected, replacement int32) int32
+			bits int
+		}{
+			{"Cmpxchg32", atomicRmwCmpxchg32, 32},
+			{"Cmpxchg32_8u", atomicRmwCmpxchg32_8u, 8},
+			{"Cmpxchg32_16u", atomicRmwCmpxchg32_16u, 16},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				m := newMemModuleM(64)
+				seedLane(m, tc.bits, 42)
+				if old := tc.fn(m, 0, 0, 42, 99); old != 42 || readLane(m, tc.bits) != 99 {
+					t.Errorf("%s match: old %d new %d, want 42/99", tc.name, old, readLane(m, tc.bits))
+				}
+				seedLane(m, tc.bits, 42)
+				if old := tc.fn(m, 0, 0, 7, 99); old != 42 || readLane(m, tc.bits) != 42 {
+					t.Errorf("%s mismatch: old %d new %d, want 42/42", tc.name, old, readLane(m, tc.bits))
+				}
+			})
+		}
+	})
+	t.Run("64", func(t *testing.T) {
+		cases := []struct {
+			name string
+			fn   func(m *Module, a, o int32, expected, replacement int64) int64
+			bits int
+		}{
+			{"Cmpxchg64", atomicRmwCmpxchg64, 64},
+			{"Cmpxchg64_8u", atomicRmwCmpxchg64_8u, 8},
+			{"Cmpxchg64_16u", atomicRmwCmpxchg64_16u, 16},
+			{"Cmpxchg64_32u", atomicRmwCmpxchg64_32u, 32},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				m := newMemModuleM(64)
+				seedLane(m, tc.bits, 42)
+				if old := tc.fn(m, 0, 0, 42, 99); old != 42 || readLane(m, tc.bits) != 99 {
+					t.Errorf("%s match: old %d new %d, want 42/99", tc.name, old, readLane(m, tc.bits))
+				}
+				seedLane(m, tc.bits, 42)
+				if old := tc.fn(m, 0, 0, 7, 99); old != 42 || readLane(m, tc.bits) != 42 {
+					t.Errorf("%s mismatch: old %d new %d, want 42/42", tc.name, old, readLane(m, tc.bits))
+				}
+			})
+		}
+	})
+}
+
+// TestAtomicFence exercises the fence helper (an empty locked critical section
+// as a memory barrier); it must return 0 and touch nothing.
+func TestAtomicFence(t *testing.T) {
+	m := newMemModuleM(8)
+	if got := atomicFence(m); got != 0 {
+		t.Errorf("atomicFence = %d, want 0", got)
+	}
+}
+
+// TestAtomicWaitNotEqualAndTimeout covers the non-blocking exits of
+// memory.atomic.wait: 1 when the value already differs, 2 on timeout, and 1 on
+// a non-shared memory (parking there is a validation error upstream).
+func TestAtomicWaitNotEqualAndTimeout(t *testing.T) {
+	m := newMemModuleM(64)
+	m.memShared = true
+	atomicStore32(m, 0, 0, 0)
+
+	if got := atomicWait32(m, 0, 0, 999, -1); got != 1 {
+		t.Errorf("wait32 with wrong expected = %d, want 1 (not-equal)", got)
+	}
+	if got := atomicWait32(m, 0, 0, 0, 0); got != 2 {
+		t.Errorf("wait32 that times out = %d, want 2", got)
+	}
+	atomicStore64(m, 8, 0, 0)
+	if got := atomicWait64(m, 8, 0, 0, 0); got != 2 {
+		t.Errorf("wait64 that times out = %d, want 2", got)
+	}
+
+	ns := newMemModuleM(64) // not shared
+	if got := atomicWait32(ns, 0, 0, 0, -1); got != 1 {
+		t.Errorf("wait on non-shared memory = %d, want 1", got)
+	}
+}
+
+// TestAtomicWaitNotify parks a waiter and wakes it, exercising the parking lot
+// (parked/parkMu), threadPool.wake, atomicNotify and the woken (0) exit of
+// atomicWait. nextTID is bumped so the infinite-wait deadlock guard sees that
+// another agent exists to notify it.
+func TestAtomicWaitNotify(t *testing.T) {
+	m := newMemModuleM(64)
+	m.memShared = true
+	m.threads.nextTID.Store(1) // pretend a sibling agent exists
+	atomicStore32(m, 0, 0, 0)
+
+	done := make(chan int32, 1)
+	go func() { done <- atomicWait32(m, 0, 0, 0, -1) }() // parks: value matches, forever
+
+	// Wait until the waiter is actually parked before notifying.
+	for {
+		m.threads.parkMu.Lock()
+		parked := len(m.threads.parked) > 0
+		m.threads.parkMu.Unlock()
+		if parked {
+			break
+		}
+		runtime.Gosched()
+	}
+
+	if woke := atomicNotify(m, 0, 0, 1); woke != 1 {
+		t.Errorf("atomicNotify woke %d, want 1", woke)
+	}
+	if got := <-done; got != 0 {
+		t.Errorf("parked wait returned %d, want 0 (woken)", got)
+	}
+	// Notifying an address with nobody parked wakes zero.
+	if woke := atomicNotify(m, 0, 0, 1); woke != 0 {
+		t.Errorf("atomicNotify with no waiters woke %d, want 0", woke)
+	}
+}

--- a/internal/codegen/helpers/helpers_full_test.go
+++ b/internal/codegen/helpers/helpers_full_test.go
@@ -769,7 +769,7 @@ func TestLoadStore(t *testing.T) {
 // ---- Module-aware memory helpers -------------------------------------------
 
 func newMemModule(size int) *Module {
-	return &Module{memory: make([]byte, size)}
+	return newTestModule(make([]byte, size))
 }
 
 func TestMLoad8(t *testing.T) {
@@ -947,7 +947,8 @@ func TestB32(t *testing.T) {
 
 func TestMemoryGrowMaxMem(t *testing.T) {
 	// maxMem that allows geometric realloc capped at maxMem
-	m := &Module{memory: make([]byte, 65536), maxMem: 4 * 65536}
+	m := newTestModule(make([]byte, 65536))
+	m.maxMem = 4 * 65536
 	// grow 2 pages — cap doubles to 2*65536 but that's below maxMem
 	if got := memoryGrow(m, 2); got != 1 {
 		t.Errorf("grow 2 pages: prev=%d want 1", got)
@@ -965,7 +966,7 @@ func TestMemoryGrowBeyond4GiB(t *testing.T) {
 	// Simulate being at 4 GiB boundary — want>1<<32 triggers -1.
 	// We can't actually allocate 4 GiB in a test; instead verify
 	// the computation path via a module whose logical size would overflow.
-	m := &Module{memory: make([]byte, 65536)}
+	m := newTestModule(make([]byte, 65536))
 	// n pages such that want > 1<<32: e.g. (1<<32/65536)+1 = 65537 pages
 	if got := memoryGrow(m, 65537); got != -1 {
 		t.Errorf("grow 65537 pages: %d want -1", got)
@@ -976,7 +977,7 @@ func TestMemoryGrowSpareCapacity(t *testing.T) {
 	// Pre-allocate backing array larger than initial len so the first grow
 	// takes the reslice (spare capacity) path.
 	mem := make([]byte, 65536, 4*65536)
-	m := &Module{memory: mem}
+	m := newTestModule(mem)
 	prev := memoryGrow(m, 1)
 	if prev != 1 {
 		t.Errorf("prev pages = %d, want 1", prev)

--- a/internal/codegen/helpers/helpers_mematomic_test.go
+++ b/internal/codegen/helpers/helpers_mematomic_test.go
@@ -1,0 +1,239 @@
+package helpers
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+// Coverage for the memory-access, passive-segment, atomic, and thread helpers
+// that codegen emits into generated output via //go:embed. They are selected by
+// name at generation time, so nothing in this package references them directly;
+// without a test they are both unlinted (staticcheck U1000) and, worse,
+// unguarded against regression. These tests exercise each one against a
+// hand-built Module, exactly as generated New() sets one up.
+
+// newMemModuleM builds a Module whose M (the unsafe base pointer the memLoad/
+// memStore family dereferences) points at its memory, the way generated New()
+// initialises it. newTestModule alone leaves M nil, which the atomic helpers
+// tolerate (they index m.memory) but the mem-access helpers do not.
+func newMemModuleM(size int) *Module {
+	m := newTestModule(make([]byte, size))
+	m.M = unsafe.Pointer(unsafe.SliceData(m.memory))
+	return m
+}
+
+func TestMemLoadStoreRoundTrip(t *testing.T) {
+	m := newMemModuleM(64)
+
+	// 8-bit: store the byte, read it zero- and sign-extended.
+	memStore8(m, 0, 0xFF)
+	if got := memLoad8(m, 0); got != 0xFF {
+		t.Errorf("memLoad8 = %#x, want 0xFF", got)
+	}
+	if got := memLoad8S(m, 0); got != -1 {
+		t.Errorf("memLoad8S(0xFF) = %d, want -1", got)
+	}
+
+	// 16-bit: little-endian byte order, then zero/sign extension.
+	memStore16(m, 4, 0x1234)
+	if memLoad8(m, 4) != 0x34 || memLoad8(m, 5) != 0x12 {
+		t.Errorf("memStore16 is not little-endian: [%#x %#x]", memLoad8(m, 4), memLoad8(m, 5))
+	}
+	if got := memLoad16(m, 4); got != 0x1234 {
+		t.Errorf("memLoad16 = %#x, want 0x1234", got)
+	}
+	memStore16(m, 6, 0xFFFF)
+	if got := memLoad16S(m, 6); got != -1 {
+		t.Errorf("memLoad16S(0xFFFF) = %d, want -1", got)
+	}
+
+	// 32-bit signed / unsigned.
+	memStore32(m, 8, -2)
+	if got := memLoad32(m, 8); got != -2 {
+		t.Errorf("memLoad32 = %d, want -2", got)
+	}
+	if got := memLoad32U(m, 8); got != 0xFFFFFFFE {
+		t.Errorf("memLoad32U = %#x, want 0xFFFFFFFE", got)
+	}
+	memStore32U(m, 12, 0xDEADBEEF)
+	if got := memLoad32U(m, 12); got != 0xDEADBEEF {
+		t.Errorf("memStore32U/memLoad32U = %#x, want 0xDEADBEEF", got)
+	}
+
+	// 64-bit.
+	memStore64(m, 16, -3)
+	if got := memLoad64(m, 16); got != -3 {
+		t.Errorf("memLoad64 = %d, want -3", got)
+	}
+
+	// Floats: value round-trip and exact bit pattern (little-endian).
+	memStoreF32(m, 24, 3.5)
+	if got := memLoadF32(m, 24); got != 3.5 {
+		t.Errorf("memLoadF32 = %v, want 3.5", got)
+	}
+	memStoreF64(m, 32, 2.5)
+	if got := memLoadF64(m, 32); got != 2.5 {
+		t.Errorf("memLoadF64 = %v, want 2.5", got)
+	}
+	memStoreF32(m, 40, math.Float32frombits(0x40490FDB)) // ~pi
+	if got := memLoad32U(m, 40); got != 0x40490FDB {
+		t.Errorf("memStoreF32 bit pattern = %#x, want 0x40490FDB", got)
+	}
+}
+
+func TestMemoryInitAndDataDrop(t *testing.T) {
+	m := newMemModuleM(64)
+	m.dataSegs = [][]byte{[]byte("hello world")}
+
+	// Copy "hello" (src 0, len 5) to offset 4.
+	memoryInit(m, 0, 4, 0, 5)
+	if got := string(m.memory[4:9]); got != "hello" {
+		t.Errorf("memoryInit copied %q, want %q", got, "hello")
+	}
+	// dataEnd tracks the end of the installed segment (dst 4 + n 5).
+	if m.dataEnd != 9 {
+		t.Errorf("dataEnd = %d, want 9 (dst+n)", m.dataEnd)
+	}
+	// n == 0 is a no-op and must not touch memory or dataEnd.
+	memoryInit(m, 0, 60, 0, 0)
+	if m.dataEnd != 9 {
+		t.Errorf("dataEnd moved on a zero-length init: %d", m.dataEnd)
+	}
+	// Re-initialising with identical bytes is the compare-then-write path: it
+	// must leave the memory correct (and, though we cannot observe the skipped
+	// write directly, must not corrupt it).
+	memoryInit(m, 0, 4, 0, 5)
+	if got := string(m.memory[4:9]); got != "hello" {
+		t.Errorf("second memoryInit corrupted memory: %q", got)
+	}
+
+	// Out of bounds on the source and on the destination both trap.
+	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit(m, 0, 0, 0, 100) })
+	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit(m, 0, 60, 0, 10) })
+
+	// After data.drop the segment is nil; naming it in memory.init traps.
+	dataDrop(m, 0)
+	if m.dataSegs[0] != nil {
+		t.Error("dataDrop did not nil the segment")
+	}
+	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit(m, 0, 0, 0, 1) })
+}
+
+func TestAtomicMemoryOps(t *testing.T) {
+	m := newMemModuleM(64)
+
+	// store / load, 32 and 64 bit.
+	atomicStore32(m, 0, 0, 0x11223344)
+	if got := atomicLoad32(m, 0, 0); got != 0x11223344 {
+		t.Errorf("atomicLoad32 = %#x, want 0x11223344", got)
+	}
+	atomicStore64(m, 8, 0, 0x1122334455667788)
+	if got := atomicLoad64(m, 8, 0); got != 0x1122334455667788 {
+		t.Errorf("atomicLoad64 = %#x", got)
+	}
+
+	// RMW helpers return the OLD value and leave the new one behind.
+	atomicStore32(m, 0, 0, 100)
+	if old := atomicRmwAdd32(m, 0, 0, 5); old != 100 {
+		t.Errorf("atomicRmwAdd32 old = %d, want 100", old)
+	}
+	if got := atomicLoad32(m, 0, 0); got != 105 {
+		t.Errorf("after add: %d, want 105", got)
+	}
+	if old := atomicRmwSub32(m, 0, 0, 5); old != 105 {
+		t.Errorf("atomicRmwSub32 old = %d, want 105", old)
+	}
+	atomicStore32(m, 0, 0, 0xF0)
+	if old := atomicRmwAnd32(m, 0, 0, 0x3C); old != 0xF0 || atomicLoad32(m, 0, 0) != 0x30 {
+		t.Errorf("atomicRmwAnd32: old %#x new %#x, want 0xF0 / 0x30", old, atomicLoad32(m, 0, 0))
+	}
+	atomicStore32(m, 0, 0, 0xF0)
+	if old := atomicRmwOr32(m, 0, 0, 0x0F); old != 0xF0 || atomicLoad32(m, 0, 0) != 0xFF {
+		t.Errorf("atomicRmwOr32: old %#x new %#x, want 0xF0 / 0xFF", old, atomicLoad32(m, 0, 0))
+	}
+	atomicStore32(m, 0, 0, 0xFF)
+	if old := atomicRmwXor32(m, 0, 0, 0x0F); old != 0xFF || atomicLoad32(m, 0, 0) != 0xF0 {
+		t.Errorf("atomicRmwXor32: old %#x new %#x, want 0xFF / 0xF0", old, atomicLoad32(m, 0, 0))
+	}
+
+	// The generic op-taking RMW forms (atomicRmw32 / atomicRmw64).
+	atomicStore32(m, 0, 0, 7)
+	if old := atomicRmw32(m, 0, 0, func(o uint32) uint32 { return o * 3 }); old != 7 || atomicLoad32(m, 0, 0) != 21 {
+		t.Errorf("atomicRmw32: old %d new %d, want 7 / 21", old, atomicLoad32(m, 0, 0))
+	}
+	atomicStore64(m, 8, 0, 4)
+	if old := atomicRmw64(m, 8, 0, func(o uint64) uint64 { return o + 100 }); old != 4 || atomicLoad64(m, 8, 0) != 104 {
+		t.Errorf("atomicRmw64: old %d new %d, want 4 / 104", old, atomicLoad64(m, 8, 0))
+	}
+
+	// Sub-word atomics: store and zero-extended load, 8- and 16-bit lanes.
+	atomicStore32_8(m, 16, 0, 0xAB)
+	if got := atomicLoad32_8u(m, 16, 0); got != 0xAB {
+		t.Errorf("atomicLoad32_8u = %#x, want 0xAB", got)
+	}
+	atomicStore32_16(m, 16, 0, 0xBEEF)
+	if got := atomicLoad32_16u(m, 16, 0); got != 0xBEEF {
+		t.Errorf("atomicLoad32_16u = %#x, want 0xBEEF", got)
+	}
+	atomicStore64_8(m, 24, 0, 0xCD)
+	if got := atomicLoad64_8u(m, 24, 0); got != 0xCD {
+		t.Errorf("atomicLoad64_8u = %#x, want 0xCD", got)
+	}
+	atomicStore64_16(m, 24, 0, 0xFACE)
+	if got := atomicLoad64_16u(m, 24, 0); got != 0xFACE {
+		t.Errorf("atomicLoad64_16u = %#x, want 0xFACE", got)
+	}
+	atomicStore64_32(m, 24, 0, 0x0BADF00D)
+	if got := atomicLoad64_32u(m, 24, 0); got != 0x0BADF00D {
+		t.Errorf("atomicLoad64_32u = %#x, want 0x0BADF00D", got)
+	}
+
+	// atomicEA's bounds and alignment checks (reached through the ops above).
+	mustPanic(t, "wasm: unaligned atomic access", func() { atomicLoad32(m, 1, 0) })
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicLoad32(m, 60, 8) })
+}
+
+func TestThreadSpawnRunsThreadStart(t *testing.T) {
+	m := newMemModuleM(64)
+
+	var mu sync.Mutex
+	var gotTID, gotArg int32
+	m.threadStart = func(child *Module, tid, arg int32) {
+		mu.Lock()
+		gotTID, gotArg = tid, arg
+		mu.Unlock()
+		// The agent runs on a struct COPY that shares the memory: a write here
+		// must be visible through the parent Module.
+		memStore32(child, 0, arg*2)
+	}
+
+	tid := threadSpawn(m, 21)
+	if tid != 1 {
+		t.Errorf("first threadSpawn tid = %d, want 1", tid)
+	}
+	ThreadsWait(m)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotTID != 1 || gotArg != 21 {
+		t.Errorf("threadStart saw tid=%d arg=%d, want 1/21", gotTID, gotArg)
+	}
+	if got := memLoad32(m, 0); got != 42 {
+		t.Errorf("agent's write not visible through shared memory: %d, want 42", got)
+	}
+
+	// A module that exports no wasi_thread_start returns -1.
+	if got := threadSpawn(newMemModuleM(8), 0); got != -1 {
+		t.Errorf("threadSpawn with no threadStart = %d, want -1", got)
+	}
+}
+
+func TestWasmTrapHelpersPanic(t *testing.T) {
+	mustPanic(t, "wasm: memory.init out of bounds", wasm_trap_meminit_oob)
+	mustPanic(t, "wasm: atomic access out of bounds", wasm_trap_atomic_oob)
+	mustPanic(t, "wasm: unaligned atomic access", wasm_trap_atomic_unaligned)
+	mustPanic(t, "wasm: blocking atomic wait with no other agents (wasi-threads not enabled)",
+		wasm_trap_atomic_wait_forever)
+}

--- a/internal/codegen/helpers/helpers_ssa_test.go
+++ b/internal/codegen/helpers/helpers_ssa_test.go
@@ -9,7 +9,7 @@ import (
 // tests; here we just probe the signatures so they're reachable to
 // staticcheck's `unused` linter and exercise the most basic shape.
 func TestMemorySize(t *testing.T) {
-	m := &Module{memory: make([]byte, 65536)}
+	m := newTestModule(make([]byte, 65536))
 	if got := memorySize(m); got != 1 {
 		t.Errorf("memorySize=%d want 1", got)
 	}
@@ -239,7 +239,7 @@ func TestSignExtend(t *testing.T) {
 }
 
 func TestMemoryCopyFill(t *testing.T) {
-	m := &Module{memory: make([]byte, 65536)}
+	m := newTestModule(make([]byte, 65536))
 	memoryFill(m, 10, 0x42, 4)
 	if got := m.memory[10:14]; got[0] != 0x42 || got[3] != 0x42 {
 		t.Errorf("memoryFill: %v", got)
@@ -261,7 +261,7 @@ func TestMemoryCopyFill(t *testing.T) {
 }
 
 func TestMemoryGrowEmpty(t *testing.T) {
-	m := &Module{memory: make([]byte, 0)}
+	m := newTestModule(make([]byte, 0))
 	if got := memoryGrow(m, 0); got != 0 {
 		t.Errorf("memoryGrow(0) on empty=%d", got)
 	}

--- a/internal/codegen/helpers/helpers_test.go
+++ b/internal/codegen/helpers/helpers_test.go
@@ -1,14 +1,33 @@
 package helpers
 
-import "testing"
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
 
 // TestMemoryGrowGeometric is the regression test for the O(n^2) startup
 // stall: a C++ heap issues a long run of small memory.grow calls during
 // static initialization. The old memoryGrow did make+copy of the whole
 // linear memory on every call, so N grows copied O(N^2) bytes. With
 // geometric backing-array growth, N grows must reallocate O(log N) times.
+// newTestModule mirrors what generated New() does for a plain (non-shared)
+// memory: memSize — the single source of truth for sizes and bounds since the
+// shared-memory work — starts at len(memory). Hand-built Modules that skip it
+// see size 0 and every helper traps.
+func newTestModule(memory []byte) *Module {
+	m := &Module{
+		memory:  memory,
+		memMu:   &sync.Mutex{},
+		memSize: &atomic.Uint64{},
+		threads: &threadPool{},
+	}
+	m.memSize.Store(uint64(len(memory)))
+	return m
+}
+
 func TestMemoryGrowGeometric(t *testing.T) {
-	m := &Module{memory: make([]byte, 65536)} // 1 page
+	m := newTestModule(make([]byte, 65536)) // 1 page
 
 	reallocs := 0
 	prevCap := cap(m.memory)
@@ -41,7 +60,7 @@ func TestMemoryGrowGeometric(t *testing.T) {
 // TestMemoryGrowCorrectness checks the wasm semantics memoryGrow must
 // preserve regardless of the backing-array strategy.
 func TestMemoryGrowCorrectness(t *testing.T) {
-	m := &Module{memory: make([]byte, 65536)}
+	m := newTestModule(make([]byte, 65536))
 	m.memory[0] = 0xAB
 	m.memory[65535] = 0xCD
 
@@ -81,7 +100,8 @@ func TestMemoryGrowCorrectness(t *testing.T) {
 		t.Fatalf("n<0: %d, want -1", got)
 	}
 
-	lim := &Module{memory: make([]byte, 65536), maxMem: 2 * 65536}
+	lim := newTestModule(make([]byte, 65536))
+	lim.maxMem = 2 * 65536
 	if got := memoryGrow(lim, 5); got != -1 {
 		t.Fatalf("grow past maxMem: %d, want -1", got)
 	}

--- a/internal/codegen/sharedimage/embed.go
+++ b/internal/codegen/sharedimage/embed.go
@@ -1,0 +1,66 @@
+// Package sharedimage carries the copy-on-write shared-memory-image runtime
+// that wasm2go emits alongside a translated module.
+//
+// It lives here as source text rather than as a string literal in the
+// generator because it is ordinary Go that happens to be output: keeping it in
+// .go.txt files means it stays readable, reviewable, and greppable. The only
+// generated parts are the identifiers the surrounding package decides — the
+// package name and the Module field names, which single-package output keeps
+// unexported and multi-package output must export.
+package sharedimage
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"go/format"
+	"text/template"
+)
+
+//go:embed sharedimage.go.txt
+var coreTmpl string
+
+//go:embed sharedimage_mmap.go.txt
+var mmapTmpl string
+
+//go:embed sharedimage_nommap.go.txt
+var nommapTmpl string
+
+// Names are the identifiers the emitting package supplies.
+type Names struct {
+	Pkg     string // package clause of the generated files
+	Module  string // the Module type's name (always "Module" today)
+	Memory  string // Module's linear-memory field
+	MemSize string // Module's *atomic.Uint64 current-size field
+	DataEnd string // Module's data-segment-extent field
+
+	// SaveGlobals is the generated globals-snapshot function (see
+	// emitGlobalsSnapshot); multi-package output exports it.
+	SaveGlobals string
+}
+
+// Files renders the runtime: output filename → formatted Go source. The three
+// files split by platform (mmap / no mmap) and must be emitted together.
+func Files(n Names) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	for name, src := range map[string]string{
+		"sharedimage.go":        coreTmpl,
+		"sharedimage_mmap.go":   mmapTmpl,
+		"sharedimage_nommap.go": nommapTmpl,
+	} {
+		t, err := template.New(name).Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("sharedimage: parsing %s: %w", name, err)
+		}
+		var buf bytes.Buffer
+		if err := t.Execute(&buf, n); err != nil {
+			return nil, fmt.Errorf("sharedimage: rendering %s: %w", name, err)
+		}
+		formatted, err := format.Source(buf.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("sharedimage: formatting %s: %w", name, err)
+		}
+		out[name] = formatted
+	}
+	return out, nil
+}

--- a/internal/codegen/sharedimage/sharedimage.go.txt
+++ b/internal/codegen/sharedimage/sharedimage.go.txt
@@ -1,0 +1,200 @@
+package {{.Pkg}}
+
+// Shared, copy-on-write linear memory.
+//
+// Most of what an instance of a large wasm module costs is memory that is
+// IDENTICAL in every instance and, apart from a handful of pages, never written
+// to. A big engine can carry tens of MB of static tables in its data segments,
+// and build more heap still while it starts its runtime up. Every instance
+// paying for its own copy of all that is pure waste.
+//
+// So build it ONCE per process and give every instance a private copy-on-write
+// map of it: read-only pages stay physically shared, and only a page a guest
+// actually writes becomes private.
+//
+// There are two kinds of image, and they differ in how much of the built
+// instance they keep:
+//
+//   - NewSharedImage keeps the data segments. Instances (NewWithMemory) re-run
+//     their own initialization over them, so the image must carry NOTHING above
+//     the segments: that tail is BSS, and it holds the start section's
+//     "already ran" flag and the C++ static state. Inheriting the flag makes
+//     the start section trap on its second run; inheriting statics that point
+//     into a heap the image does not carry breaks the first thing that follows
+//     one of those pointers. What makes even the segments survive the re-run is
+//     that memory.init compares before it writes (see memoryInit) — it finds
+//     them already in place and leaves the pages shared.
+//
+//   - NewSharedSnapshot keeps the whole initialized instance, memory and wasm
+//     globals both. Instances (NewFromSnapshot) re-run NOTHING, which is what
+//     lets the snapshot keep the BSS and the heap that the first kind has to
+//     throw away. It shares much more; it also freezes whatever the build did.
+//
+// Measured on one large embedding (instances live in a 4 GiB container, created
+// until the kernel kills the process): a hundred-odd without any image, several
+// times that with the data-segment image, and an order of magnitude more with
+// the snapshot, which shares the started runtime's heap on top of the segments.
+//
+// Where mmap is unavailable (windows, js/wasm — see sharedimage_nommap.go),
+// every instance allocates and initializes its own memory, exactly as before.
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// SharedImage is a process-wide initialized linear-memory template.
+type SharedImage struct {
+	f       *os.File // unlinked; holds the image
+	size    uint64   // the guest's memory.size for the image
+	dataEnd uint32   // where the data segments stop and BSS begins
+	globals []uint64 // non-nil for a snapshot: the instance's wasm globals
+	err     error    // non-nil if the image could not be built
+}
+
+// ImageBuilder brings up one throwaway instance. The caller supplies it because
+// only the generated package knows how to construct a Module (its constructor's
+// signature depends on the wasm's imports). How far it must initialize that
+// instance depends on which of the two images below is being built.
+type ImageBuilder func() (m *{{.Module}}, err error)
+
+// NewSharedImage builds the DATA-SEGMENT image once and caches it. Every later
+// call returns the same one. A failure is remembered, not retried: callers then
+// fall back to a private allocation, which is correct, only larger.
+//
+// build must run the start section (the ordinary constructor does) and nothing
+// more: everything above the data segments is discarded. Instances go through
+// NewWithMemory and re-run their own initialization over the shared segments.
+func NewSharedImage(build ImageBuilder) *SharedImage {
+	sharedOnce.Do(func() { sharedImg = buildSharedImage(build, false) })
+	return sharedImg
+}
+
+// NewSharedSnapshot builds an image of a FULLY INITIALIZED instance — memory
+// and wasm globals, everything, exactly as build() left it — and caches it the
+// same way. Instances go through NewFromSnapshot, which re-runs nothing at all.
+//
+// This shares far more than NewSharedImage does. A runtime's initialization
+// (C++ static constructors, an interpreter's own start-up) leaves megabytes of
+// heap behind that are identical in every instance, and NewSharedImage cannot
+// share ANY of it: it must zero the BSS, because a fresh instance re-runs the
+// initialization and would trip over the previous one's leftovers. A snapshot
+// re-runs nothing, so it can keep the lot.
+//
+// The catch is that build() must leave the instance in a state every later
+// instance can start from. Anything build() does is done for all of them — an
+// instance that is already holding a lock or mid-request is not a snapshot, it
+// is a bug. Build it clean and take it at rest.
+//
+// Unlike NewSharedImage, this does NOT cache: a snapshot bakes in whatever
+// build() configured, so whether two callers want the same snapshot is a
+// question only the caller can answer. Build it once and hold on to it (a
+// caller whose instances come in flavours will want one per flavour); building
+// it per instance would be slower than not sharing at all.
+func NewSharedSnapshot(build ImageBuilder) *SharedImage {
+	return buildSharedImage(build, true)
+}
+
+var (
+	sharedOnce sync.Once
+	sharedImg  *SharedImage
+)
+
+func buildSharedImage(build ImageBuilder, snapshot bool) *SharedImage {
+	if !mmapSupported {
+		return &SharedImage{err: fmt.Errorf("wasm2go: copy-on-write memory is not supported on this platform")}
+	}
+	m, err := build()
+	if err != nil {
+		return &SharedImage{err: fmt.Errorf("wasm2go: building the shared memory image: %w", err)}
+	}
+	size := m.{{.MemSize}}.Load()
+	dataEnd := m.{{.DataEnd}}
+	if dataEnd == 0 || uint64(dataEnd) > size {
+		return &SharedImage{err: fmt.Errorf(
+			"wasm2go: shared memory image: no data segments were installed (dataEnd=%d, size=%d)",
+			dataEnd, size)}
+	}
+
+	// How much of the built instance the image keeps is the whole difference
+	// between the two kinds.
+	//
+	// A snapshot keeps ALL of it, and its instances re-run nothing.
+	//
+	// A data-segment image keeps the segments and NOTHING above them, because
+	// its instances DO re-run their initialization: that tail is BSS, and it
+	// holds the start section's "already ran" flag and the C++ static state.
+	// Inheriting the flag makes the start section trap on its second run;
+	// inheriting statics that point into a heap this image does not carry
+	// breaks the first thing that follows one of those pointers. A fresh
+	// make() zeroes it for us.
+	keep := uint64(dataEnd)
+	if snapshot {
+		keep = size
+	}
+	img := make([]byte, size)
+	copy(img, m.{{.Memory}}[:keep])
+
+	var globals []uint64
+	if snapshot {
+		// Globals live outside linear memory, so the image cannot carry them —
+		// and the guest's TLS base and stack pointer are globals. Without them
+		// the memory would describe an initialized instance that the Module
+		// does not know it is.
+		globals = {{.SaveGlobals}}(m)
+	}
+
+	f, err := os.CreateTemp("", "wasm2go-image-*")
+	if err != nil {
+		return &SharedImage{err: fmt.Errorf("wasm2go: shared memory image: %w", err)}
+	}
+	// Unlink now: the image must never be reachable by name. The pages live
+	// as long as we hold the descriptor.
+	_ = os.Remove(f.Name())
+	if _, err := f.Write(img); err != nil {
+		f.Close()
+		return &SharedImage{err: fmt.Errorf("wasm2go: shared memory image: %w", err)}
+	}
+	return &SharedImage{f: f, size: size, dataEnd: dataEnd, globals: globals}
+}
+
+// Err reports why the image is unavailable, or nil. A caller that gets an
+// error must build each instance's memory itself.
+func (s *SharedImage) Err() error { return s.err }
+
+// Size is the guest's memory.size for the image, in bytes: what a Module built
+// on it must be told its memory already holds.
+func (s *SharedImage) Size() uint64 { return s.size }
+
+// DataEnd is where the image's data segments stop and its BSS begins. For an
+// image from NewSharedImage that is also where the image stops carrying data;
+// a snapshot carries everything.
+func (s *SharedImage) DataEnd() uint32 { return s.dataEnd }
+
+// Globals are the snapshotted instance's wasm globals, to be handed to
+// NewFromSnapshot along with the memory. Nil for a NewSharedImage image, which
+// snapshots no instance and whose instances initialize their own globals.
+func (s *SharedImage) Globals() []uint64 { return s.globals }
+
+// Memory returns a private, copy-on-write mapping of the image, ceiling bytes
+// long. The instance built on it must still run the start section and the
+// module's initializers: memory.init will find the segments already in place
+// and write nothing, while the initializers build this instance's own BSS.
+//
+// The mapping is NOT Go heap — the GC will not reclaim it. Pass it to
+// UnmapMemory when the instance is done.
+func (s *SharedImage) Memory(ceiling int) ([]byte, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if uint64(ceiling) < s.size {
+		return nil, fmt.Errorf("wasm2go: memory ceiling %d is below the image (%d bytes)", ceiling, s.size)
+	}
+	return mmapImage(s.f, ceiling)
+}
+
+// UnmapMemory releases a mapping returned by SharedImage.Memory. Calling it on
+// a slice that did not come from there is a no-op on platforms without mmap
+// and undefined otherwise, so do not.
+func UnmapMemory(mem []byte) { unmapMemory(mem) }

--- a/internal/codegen/sharedimage/sharedimage_mmap.go.txt
+++ b/internal/codegen/sharedimage/sharedimage_mmap.go.txt
@@ -1,0 +1,44 @@
+//go:build unix
+
+package {{.Pkg}}
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const mmapSupported = true
+
+// mmapImage maps the image as one instance's linear memory: MAP_PRIVATE, so
+// reads share the image's physical pages with every other instance and a write
+// faults in a private copy of just that page.
+//
+// The file is sparse-extended to the ceiling first, so the whole range is
+// mappable and everything past the image reads as zeros — which is what a
+// freshly grown wasm page must contain. Mapping past the end of the file
+// instead would fault with SIGBUS on first access.
+func mmapImage(f *os.File, ceiling int) ([]byte, error) {
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() < int64(ceiling) {
+		if err := f.Truncate(int64(ceiling)); err != nil {
+			return nil, fmt.Errorf("wasm2go: sizing the shared memory image: %w", err)
+		}
+	}
+	mem, err := syscall.Mmap(int(f.Fd()), 0, ceiling,
+		syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE)
+	if err != nil {
+		return nil, fmt.Errorf("wasm2go: mapping the shared memory image: %w", err)
+	}
+	return mem, nil
+}
+
+func unmapMemory(mem []byte) {
+	if len(mem) == 0 {
+		return
+	}
+	_ = syscall.Munmap(mem)
+}

--- a/internal/codegen/sharedimage/sharedimage_nommap.go.txt
+++ b/internal/codegen/sharedimage/sharedimage_nommap.go.txt
@@ -1,0 +1,19 @@
+//go:build !unix
+
+package {{.Pkg}}
+
+import (
+	"fmt"
+	"os"
+)
+
+// Platforms without mmap (windows, js/wasm, ...) get the historical behaviour:
+// every instance allocates and initializes its own linear memory. Correct, only
+// larger — see sharedimage.go for what the sharing buys.
+const mmapSupported = false
+
+func mmapImage(f *os.File, ceiling int) ([]byte, error) {
+	return nil, fmt.Errorf("wasm2go: copy-on-write memory is not supported on this platform")
+}
+
+func unmapMemory(mem []byte) {}

--- a/internal/codegen/sharedimage_test.go
+++ b/internal/codegen/sharedimage_test.go
@@ -1,0 +1,182 @@
+package codegen_test
+
+import (
+	"bytes"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// The shared image is the whole point of learning dataEnd at run time, so test
+// it end to end: build the image from a module whose start section installs its
+// data segments with memory.init, then stand two instances on copy-on-write maps
+// of it and check that (a) they see the segments, (b) the start section running
+// a second time does not trap, (c) a write in one instance is invisible to the
+// other, and (d) the BSS above the segments is zero rather than inherited.
+//
+// (c) is what makes the sharing safe and (d) is what makes it work at all — an
+// instance that inherited the start section's "already ran" flag would trap on
+// its second run.
+func TestSharedImageCopyOnWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no mmap: the generated package falls back to private memory")
+	}
+	bin := testfixture.Wasm(t, "cg_sharedimage")
+	parsed, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, parsed, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := res.AuxFiles["sharedimage.go"]; !ok {
+		t.Fatalf("no sharedimage.go in AuxFiles; got %v", keysOf(res.AuxFiles))
+	}
+
+	// 1024..1041 is the "early" segment, 4096..4098 the "late" one; dataEnd is
+	// therefore 4099, and 8192 is BSS. The image is 2 pages, so a 4-page
+	// ceiling also exercises growing past it.
+	const main = `package main
+
+import (
+	"fmt"
+
+	"gentest/pkg"
+)
+
+func main() {
+	img := pkg.NewSharedImage(func() (*pkg.Module, error) { return pkg.New(), nil })
+	if err := img.Err(); err != nil {
+		fmt.Println("image:", err)
+		return
+	}
+	fmt.Println("dataEnd", img.DataEnd())
+
+	newInstance := func() *pkg.Module {
+		mem, err := img.Memory(4 * 65536)
+		if err != nil {
+			panic(err)
+		}
+		return pkg.NewWithMemory(mem, img.Size())
+	}
+	a, b := newInstance(), newInstance()
+
+	// Both see the segments the IMAGE's start section installed — and their
+	// own start section, which ran again over the shared pages, wrote nothing.
+	fmt.Printf("a=%q b=%q late=%q\n",
+		string([]byte{byte(a.Peek(1024)), byte(a.Peek(1025))}),
+		string([]byte{byte(b.Peek(1024)), byte(b.Peek(1025))}),
+		string([]byte{byte(a.Peek(4096)), byte(a.Peek(4097)), byte(a.Peek(4098))}))
+
+	// BSS is zero, not inherited.
+	fmt.Println("bss", a.Peek(8192))
+
+	// A write in a is private to a.
+	a.Poke(1024, 'X')
+	fmt.Printf("after poke a=%d b=%d\n", a.Peek(1024), b.Peek(1024))
+}
+`
+	out := runGoSnippetWithAux(t, buf.String(), main,
+		[]map[string][]byte{res.Sidecars, res.Files}, res.AuxFiles)
+
+	for _, want := range []string{
+		"dataEnd 4099",
+		`a="he" b="he" late="END"`,
+		"bss 0",
+		"after poke a=88 b=104", // 'X' in a, still 'h' in b
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// A snapshot is an image of a FULLY INITIALIZED instance, and its instances
+// re-run nothing. Prove both halves of that, because getting either wrong is
+// silent: the start section must NOT run again (the fixture's start bumps a
+// counter in memory, so a re-run shows up as 2), and the globals must be
+// restored from the snapshot (the fixture's start sets one to a value its
+// declared initializer does not have, so a global that was dropped shows up
+// as 0).
+//
+// And the sharing must still be copy-on-write: a write in one instance stays
+// out of the other.
+func TestSharedSnapshot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no mmap: the generated package falls back to private memory")
+	}
+	bin := testfixture.Wasm(t, "cg_sharedimage")
+	parsed, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, parsed, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const main = `package main
+
+import (
+	"fmt"
+
+	"gentest/pkg"
+)
+
+func main() {
+	snap := pkg.NewSharedSnapshot(func() (*pkg.Module, error) { return pkg.New(), nil })
+	if err := snap.Err(); err != nil {
+		fmt.Println("snapshot:", err)
+		return
+	}
+
+	newInstance := func() *pkg.Module {
+		mem, err := snap.Memory(4 * 65536)
+		if err != nil {
+			panic(err)
+		}
+		return pkg.NewFromSnapshot(mem, snap.Size(), snap.Globals())
+	}
+	a, b := newInstance(), newInstance()
+
+	// The start section ran ONCE, when the snapshot was built.
+	fmt.Println("start ran", a.Peek(100), "time(s) for a,", b.Peek(100), "for b")
+
+	// The globals came back with the memory.
+	fmt.Println("marker a", a.Marker(), "b", b.Marker())
+
+	// The segments are there, and still copy-on-write.
+	fmt.Printf("a=%q\n", string([]byte{byte(a.Peek(1024)), byte(a.Peek(1025))}))
+	a.Poke(1024, 'X')
+	fmt.Printf("after poke a=%d b=%d\n", a.Peek(1024), b.Peek(1024))
+}
+`
+	out := runGoSnippetWithAux(t, buf.String(), main,
+		[]map[string][]byte{res.Sidecars, res.Files}, res.AuxFiles)
+
+	for _, want := range []string{
+		"start ran 1 time(s) for a, 1 for b",
+		"marker a 42 b 42",
+		`a="he"`,
+		"after poke a=88 b=104",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/goccy/wasm2go/internal/codegen/sharedimage"
 	"github.com/goccy/wasm2go/internal/lower"
 	"github.com/goccy/wasm2go/internal/ssa"
 	"github.com/goccy/wasm2go/internal/ssa/pass"
@@ -359,6 +360,13 @@ func Translate(w io.Writer, m *wasm.Module, opts Options) (Result, error) {
 	}
 	out.Decls = append(out.Decls, helpers...)
 
+	// Globals save/restore — see emitGlobalsSnapshot; NewFromSnapshot calls it.
+	globalsSnap, err := t.emitGlobalsSnapshot()
+	if err != nil {
+		return Result{}, err
+	}
+	out.Decls = append(out.Decls, globalsSnap...)
+
 	// //go:embed declarations for data sidecars (if any).
 	out.Decls = append(out.Decls, t.emitSidecarDecls()...)
 
@@ -391,7 +399,152 @@ func Translate(w io.Writer, m *wasm.Module, opts Options) (Result, error) {
 		return Result{}, err
 	}
 	t.reportMemMetrics()
+	shared, err := t.emitSharedImage(opts.Package)
+	if err != nil {
+		return Result{}, err
+	}
+	for name, content := range shared {
+		if t.auxFiles == nil {
+			t.auxFiles = map[string][]byte{}
+		}
+		t.auxFiles[name] = content
+	}
 	return finalizeSinglePkgWithAsm(m, opts, w, goBuf.Bytes(), t.sidecars, t.auxFiles)
+}
+
+// emitGlobalsSnapshot emits SaveGlobals/RestoreGlobals over the module's
+// MUTABLE globals. They belong to the package that holds the Module struct,
+// because they are the only code that can see the gN fields.
+//
+// Globals live outside linear memory, so an image of an initialized instance's
+// memory is not by itself enough to reconstruct that instance: the guest's TLS
+// base and stack pointer are globals, and a Module built fresh would have them
+// at their declared init values (typically zero) with the memory saying
+// otherwise. These two carry them across. Immutable globals are skipped — they
+// cannot have moved, and the fresh Module already has them right.
+func (t *translator) emitGlobalsSnapshot() ([]ast.Decl, error) {
+	if len(t.mod.Memories) == 0 {
+		return nil, nil // no memory, no image, nobody to snapshot for
+	}
+	type gl struct {
+		field string
+		typ   wasm.ValType
+	}
+	var gs []gl
+	for i, g := range t.mod.Globals {
+		if !g.Type.Mutable {
+			continue
+		}
+		gs = append(gs, gl{
+			field: t.fieldName(fmt.Sprintf("g%d", int(t.mod.NumImportedGlobals)+i)),
+			typ:   g.Type.Type,
+		})
+	}
+
+	save := &strings.Builder{}
+	restore := &strings.Builder{}
+	needMath := false
+	for i, g := range gs {
+		switch g.typ {
+		case wasm.ValI32:
+			fmt.Fprintf(save, "\tg[%d] = uint64(uint32(m.%s))\n", i, g.field)
+			fmt.Fprintf(restore, "\tm.%s = int32(uint32(g[%d]))\n", g.field, i)
+		case wasm.ValI64:
+			fmt.Fprintf(save, "\tg[%d] = uint64(m.%s)\n", i, g.field)
+			fmt.Fprintf(restore, "\tm.%s = int64(g[%d])\n", g.field, i)
+		case wasm.ValF32:
+			needMath = true
+			fmt.Fprintf(save, "\tg[%d] = uint64(math.Float32bits(m.%s))\n", i, g.field)
+			fmt.Fprintf(restore, "\tm.%s = math.Float32frombits(uint32(g[%d]))\n", g.field, i)
+		case wasm.ValF64:
+			needMath = true
+			fmt.Fprintf(save, "\tg[%d] = math.Float64bits(m.%s)\n", i, g.field)
+			fmt.Fprintf(restore, "\tm.%s = math.Float64frombits(g[%d])\n", g.field, i)
+		default:
+			// A reference-typed global cannot be snapshotted as a scalar; it
+			// also cannot survive a process boundary. Leave it to the fresh
+			// Module's own initializer.
+			fmt.Fprintf(save, "\t// g%d: reference type, not snapshottable\n", i)
+		}
+	}
+	if needMath {
+		t.use("math")
+	}
+
+	saveName, restoreName := "saveGlobals", "restoreGlobals"
+	if t.multiPackage {
+		saveName, restoreName = "SaveGlobals", "RestoreGlobals"
+	}
+	src := fmt.Sprintf(`package p
+
+%s
+
+// %s returns the module's mutable globals, in a form that can be handed back
+// to %s. It is how a snapshot of an instance captures the state that does not
+// live in linear memory.
+func %s(m *Module) []uint64 {
+	g := make([]uint64, %d)
+%s	return g
+}
+
+// %s puts a snapshot's globals back. A snapshot from a different module (or a
+// different build of the same one) has a different global count; rather than
+// index out of bounds, take what fits and leave the rest at their declared
+// initializers.
+func %s(m *Module, g []uint64) {
+	if len(g) != %d {
+		return
+	}
+%s}
+`,
+		mathImport(needMath),
+		saveName, restoreName, saveName, len(gs), save.String(),
+		restoreName, restoreName, len(gs), restore.String())
+
+	f, err := parser.ParseFile(t.fset, "globals_snapshot.go", src, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("wasm2go: emitting the globals snapshot: %w", err)
+	}
+	var decls []ast.Decl
+	for _, d := range f.Decls {
+		if _, ok := d.(*ast.FuncDecl); ok {
+			decls = append(decls, d)
+		}
+	}
+	return decls, nil
+}
+
+// mathImport is the import block emitGlobalsSnapshot's synthetic file needs to
+// parse; the decls are then lifted out and the import is registered on the real
+// file through t.use.
+func mathImport(need bool) string {
+	if need {
+		return `import "math"`
+	}
+	return ""
+}
+
+// emitSharedImage renders the copy-on-write shared-memory-image runtime into
+// the package that holds the Module struct. It reads three of that struct's
+// fields, and their names differ between single- and multi-package output
+// (multi-package exports them), so the source is a template rather than a
+// fixed file. A module with no linear memory has nothing to share.
+func (t *translator) emitSharedImage(pkg string) (map[string][]byte, error) {
+	if len(t.mod.Memories) == 0 {
+		return nil, nil
+	}
+	saveGlobals := "saveGlobals"
+	if t.multiPackage {
+		saveGlobals = "SaveGlobals"
+	}
+	return sharedimage.Files(sharedimage.Names{
+		Pkg:         pkg,
+		Module:      "Module",
+		Memory:      t.fieldName("memory"),
+		MemSize:     t.fieldName("memSize"),
+		DataEnd:     t.fieldName("dataEnd"),
+		SaveGlobals: saveGlobals,
+	})
 }
 
 // finalizeSinglePkgWithAsm is the asm-always-on tail of single-package
@@ -515,6 +668,10 @@ type translator struct {
 
 	// helpersFile is parsed lazily by emitHelpers.
 	helpersFile *ast.File
+
+	// passiveLocs maps original data-segment index → its span in the data.bin
+	// blob, for passive segments only (dataSegs views are sliced from these).
+	passiveLocs map[int]blobSpan
 
 	// sidecars maps sidecar filename → bytes (populated when DataSidecar is true).
 	sidecars map[string][]byte
@@ -714,6 +871,18 @@ func (t *translator) wasmExcTypeExpr() ast.Expr {
 		return &ast.SelectorExpr{X: newID("base"), Sel: newID("WasmExc")}
 	}
 	return newID("wasmExc")
+}
+
+// threadPoolTypeExpr names the wasi-threads pool type, mirroring
+// wasmExcTypeExpr: exported and homed in `base` under multi-package output.
+func (t *translator) threadPoolTypeExpr() ast.Expr {
+	if t.multiPackage {
+		if t.currentChunk == chunkBase {
+			return newID("ThreadPool")
+		}
+		return &ast.SelectorExpr{X: newID("base"), Sel: newID("ThreadPool")}
+	}
+	return newID("threadPool")
 }
 
 // helperRef returns the AST expression that names a helper function. In
@@ -1053,6 +1222,14 @@ func (t *translator) use(pkg string) { t.imports[pkg] = "" }
 // useHelper marks a helper as needed.
 func (t *translator) useHelper(name string) { t.helpers[name] = true }
 
+// importHandledInternally reports whether a wasm import never surfaces to the
+// host because the code generator implements it inline (today: wasi-threads'
+// thread-spawn, which becomes a goroutine).
+func importHandledInternally(imp wasm.Import) bool {
+	return (imp.Module == "wasi" && imp.Name == "thread-spawn") ||
+		(imp.Module == "wasi_snapshot_preview1" && imp.Name == "thread_spawn")
+}
+
 // knownImportModuleOrder is the fixed parameter order for the host-import
 // modules the wasmify pipeline emits: the WASI host interface first, then env,
 // then the wasmify bridge module. The generated constructor (New / NewWithWASI)
@@ -1069,6 +1246,13 @@ var knownImportModuleOrder = []string{"wasi_snapshot_preview1", "env", "wasmify"
 func (t *translator) collectImportModules() {
 	present := map[string]bool{}
 	for _, imp := range t.mod.Imports {
+		if importHandledInternally(imp) {
+			// wasi-threads' thread-spawn never reaches the host — the emitter
+			// maps it onto a goroutine spawn — so it must not surface as a
+			// constructor parameter / host interface either. A module whose
+			// imports are ALL internal disappears from the signature.
+			continue
+		}
 		present[imp.Module] = true
 	}
 	// Emit the known modules first, in the prescribed order, if the wasm uses them.
@@ -1095,9 +1279,13 @@ func (t *translator) emitImportInterfaces() []ast.Decl {
 	if len(t.mod.Imports) == 0 {
 		return nil
 	}
-	// Group imports by module name.
+	// Group imports by module name (internal ones — goroutine-backed
+	// thread-spawn — never surface as interface methods).
 	byMod := map[string][]wasm.Import{}
 	for _, imp := range t.mod.Imports {
+		if importHandledInternally(imp) {
+			continue
+		}
 		byMod[imp.Module] = append(byMod[imp.Module], imp)
 	}
 	var decls []ast.Decl
@@ -1240,11 +1428,72 @@ func (t *translator) emitModuleStruct() ast.Decl {
 	// memory/maxMem/M offsets the generated asm hardcodes (moduleMOffset)
 	// are unaffected.
 	if len(t.mod.Memories) > 0 {
+		// memMu/memSize/threads are pointers: a wasi-threads agent runs on
+		// a struct COPY of the Module (own globals, shared everything else),
+		// and this state must stay shared across the copies.
 		fields = append(fields, &ast.Field{
 			Names: []*ast.Ident{newID(t.fieldName("memMu"))},
-			Type:  &ast.SelectorExpr{X: newID("sync"), Sel: newID("Mutex")},
+			Type:  &ast.StarExpr{X: &ast.SelectorExpr{X: newID("sync"), Sel: newID("Mutex")}},
 		})
 		t.use("sync")
+
+		// memSize is the CURRENT linear-memory size in bytes. For a shared
+		// memory (threads proposal) the slice header is immutable after
+		// New() — len == cap == the declared maximum, reserved once as
+		// virtual address space that only becomes resident as the guest
+		// touches it — so growth is a lone atomic store here and the data
+		// pointer other agents deref through never moves. Size-consulting
+		// helpers read this atomically; the hot load/store path reads
+		// neither (it derefs m.M), so threads cost it nothing.
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{newID(t.fieldName("memSize"))},
+			Type:  &ast.StarExpr{X: &ast.SelectorExpr{X: newID("atomic"), Sel: newID("Uint64")}},
+		})
+		t.use("sync/atomic")
+		// dataSegs are the module's PASSIVE data segments (views into the
+		// embedded data blob), indexed by their original data-section index —
+		// memory.init names them by that index. Active segments hold nil (a
+		// memory.init on one traps, same as post-drop). data.drop nils the
+		// entry out.
+		if t.hasPassiveData() {
+			fields = append(fields, &ast.Field{
+				Names: []*ast.Ident{newID(t.fieldName("dataSegs"))},
+				Type:  &ast.ArrayType{Elt: &ast.ArrayType{Elt: newID("byte")}},
+			})
+		}
+		// dataEnd is where the data segments stop and BSS begins. The
+		// constructor seeds it from the ACTIVE segments (their extent is known
+		// here, at compile time) and memoryInit raises it for the PASSIVE ones,
+		// whose destinations are wasm constants the host cannot see until the
+		// start section runs them. SharedImage is the consumer: it may share
+		// everything below this line and must zero everything above it.
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{newID(t.fieldName("dataEnd"))},
+			Type:  newID("uint32"),
+		})
+		// memShared records whether the memory was declared shared, which
+		// is what makes the reslice-free grow above legal.
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{newID(t.fieldName("memShared"))},
+			Type:  newID("bool"),
+		})
+		// threads holds the wasi-threads agents (a wasm thread is a
+		// goroutine) and the wait/notify parking lot. Zero-sized until the
+		// guest actually spawns or blocks.
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{newID(t.fieldName("threads"))},
+			Type:  &ast.StarExpr{X: t.threadPoolTypeExpr()},
+		})
+		// threadStart carries the wasi_thread_start export as a function
+		// value: multi-package output emits exports as free functions in the
+		// main package, so base's threadSpawn helper cannot reach them any
+		// other way (no method to assert, no upward import).
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{newID(t.fieldName("threadStart"))},
+			Type: &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{
+				{Type: t.moduleType()}, {Type: newID("int32")}, {Type: newID("int32")},
+			}}},
+		})
 	}
 
 	return &ast.GenDecl{
@@ -1256,8 +1505,81 @@ func (t *translator) emitModuleStruct() ast.Decl {
 	}
 }
 
-// emitNewFuncs is the underlying constructor emitter; see emitNewFunc.
+// blobSpan is a byte range in the embedded data.bin blob.
+type blobSpan struct {
+	start  int
+	length int
+}
+
+// memIsShared reports whether memory 0 is a threads-proposal SHARED memory.
+// Plain loads/stores against a shared memory are emitted through noinline
+// helpers so cross-agent coherence survives the Go compiler.
+func (t *translator) memIsShared() bool {
+	return len(t.mod.Memories) > 0 && t.mod.Memories[0].Limits.Shared
+}
+
+// hasPassiveData reports whether the module carries passive data segments
+// (LLVM's shared-memory output always does).
+func (t *translator) hasPassiveData() bool {
+	for _, ds := range t.mod.Datas {
+		if ds.Passive {
+			return true
+		}
+	}
+	return false
+}
+
+// newMode selects which constructor emitNewFuncsMode is building.
+type newMode int
+
+const (
+	// newAlloc allocates and initializes the linear memory itself: New,
+	// NewWithWASI, NewWithWASIReserve.
+	newAlloc newMode = iota
+	// newFromMemory takes the memory from the caller (NewWithMemory) and skips
+	// copying the active data segments into it — the caller's memory already
+	// holds them. The start section still runs, because the caller's memory is
+	// an image of the data segments and nothing more.
+	newFromMemory
+	// newFromSnapshot takes the memory AND the wasm globals from the caller
+	// (NewFromSnapshot): a snapshot of an instance that has already been fully
+	// initialized. Nothing is re-run — not the data segments, not the start
+	// section — because everything they would do is already in the snapshot,
+	// and re-running the start section over it would trap on its own
+	// already-ran flag.
+	newFromSnapshot
+)
+
+// emitNewFuncs emits the constructor family: the allocating ones, plus the two
+// that take the linear memory from the caller. Those two are the hook an
+// embedding needs to share memory across instances (map an image copy-on-write
+// and its unwritten pages cost nothing per instance) — NewWithMemory for an
+// image of the data segments, NewFromSnapshot for an image of a whole
+// initialized instance.
 func (t *translator) emitNewFuncs() []ast.Decl {
+	decls := t.emitNewFuncsMode(newAlloc)
+	if len(t.mod.Memories) > 0 {
+		decls = append(decls, t.emitNewFuncsMode(newFromMemory)...)
+		decls = append(decls, t.emitNewFuncsMode(newFromSnapshot)...)
+	}
+	return decls
+}
+
+// memLenExpr is uint64(len(memory)): with a caller-supplied memory the
+// allocation itself is the ceiling, so the wasm's declared maximum does not
+// enter into it.
+func memLenExpr() ast.Expr {
+	return &ast.CallExpr{
+		Fun:  newID("uint64"),
+		Args: []ast.Expr{&ast.CallExpr{Fun: newID("len"), Args: []ast.Expr{newID("memory")}}},
+	}
+}
+
+// emitNewFuncsMode builds the constructors. With memFromArg, it emits ONLY
+// NewWithMemory: the same body, except the linear memory (and the size the
+// guest sees) come from parameters.
+func (t *translator) emitNewFuncsMode(mode newMode) []ast.Decl {
+	memFromArg := mode != newAlloc
 	primaryName := "New"
 	emitNativeWASIWrapper := false
 	wasiIdx := -1
@@ -1298,7 +1620,21 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 	// the thin NewWithWASI / New delegators. The primary gets reserveBytes
 	// appended when emitReserve.
 	modParams := params
-	if emitReserve {
+	if memFromArg {
+		primaryName = "NewWithMemory"
+		emitReserve = false
+		params = append(append([]*ast.Field{}, params...),
+			&ast.Field{Names: []*ast.Ident{newID("memory")}, Type: &ast.ArrayType{Elt: newID("byte")}},
+			&ast.Field{Names: []*ast.Ident{newID("memSize")}, Type: newID("uint64")},
+		)
+		if mode == newFromSnapshot {
+			primaryName = "NewFromSnapshot"
+			params = append(params, &ast.Field{
+				Names: []*ast.Ident{newID("globals")},
+				Type:  &ast.ArrayType{Elt: newID("uint64")},
+			})
+		}
+	} else if emitReserve {
 		params = append(append([]*ast.Field{}, params...), &ast.Field{
 			Names: []*ast.Ident{newID("reserveBytes")},
 			Type:  newID("int"),
@@ -1372,18 +1708,118 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 		} else {
 			capArg = uintLit(defaultReserveCap)
 		}
+		// A SHARED memory (threads proposal, which requires a declared
+		// maximum) is allocated at its ceiling LENGTH once: other agents
+		// deref the data pointer concurrently, so the backing array must
+		// never move and the slice must never be re-made. Growth is then a
+		// lone atomic store (memSize), and the hot load/store path stays
+		// lock- and atomic-free.
+		//
+		// The ceiling is a RUNTIME value, not the wasm's declared maximum:
+		// NewWithReserve's caller passes the memory cap it wants to enforce,
+		// and a host that means to allow more than the module declares is
+		// entitled to — the declared max is a property of the binary, not a
+		// policy. Untouched pages of the allocation never become resident
+		// (Go mmaps a large slice; the OS pages it in on demand), so a
+		// generous ceiling costs address space, not memory.
+		lenArg := ast.Expr(uintLit(minBytesU))
+		if memFromArg {
+			// The caller owns the allocation: it may be a copy-on-write map
+			// of a pre-initialized image shared by every instance. Nothing
+			// here may touch it — a write would fault in a private copy of
+			// the page and undo the sharing.
+			lenArg = nil
+			capArg = nil
+		} else if mem.Limits.Shared {
+			ceiling := ast.Expr(uintLit(defaultReserveCap))
+			if mem.Limits.HasMax {
+				ceiling = uintLit(mem.Limits.Max * 65536)
+			}
+			if emitReserve {
+				// __memcap is reserveBytes clamped up to minBytes; for a
+				// shared memory it IS the ceiling, so a caller passing 0
+				// falls back to the declared maximum rather than to a
+				// headroom that could not grow later.
+				body.List = append(body.List, &ast.IfStmt{
+					Cond: &ast.BinaryExpr{
+						X:  newID("__memcap"),
+						Op: token.LSS,
+						Y:  ceiling,
+					},
+					Body: &ast.BlockStmt{List: []ast.Stmt{&ast.AssignStmt{
+						Tok: token.ASSIGN,
+						Lhs: []ast.Expr{newID("__memcap")},
+						Rhs: []ast.Expr{ceiling},
+					}}},
+				})
+				lenArg = newID("__memcap")
+				capArg = newID("__memcap")
+			} else {
+				lenArg = ceiling
+				capArg = ceiling
+			}
+		}
+		memRhs := ast.Expr(&ast.CallExpr{
+			Fun: newID("make"),
+			Args: []ast.Expr{
+				&ast.ArrayType{Elt: newID("byte")},
+				lenArg,
+				capArg,
+			},
+		})
+		if memFromArg {
+			memRhs = newID("memory")
+		}
 		body.List = append(body.List, &ast.AssignStmt{
 			Tok: token.ASSIGN,
 			Lhs: []ast.Expr{t.fieldRef("memory")},
-			Rhs: []ast.Expr{&ast.CallExpr{
-				Fun: newID("make"),
-				Args: []ast.Expr{
-					&ast.ArrayType{Elt: newID("byte")},
-					uintLit(minBytesU),
-					capArg,
-				},
-			}},
+			Rhs: []ast.Expr{memRhs},
 		})
+		// memSize is the size the guest sees; for a shared memory it is the
+		// only thing growth changes.
+		// The pointered shared-state fields exist exactly once, on the
+		// PRIMARY module; agent clones copy the pointers and share them.
+		body.List = append(body.List, &ast.AssignStmt{
+			Tok: token.ASSIGN,
+			Lhs: []ast.Expr{t.fieldRef("memMu")},
+			Rhs: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: &ast.CompositeLit{
+				Type: &ast.SelectorExpr{X: newID("sync"), Sel: newID("Mutex")},
+			}}},
+		})
+		body.List = append(body.List, &ast.AssignStmt{
+			Tok: token.ASSIGN,
+			Lhs: []ast.Expr{t.fieldRef("memSize")},
+			Rhs: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: &ast.CompositeLit{
+				Type: &ast.SelectorExpr{X: newID("atomic"), Sel: newID("Uint64")},
+			}}},
+		})
+		body.List = append(body.List, &ast.AssignStmt{
+			Tok: token.ASSIGN,
+			Lhs: []ast.Expr{t.fieldRef("threads")},
+			Rhs: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: &ast.CompositeLit{
+				Type: t.threadPoolTypeExpr(),
+			}}},
+		})
+		sizeArg := ast.Expr(uintLit(minBytesU))
+		if memFromArg {
+			// The image the caller handed us is already initialized; its
+			// grown size travels with it.
+			sizeArg = newID("memSize")
+		}
+		body.List = append(body.List, &ast.ExprStmt{X: &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.SelectorExpr{X: newID("m"), Sel: newID(t.fieldName("memSize"))},
+				Sel: newID("Store"),
+			},
+			Args: []ast.Expr{sizeArg},
+		}})
+		if mem.Limits.Shared {
+			body.List = append(body.List, &ast.AssignStmt{
+				Tok: token.ASSIGN,
+				Lhs: []ast.Expr{t.fieldRef("memShared")},
+				Rhs: []ast.Expr{newID("true")},
+			})
+		}
 		// Prime the m.M cache so the first load/store doesn't need a
 		// special-case "is M still nil" check. memoryGrow's reallocate
 		// path keeps M in sync.
@@ -1416,17 +1852,25 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 					}},
 				}}
 			}
+			maxRhs := ast.Expr(uintLit(mem.Limits.Max * 65536))
+			if memFromArg {
+				maxRhs = memLenExpr()
+			}
 			body.List = append(body.List, &ast.AssignStmt{
 				Tok: token.ASSIGN,
 				Lhs: []ast.Expr{t.fieldRef("maxMem")},
-				Rhs: []ast.Expr{uintLit(mem.Limits.Max * 65536)},
+				Rhs: []ast.Expr{maxRhs},
 			})
 		} else {
 			// 4 GiB default cap (wasm32 limit).
+			maxRhs := ast.Expr(uintLit(1 << 32))
+			if memFromArg {
+				maxRhs = memLenExpr()
+			}
 			body.List = append(body.List, &ast.AssignStmt{
 				Tok: token.ASSIGN,
 				Lhs: []ast.Expr{t.fieldRef("maxMem")},
-				Rhs: []ast.Expr{uintLit(1 << 32)},
+				Rhs: []ast.Expr{maxRhs},
 			})
 		}
 	}
@@ -1508,7 +1952,7 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 		// helpers that only reference its own Fn<idx> values (zero linkname
 		// forwards from chunk into other chunks). Main calls each helper
 		// via linkname forward — bounded by num_chunks × num_batches.
-		if err := t.emitShardedElementInit(body); err != nil {
+		if err := t.emitShardedElementInit(body, memFromArg); err != nil {
 			return []ast.Decl{&ast.FuncDecl{
 				Name: newID("New"),
 				Type: &ast.FuncType{
@@ -1587,7 +2031,11 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 					Args: []ast.Expr{newID("m")},
 				}})
 			}
-			t.elemInitChunks = append(t.elemInitChunks, chunkDecls...)
+			if !memFromArg {
+				// Emitted once: building the body a second time (for
+				// NewWithMemory) must not redeclare these.
+				t.elemInitChunks = append(t.elemInitChunks, chunkDecls...)
+			}
 		}
 	}
 
@@ -1614,6 +2062,9 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 		}
 		raws := make([]rawSeg, 0, len(t.mod.Datas))
 		for i, ds := range t.mod.Datas {
+			if ds.Passive {
+				continue // becomes a dataSegs view below, not a New()-time copy
+			}
 			off, err := evalConstExprI64(ds.Offset, t.mod)
 			if err != nil {
 				body.List = append(body.List, &ast.ExprStmt{X: &ast.CallExpr{
@@ -1625,6 +2076,25 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 			raws = append(raws, rawSeg{memOff: off, bytes: ds.Bytes})
 		}
 		sort.Slice(raws, func(i, j int) bool { return raws[i].memOff < raws[j].memOff })
+		// Seed dataEnd with the active segments' extent. Passive segments are
+		// added by memoryInit when the start section installs them; an active
+		// one is copied right here, so its end is known now. Emitted even when
+		// the memory came from the caller (memFromArg) and the copies below are
+		// skipped: the bytes are in that memory already, and dataEnd describes
+		// the memory, not the copying.
+		if len(raws) > 0 {
+			var maxEnd int64
+			for _, r := range raws {
+				if end := r.memOff + int64(len(r.bytes)); end > maxEnd {
+					maxEnd = end
+				}
+			}
+			body.List = append(body.List, &ast.AssignStmt{
+				Lhs: []ast.Expr{t.fieldRef("dataEnd")},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{uintLit(uint64(maxEnd))},
+			})
+		}
 		// Coalescing reorders writes by offset, which is only safe when
 		// no two segments overlap (overlapping active segments must be
 		// applied in data-section order). Real C++→wasm output never
@@ -1664,6 +2134,18 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 			segs = append(segs, segLoc{memOff: spanMemOff, start: spanStart, length: len(concat) - spanStart})
 			i = j
 		}
+		// Passive segments ride in the same blob, after the active spans.
+		// They are NOT copied into memory here — memory.init does that at the
+		// guest's request (for LLVM shared-memory output, from the
+		// __wasm_init_memory start function, exactly once).
+		t.passiveLocs = make(map[int]blobSpan)
+		for i, ds := range t.mod.Datas {
+			if !ds.Passive {
+				continue
+			}
+			t.passiveLocs[i] = blobSpan{start: len(concat), length: len(ds.Bytes)}
+			concat = append(concat, ds.Bytes...)
+		}
 		t.sidecars["data.bin"] = concat
 		blobIdent := newID("wasm2goData_" + sanitizeFilename("data.bin"))
 		const dataChunkSize = 256
@@ -1692,6 +2174,10 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 				}})
 			}
 			chunkName := fmt.Sprintf("initData_%d", c)
+			if memFromArg {
+				// See above: definitions once, calls per constructor.
+				continue
+			}
 			t.elemInitChunks = append(t.elemInitChunks, &ast.FuncDecl{
 				Name: newID(chunkName),
 				Type: &ast.FuncType{
@@ -1709,6 +2195,79 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 		}
 	}
 
+	// Passive data segments: register blob views under their ORIGINAL
+	// data-section indices so memory.init can name them. The blob is the same
+	// embedded data.bin the active segments use; passive bytes were appended
+	// after the active spans by the emission above.
+	if t.hasPassiveData() {
+		elts := make([]ast.Expr, len(t.mod.Datas))
+		for i, ds := range t.mod.Datas {
+			if !ds.Passive {
+				elts[i] = newID("nil")
+				continue
+			}
+			loc := t.passiveLocs[i]
+			elts[i] = &ast.SliceExpr{
+				X:    newID("wasm2goData_" + sanitizeFilename("data.bin")),
+				Low:  uintLit(uint64(loc.start)),
+				High: uintLit(uint64(loc.start + loc.length)),
+			}
+		}
+		body.List = append(body.List, &ast.AssignStmt{
+			Tok: token.ASSIGN,
+			Lhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID(t.fieldName("dataSegs"))}},
+			Rhs: []ast.Expr{&ast.CompositeLit{
+				Type: &ast.ArrayType{Elt: &ast.ArrayType{Elt: newID("byte")}},
+				Elts: elts,
+			}},
+		})
+	}
+
+	// Wire the wasi_thread_start export into the Module so threadSpawn (in
+	// base) can launch agents without reaching into this package.
+	for _, exp := range t.mod.Exports {
+		if exp.Kind != wasm.ExportFunc || exp.Name != "wasi_thread_start" || !t.funcReachable(exp.Index) {
+			continue
+		}
+		// The export already takes the module as its first parameter, so the
+		// function value itself is what goes in the field — a closure over
+		// the PRIMARY module here would defeat the per-agent clone that
+		// threadSpawn passes in.
+		body.List = append(body.List, &ast.AssignStmt{
+			Tok: token.ASSIGN,
+			Lhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID(t.fieldName("threadStart"))}},
+			Rhs: []ast.Expr{t.funcRef(exp.Index)},
+		})
+		break
+	}
+
+	// The wasm start section runs at instantiation, before any export is
+	// callable. Under LLVM's shared-memory scheme this is __wasm_init_memory:
+	// it memory.inits every passive segment exactly once (guarded by an
+	// atomic flag) and data.drops them.
+	//
+	// A snapshot skips it, and must: the snapshot was taken from an instance
+	// that already ran it, so the flag it guards itself with is set in the
+	// snapshotted memory and a second run would trap on it. Everything the
+	// start section does is in the snapshot already.
+	if t.mod.Start != nil && *t.mod.Start >= t.mod.NumImportedFuncs && mode != newFromSnapshot {
+		body.List = append(body.List, &ast.ExprStmt{X: &ast.CallExpr{
+			Fun:  t.funcRef(*t.mod.Start),
+			Args: []ast.Expr{newID("m")},
+		}})
+	}
+
+	// A snapshot's globals are as load-bearing as its memory: the guest's TLS
+	// base, its shadow-stack pointer, anything else the initialization moved
+	// off its declared value. They live outside linear memory, so the image
+	// cannot carry them — the caller passes them alongside it.
+	if mode == newFromSnapshot {
+		body.List = append(body.List, &ast.ExprStmt{X: &ast.CallExpr{
+			Fun:  t.helperRef("restoreGlobals"),
+			Args: []ast.Expr{newID("m"), newID("globals")},
+		}})
+	}
+
 	body.List = append(body.List, &ast.ReturnStmt{Results: []ast.Expr{newID("m")}})
 
 	primary := &ast.FuncDecl{
@@ -1718,6 +2277,12 @@ func (t *translator) emitNewFuncs() []ast.Decl {
 			Results: &ast.FieldList{List: []*ast.Field{{Type: t.moduleType()}}},
 		},
 		Body: body,
+	}
+	if memFromArg {
+		// NewWithMemory only: the delegators (New / NewWithWASI) exist to
+		// pick an allocation for the caller, and this variant's caller has
+		// already made that choice.
+		return []ast.Decl{primary}
 	}
 	if !emitNativeWASIWrapper {
 		return []ast.Decl{primary}
@@ -1883,23 +2448,38 @@ func (t *translator) compileBodyViaSSA(funcIdx uint32, fn wasm.Function) (*ast.B
 		return nil, err
 	}
 	insBefore := ssa.CountValues(ssaFn)
+	// WASM2GO_SSA_PASSES_OFF disables individual optimization passes (comma
+	// list of constprop,branchfold,simplify,cse,dce — or "all"). Diagnostic
+	// escape hatch for bisecting a suspected pass miscompile; not a
+	// supported build mode.
+	passesOff := map[string]bool{}
+	if env := os.Getenv("WASM2GO_SSA_PASSES_OFF"); env != "" {
+		for _, p := range strings.Split(env, ",") {
+			passesOff[strings.TrimSpace(strings.ToLower(p))] = true
+		}
+		if passesOff["all"] {
+			for _, p := range []string{"constprop", "branchfold", "simplify", "cse", "dce"} {
+				passesOff[p] = true
+			}
+		}
+	}
 	const optFixpointCap = 8
 	fixpointReached := false
 	for i := 0; i < optFixpointCap; i++ {
 		changed := false
-		if pass.ConstProp(ssaFn) {
+		if !passesOff["constprop"] && pass.ConstProp(ssaFn) {
 			changed = true
 		}
-		if pass.BranchFold(ssaFn) {
+		if !passesOff["branchfold"] && pass.BranchFold(ssaFn) {
 			changed = true
 		}
-		if pass.Simplify(ssaFn) {
+		if !passesOff["simplify"] && pass.Simplify(ssaFn) {
 			changed = true
 		}
-		if pass.CSE(ssaFn) {
+		if !passesOff["cse"] && pass.CSE(ssaFn) {
 			changed = true
 		}
-		if pass.DCE(ssaFn) {
+		if !passesOff["dce"] && pass.DCE(ssaFn) {
 			changed = true
 		}
 		if !changed {
@@ -2035,7 +2615,12 @@ func shardInitElemName(chunkIdx, batch int) string {
 //
 // initBody is the statement list of New()'s body; helper-call statements
 // are appended in chunk-order, batch-order.
-func (t *translator) emitShardedElementInit(initBody *ast.BlockStmt) error {
+// defsEmitted: the constructor body is built twice (New* and NewWithMemory),
+// and the per-chunk InitElemSeg_* helpers must be DEFINED once while both
+// bodies CALL them. The element segments populate the function table — a Go
+// slice, not linear memory — so even an instance whose memory came from the
+// shared image has to run them.
+func (t *translator) emitShardedElementInit(initBody *ast.BlockStmt, defsEmitted bool) error {
 	// Per-chunk slot writes: chunkIdx -> []slotWrite (one entry per slot
 	// whose funcIdx is owned by that chunk).
 	type slotWrite struct {
@@ -2105,15 +2690,18 @@ func (t *translator) emitShardedElementInit(initBody *ast.BlockStmt) error {
 				})
 			}
 			helperName := shardInitElemName(ck, b)
-			t.addChunkExtraDecl(ck, &ast.FuncDecl{
-				Name: newID(helperName),
-				Type: helperSig,
-				Body: helperBody,
-			})
+			if !defsEmitted {
+				t.addChunkExtraDecl(ck, &ast.FuncDecl{
+					Name: newID(helperName),
+					Type: helperSig,
+					Body: helperBody,
+				})
+				t.registerLinknameSymbol(-1, helperName, ck, helperSig)
+			}
 			t.currentChunk = prev
 
-			// Main: register linkname forward + emit call.
-			t.registerLinknameSymbol(-1, helperName, ck, helperSig)
+			// The CALL goes into every constructor body; the definition above
+			// is emitted once (see the doc comment).
 			initBody.List = append(initBody.List, &ast.ExprStmt{X: &ast.CallExpr{
 				Fun:  newID(helperName),
 				Args: []ast.Expr{newID("m")},
@@ -2479,6 +3067,14 @@ func (t *translator) emitHelpers() ([]ast.Decl, error) {
 				t.use("runtime")
 			case "unsafe":
 				t.use("unsafe")
+			case "atomic":
+				t.use("sync/atomic")
+			case "time":
+				t.use("time")
+			case "bytes":
+				t.use("bytes")
+			case "sync":
+				t.use("sync")
 			}
 			return true
 		})
@@ -2497,6 +3093,12 @@ func (t *translator) emitHelpers() ([]ast.Decl, error) {
 				rewriteNames[k] = true
 			}
 			rewriteNames["wasmExc"] = true
+			// The threads types live in base and are exported there
+			// (ThreadPool/WasiThreadStarter); helper bodies that name them
+			// (threadSpawn's interface assertion, the pool methods) must
+			// follow, or base won't compile.
+			rewriteNames["threadPool"] = true
+			rewriteNames["wasiThreadStarter"] = true
 			renamed := *fn
 			renamed.Name = newID(capitalize(fn.Name.Name))
 			// Only rebuild the signature when it actually references a rewritten
@@ -2516,6 +3118,60 @@ func (t *translator) emitHelpers() ([]ast.Decl, error) {
 	// must be exported (WasmExc) so chunk packages can name it; single-package
 	// keeps it unexported (wasmExc). Field names (Tag, Vals) are already
 	// exported, so only the type name needs capitalizing.
+	// Memory-bearing modules always carry the threads types: the Module struct
+	// embeds threadPool (memSize/memShared/threads are declared together), and
+	// threadSpawn asserts the module against wasiThreadStarter. Both are
+	// zero-cost when the guest never spawns.
+	if len(t.mod.Memories) > 0 {
+		for _, decl := range t.helpersFile.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || (ts.Name.Name != "threadPool" && ts.Name.Name != "wasiThreadStarter") {
+					continue
+				}
+				emitted := ts
+				if t.multiPackage {
+					renamed := *ts
+					renamed.Name = newID(capitalize(ts.Name.Name))
+					emitted = &renamed
+				}
+				out = append(out, &ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{emitted}})
+			}
+		}
+		// threadPool's methods (wake) ride along with the type.
+		for _, decl := range t.helpersFile.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				continue
+			}
+			star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			id, ok := star.X.(*ast.Ident)
+			if !ok || id.Name != "threadPool" {
+				continue
+			}
+			if t.multiPackage {
+				// The receiver type was exported above; the methods must
+				// follow it (and their bodies may name other helpers).
+				renamed := *fn
+				recv := *fn.Recv.List[0]
+				recv.Type = &ast.StarExpr{X: newID("ThreadPool")}
+				renamed.Recv = &ast.FieldList{List: []*ast.Field{&recv}}
+				renamed.Body = rewriteHelperBody(fn.Body, map[string]bool{
+					"threadPool": true, "wasiThreadStarter": true,
+				})
+				out = append(out, &renamed)
+				continue
+			}
+			out = append(out, fn)
+		}
+	}
 	if t.usesWasmExc {
 		for _, decl := range t.helpersFile.Decls {
 			gd, ok := decl.(*ast.GenDecl)
@@ -2536,6 +3192,43 @@ func (t *translator) emitHelpers() ([]ast.Decl, error) {
 				out = append(out, &ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{emitted}})
 			}
 		}
+	}
+	// One stdlib scan over EVERYTHING emitHelpers emits — functions, type
+	// decls, methods. The per-function scan above misses types: ThreadPool
+	// carries atomic.Int32/sync.WaitGroup fields, and emitting it into base
+	// without registering sync/atomic left the base package uncompilable
+	// (the base import snapshot is taken before the Module struct's own
+	// use() calls run).
+	for _, decl := range out {
+		ast.Inspect(decl, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			id, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			switch id.Name {
+			case "math":
+				t.use("math")
+			case "bits":
+				t.use("math/bits")
+			case "binary":
+				t.use("encoding/binary")
+			case "runtime":
+				t.use("runtime")
+			case "unsafe":
+				t.use("unsafe")
+			case "atomic":
+				t.use("sync/atomic")
+			case "time":
+				t.use("time")
+			case "sync":
+				t.use("sync")
+			}
+			return true
+		})
 	}
 	return out, nil
 }
@@ -2564,209 +3257,54 @@ func capitalizeModuleFieldRefs(body *ast.BlockStmt) *ast.BlockStmt {
 	return rewriteHelperBody(body, nil)
 }
 
-// rewriteHelperBody rewrites a helper-function body for emission in
-// multi-package mode. Two changes are applied recursively across the
-// AST:
+// rewriteHelperBody rewrites a helper body for multi-package output, IN
+// PLACE: `m.<field>` selectors get exported field names, and bare identifiers
+// in the rename set (helper functions, the wasmExc/threads types) get
+// capitalized. A previous version hand-walked the AST node by node and
+// silently skipped every node type it didn't enumerate — helpers using
+// select/go/defer (the atomics wait/park helpers) kept lowercase references
+// and broke the base package. ast.Inspect visits everything.
 //
-//  1. `m.<lowercase>` selectors become `m.<Capitalized>` so helper code
-//     keeps referencing the (now-exported) Module fields.
-//  2. Bare-ident calls whose name matches another helper get
-//     capitalized (e.g. i32_div_u_s's body calls i32_div_u → I32_div_u)
-//     so the helper-to-helper edges resolve inside the base package.
-//
-// Returns a fresh AST so the shared helpersFile isn't mutated across
-// calls.
+// Two passes: the first records every SelectorExpr.Sel identifier so the
+// second never confuses a field/method selector with a bare name — `x.wake`
+// must not become `x.Wake` just because a helper is named wake.
 func rewriteHelperBody(body *ast.BlockStmt, helperNames map[string]bool) *ast.BlockStmt {
-	return rewriteHelperNode(body, helperNames).(*ast.BlockStmt)
+	rewriteHelperInPlace(body, helperNames)
+	return body
 }
 
-// rewriteHelperNode is the recursive worker for rewriteHelperBody.
+// rewriteHelperNode applies the same rewrite to any node (used for helper
+// signatures whose types name wasmExc etc.); returns the node for
+// call-site convenience.
 func rewriteHelperNode(n ast.Node, helperNames map[string]bool) ast.Node {
-	if n == nil {
-		return nil
-	}
-	switch v := n.(type) {
-	case *ast.Ident:
-		// Bare ident inside an expression — capitalize iff it's a
-		// helper name. (Call sites are handled in CallExpr below, but
-		// helpers may also pass other helpers as values; treat both.)
-		if helperNames[v.Name] {
-			return newID(capitalize(v.Name))
-		}
-		return v
-	case *ast.SelectorExpr:
-		if id, ok := v.X.(*ast.Ident); ok && id.Name == "m" {
-			if len(v.Sel.Name) > 0 && v.Sel.Name[0] >= 'a' && v.Sel.Name[0] <= 'z' {
-				return &ast.SelectorExpr{X: id, Sel: newID(capitalize(v.Sel.Name))}
-			}
-		}
-		return &ast.SelectorExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr), Sel: v.Sel}
-	case *ast.CallExpr:
-		// Recurse into Fun so a bare-ident helper call gets renamed.
-		fun := rewriteHelperNode(v.Fun, helperNames).(ast.Expr)
-		args := make([]ast.Expr, len(v.Args))
-		for i, a := range v.Args {
-			args[i] = rewriteHelperNode(a, helperNames).(ast.Expr)
-		}
-		return &ast.CallExpr{Fun: fun, Args: args, Ellipsis: v.Ellipsis}
-	case *ast.IndexExpr:
-		return &ast.IndexExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr), Index: rewriteHelperNode(v.Index, helperNames).(ast.Expr)}
-	case *ast.SliceExpr:
-		out := &ast.SliceExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr), Slice3: v.Slice3}
-		if v.Low != nil {
-			out.Low = rewriteHelperNode(v.Low, helperNames).(ast.Expr)
-		}
-		if v.High != nil {
-			out.High = rewriteHelperNode(v.High, helperNames).(ast.Expr)
-		}
-		if v.Max != nil {
-			out.Max = rewriteHelperNode(v.Max, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.BinaryExpr:
-		return &ast.BinaryExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr), Op: v.Op, Y: rewriteHelperNode(v.Y, helperNames).(ast.Expr)}
-	case *ast.UnaryExpr:
-		return &ast.UnaryExpr{Op: v.Op, X: rewriteHelperNode(v.X, helperNames).(ast.Expr)}
-	case *ast.ParenExpr:
-		return &ast.ParenExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr)}
-	case *ast.AssignStmt:
-		out := &ast.AssignStmt{Tok: v.Tok, Lhs: make([]ast.Expr, len(v.Lhs)), Rhs: make([]ast.Expr, len(v.Rhs))}
-		for i, e := range v.Lhs {
-			out.Lhs[i] = rewriteHelperNode(e, helperNames).(ast.Expr)
-		}
-		for i, e := range v.Rhs {
-			out.Rhs[i] = rewriteHelperNode(e, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.ExprStmt:
-		return &ast.ExprStmt{X: rewriteHelperNode(v.X, helperNames).(ast.Expr)}
-	case *ast.ReturnStmt:
-		out := &ast.ReturnStmt{Results: make([]ast.Expr, len(v.Results))}
-		for i, e := range v.Results {
-			out.Results[i] = rewriteHelperNode(e, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.IfStmt:
-		out := &ast.IfStmt{Cond: rewriteHelperNode(v.Cond, helperNames).(ast.Expr)}
-		if v.Init != nil {
-			out.Init = rewriteHelperNode(v.Init, helperNames).(ast.Stmt)
-		}
-		out.Body = rewriteHelperNode(v.Body, helperNames).(*ast.BlockStmt)
-		if v.Else != nil {
-			out.Else = rewriteHelperNode(v.Else, helperNames).(ast.Stmt)
-		}
-		return out
-	case *ast.ForStmt:
-		out := &ast.ForStmt{Body: rewriteHelperNode(v.Body, helperNames).(*ast.BlockStmt)}
-		if v.Init != nil {
-			out.Init = rewriteHelperNode(v.Init, helperNames).(ast.Stmt)
-		}
-		if v.Cond != nil {
-			out.Cond = rewriteHelperNode(v.Cond, helperNames).(ast.Expr)
-		}
-		if v.Post != nil {
-			out.Post = rewriteHelperNode(v.Post, helperNames).(ast.Stmt)
-		}
-		return out
-	case *ast.RangeStmt:
-		out := &ast.RangeStmt{
-			Tok:  v.Tok,
-			X:    rewriteHelperNode(v.X, helperNames).(ast.Expr),
-			Body: rewriteHelperNode(v.Body, helperNames).(*ast.BlockStmt),
-		}
-		if v.Key != nil {
-			out.Key = rewriteHelperNode(v.Key, helperNames).(ast.Expr)
-		}
-		if v.Value != nil {
-			out.Value = rewriteHelperNode(v.Value, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.BlockStmt:
-		out := &ast.BlockStmt{List: make([]ast.Stmt, len(v.List))}
-		for i, s := range v.List {
-			out.List[i] = rewriteHelperNode(s, helperNames).(ast.Stmt)
-		}
-		return out
-	case *ast.IncDecStmt:
-		return &ast.IncDecStmt{Tok: v.Tok, X: rewriteHelperNode(v.X, helperNames).(ast.Expr)}
-	case *ast.DeclStmt:
-		return v
-	case *ast.SwitchStmt:
-		out := &ast.SwitchStmt{Body: rewriteHelperNode(v.Body, helperNames).(*ast.BlockStmt)}
-		if v.Init != nil {
-			out.Init = rewriteHelperNode(v.Init, helperNames).(ast.Stmt)
-		}
-		if v.Tag != nil {
-			out.Tag = rewriteHelperNode(v.Tag, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.CaseClause:
-		out := &ast.CaseClause{Body: make([]ast.Stmt, len(v.Body))}
-		if v.List != nil {
-			out.List = make([]ast.Expr, len(v.List))
-			for i, e := range v.List {
-				out.List[i] = rewriteHelperNode(e, helperNames).(ast.Expr)
-			}
-		}
-		for i, s := range v.Body {
-			out.Body[i] = rewriteHelperNode(s, helperNames).(ast.Stmt)
-		}
-		return out
-	case *ast.TypeAssertExpr:
-		out := &ast.TypeAssertExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr)}
-		if v.Type != nil {
-			out.Type = rewriteHelperNode(v.Type, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.DeferStmt:
-		return &ast.DeferStmt{Call: rewriteHelperNode(v.Call, helperNames).(*ast.CallExpr)}
-	case *ast.BranchStmt:
-		return v
-	case *ast.LabeledStmt:
-		return &ast.LabeledStmt{Label: v.Label, Stmt: rewriteHelperNode(v.Stmt, helperNames).(ast.Stmt)}
-	case *ast.StarExpr:
-		return &ast.StarExpr{X: rewriteHelperNode(v.X, helperNames).(ast.Expr)}
-	case *ast.CompositeLit:
-		out := &ast.CompositeLit{Elts: make([]ast.Expr, len(v.Elts))}
-		if v.Type != nil {
-			out.Type = rewriteHelperNode(v.Type, helperNames).(ast.Expr)
-		}
-		for i, e := range v.Elts {
-			out.Elts[i] = rewriteHelperNode(e, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.KeyValueExpr:
-		return &ast.KeyValueExpr{Key: rewriteHelperNode(v.Key, helperNames).(ast.Expr), Value: rewriteHelperNode(v.Value, helperNames).(ast.Expr)}
-	case *ast.Ellipsis:
-		out := &ast.Ellipsis{}
-		if v.Elt != nil {
-			out.Elt = rewriteHelperNode(v.Elt, helperNames).(ast.Expr)
-		}
-		return out
-	case *ast.FuncType:
-		// Rewrite parameter/result type references (e.g. a helper whose
-		// signature names wasmExc) so a renamed type stays consistent between
-		// the declaration and its uses. Params/Results are FieldLists.
-		out := &ast.FuncType{}
-		if v.Params != nil {
-			out.Params = rewriteHelperNode(v.Params, helperNames).(*ast.FieldList)
-		}
-		if v.Results != nil {
-			out.Results = rewriteHelperNode(v.Results, helperNames).(*ast.FieldList)
-		}
-		return out
-	case *ast.FieldList:
-		out := &ast.FieldList{List: make([]*ast.Field, len(v.List))}
-		for i, f := range v.List {
-			out.List[i] = rewriteHelperNode(f, helperNames).(*ast.Field)
-		}
-		return out
-	case *ast.Field:
-		out := &ast.Field{Names: v.Names, Tag: v.Tag}
-		if v.Type != nil {
-			out.Type = rewriteHelperNode(v.Type, helperNames).(ast.Expr)
-		}
-		return out
-	}
+	rewriteHelperInPlace(n, helperNames)
 	return n
+}
+
+func rewriteHelperInPlace(n ast.Node, helperNames map[string]bool) {
+	if n == nil {
+		return
+	}
+	sels := map[*ast.Ident]bool{}
+	ast.Inspect(n, func(c ast.Node) bool {
+		if se, ok := c.(*ast.SelectorExpr); ok {
+			sels[se.Sel] = true
+		}
+		return true
+	})
+	ast.Inspect(n, func(c ast.Node) bool {
+		switch v := c.(type) {
+		case *ast.SelectorExpr:
+			if id, ok := v.X.(*ast.Ident); ok && id.Name == "m" {
+				if len(v.Sel.Name) > 0 && v.Sel.Name[0] >= 'a' && v.Sel.Name[0] <= 'z' {
+					v.Sel.Name = capitalize(v.Sel.Name)
+				}
+			}
+		case *ast.Ident:
+			if !sels[v] && helperNames[v.Name] {
+				v.Name = capitalize(v.Name)
+			}
+		}
+		return true
+	})
 }

--- a/internal/codegen/translate_linkname.go
+++ b/internal/codegen/translate_linkname.go
@@ -101,6 +101,14 @@ func (t *translator) translateLinknameMulti() (Result, error) {
 		t.use(p)
 	}
 
+	// Globals save/restore lands in base (it reads the Module's gN fields), so
+	// it has to register its imports before the snapshot below freezes base's
+	// import set. See emitGlobalsSnapshot; NewFromSnapshot calls it.
+	globalsSnap, err := t.emitGlobalsSnapshot()
+	if err != nil {
+		return Result{}, err
+	}
+
 	// Step 3: snapshot t.imports as base's view BEFORE main pass adds
 	// any further dependencies (e.g. "fmt" via SafeInvokeExport).
 	baseImportSnapshot := make(map[string]string, len(t.imports))
@@ -194,6 +202,7 @@ func (t *translator) translateLinknameMulti() (Result, error) {
 	baseFile.Decls = append(baseFile.Decls, t.emitImportInterfaces()...)
 	baseFile.Decls = append(baseFile.Decls, t.emitModuleStruct())
 	baseFile.Decls = append(baseFile.Decls, helpers...)
+	baseFile.Decls = append(baseFile.Decls, globalsSnap...)
 	baseFile.Decls = append(baseFile.Decls, wasiDecls...)
 	baseFile.Decls = prependImportsForBase(baseFile.Decls, baseImportSnapshot)
 	{
@@ -202,6 +211,17 @@ func (t *translator) translateLinknameMulti() (Result, error) {
 			return Result{}, fmt.Errorf("format base: %w", err)
 		}
 		files["base/base.go"] = buf.Bytes()
+	}
+
+	// The copy-on-write shared-image runtime rides along in base, next to the
+	// Module whose fields it reads. It is inert unless an embedder calls
+	// NewSharedImage.
+	shared, err := t.emitSharedImage("base")
+	if err != nil {
+		return Result{}, err
+	}
+	for name, content := range shared {
+		files["base/"+name] = content
 	}
 
 	// Step 7: serialize main file.

--- a/internal/codegen/translate_multi.go
+++ b/internal/codegen/translate_multi.go
@@ -73,12 +73,17 @@ func chunkUsedDeps(decls []ast.Decl) []int {
 // import paths.
 func scanStdlibRefs(decls []ast.Decl) []string {
 	pkgs := map[string]string{
+		"bytes":   "bytes",
 		"bits":    "math/bits",
 		"math":    "math",
 		"binary":  "encoding/binary",
 		"runtime": "runtime",
 		"unsafe":  "unsafe",
 		"fmt":     "fmt",
+		// New() initializes the pointered shared state (&sync.Mutex{},
+		// &atomic.Uint64{}) in whichever package hosts the constructor.
+		"sync":   "sync",
+		"atomic": "sync/atomic",
 	}
 	used := map[string]bool{}
 	for _, d := range decls {

--- a/internal/gcasm/capture.go
+++ b/internal/gcasm/capture.go
@@ -66,7 +66,7 @@ func captureArch(pkgDir, pkgPath, arch string) ([]*Fn, []*DataSym, error) {
 	cmd.Env = append(os.Environ(), "GOARCH="+arch)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, nil, fmt.Errorf("gcasm capture: go build: %w\n%s", err, clip(out))
+		return nil, nil, fmt.Errorf("gcasm capture: go build: %w\n%s", err, diagnostics(out))
 	}
 	return ParseListing(string(out))
 }
@@ -181,6 +181,36 @@ func ParseListing(listing string) ([]*Fn, []*DataSym, error) {
 	sort.Slice(fns, func(i, j int) bool { return fns[i].Name < fns[j].Name })
 	sort.Slice(datas, func(i, j int) bool { return datas[i].Name < datas[j].Name })
 	return fns, datas, nil
+}
+
+// diagnostics extracts go build's error lines from a -gcflags=-S run. The
+// listing dwarfs the errors by megabytes and, with parallel package compiles,
+// the errors can land anywhere in the stream — a head or tail clip usually
+// keeps only listing noise. KEEP the shapes an error takes (package headers,
+// file:line:col messages, go's own tool complaints) instead of trying to
+// enumerate every listing shape there is.
+func diagnostics(b []byte) string {
+	errLine := regexp.MustCompile(`^[^\s#].*\.(go|s):[0-9]+(:[0-9]+)?: `)
+	var diag []string
+	for _, ln := range strings.Split(string(b), "\n") {
+		switch {
+		case strings.HasPrefix(ln, "# "),
+			strings.HasPrefix(ln, "go: "),
+			strings.HasPrefix(ln, "go build"),
+			errLine.MatchString(ln):
+			diag = append(diag, ln)
+		}
+	}
+	out := strings.Join(diag, "\n")
+	if out == "" {
+		// Nothing error-shaped: fall back to the raw tail rather than hiding
+		// everything.
+		return clip(b[max(0, len(b)-2000):])
+	}
+	if len(out) > 8000 {
+		out = out[:8000] + "...[clipped]"
+	}
+	return out
 }
 
 func clip(b []byte) string {

--- a/internal/lower/lower.go
+++ b/internal/lower/lower.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 
 	"github.com/goccy/wasm2go/internal/ssa"
 	"github.com/goccy/wasm2go/internal/wasm"
@@ -582,6 +583,8 @@ func (ls *lowerState) handleOp(op byte, r *wasm.InstrReader) error {
 		return nil
 	case op == wasm.OpPrefixFC:
 		return ls.handleFCOp(r)
+	case op == wasm.OpPrefixFE:
+		return ls.handleFEOp(r)
 	}
 	return fmt.Errorf("%w: opcode 0x%02x not implemented", ErrSSAUnsupported, op)
 }
@@ -630,6 +633,123 @@ func (ls *lowerState) handleSelect(op byte, r *wasm.InstrReader) error {
 	ls.b.SetCurrent(postBlk)
 	phi := ls.b.NewValue(ssa.OpPhi, thenVal.Type, thenVal, elseVal)
 	ls.push(phi)
+	return nil
+}
+
+// feAtomicSpec describes one threads-proposal atomic op: the module-aware
+// helper it lowers to, its result type, and how many value operands it pops
+// beyond the address (0 = load, 1 = store/RMW/notify, 2 = cmpxchg/wait).
+type feAtomicSpec struct {
+	helper  string
+	resType ssa.Type
+	extra   int
+	// wait64's expected operand and cmpxchg64's operands are i64; everything
+	// else extra-operand-wise is inferred from resType except waits (i32
+	// result, typed operands) — recorded explicitly where it matters.
+}
+
+// feAtomics maps 0xFE sub-opcodes to their lowering. Sub-opcode layout is
+// fixed by the threads proposal: 0x00 notify, 0x01/0x02 wait32/64,
+// 0x03 fence, 0x10.. loads, 0x17.. stores, then RMW families in op order
+// add/sub/and/or/xor/xchg/cmpxchg, each over
+// {i32, i64, i32_8u, i32_16u, i64_8u, i64_16u, i64_32u}.
+var feAtomics = map[uint32]feAtomicSpec{
+	0x00: {"atomicNotify", ssa.TypeI32, 1},
+	0x01: {"atomicWait32", ssa.TypeI32, 2},
+	0x02: {"atomicWait64", ssa.TypeI32, 2},
+
+	0x10: {"atomicLoad32", ssa.TypeI32, 0},
+	0x11: {"atomicLoad64", ssa.TypeI64, 0},
+	0x12: {"atomicLoad32_8u", ssa.TypeI32, 0},
+	0x13: {"atomicLoad32_16u", ssa.TypeI32, 0},
+	0x14: {"atomicLoad64_8u", ssa.TypeI64, 0},
+	0x15: {"atomicLoad64_16u", ssa.TypeI64, 0},
+	0x16: {"atomicLoad64_32u", ssa.TypeI64, 0},
+
+	0x17: {"atomicStore32", ssa.TypeI32, 1},
+	0x18: {"atomicStore64", ssa.TypeI32, 1},
+	0x19: {"atomicStore32_8", ssa.TypeI32, 1},
+	0x1a: {"atomicStore32_16", ssa.TypeI32, 1},
+	0x1b: {"atomicStore64_8", ssa.TypeI32, 1},
+	0x1c: {"atomicStore64_16", ssa.TypeI32, 1},
+	0x1d: {"atomicStore64_32", ssa.TypeI32, 1},
+}
+
+func init() {
+	// The seven RMW families share the size/type layout of the load family.
+	families := []struct {
+		base uint32
+		name string
+	}{
+		{0x1e, "Add"}, {0x25, "Sub"}, {0x2c, "And"}, {0x33, "Or"},
+		{0x3a, "Xor"}, {0x41, "Xchg"}, {0x48, "Cmpxchg"},
+	}
+	sizes := []struct {
+		suffix string
+		typ    ssa.Type
+	}{
+		{"32", ssa.TypeI32}, {"64", ssa.TypeI64},
+		{"32_8u", ssa.TypeI32}, {"32_16u", ssa.TypeI32},
+		{"64_8u", ssa.TypeI64}, {"64_16u", ssa.TypeI64}, {"64_32u", ssa.TypeI64},
+	}
+	for _, f := range families {
+		for i, sz := range sizes {
+			extra := 1
+			if f.name == "Cmpxchg" {
+				extra = 2
+			}
+			feAtomics[f.base+uint32(i)] = feAtomicSpec{
+				"atomicRmw" + f.name + sz.suffix, sz.typ, extra,
+			}
+		}
+	}
+}
+
+// handleFEOp dispatches the wasm 0xFE threads-proposal opcodes. Every memory
+// atomic lowers to an OpAtomicCall of a module-aware helper taking
+// (m, addr, offset, operands...); alignment and bounds are checked in the
+// helper (misalignment traps, as the proposal requires).
+func (ls *lowerState) handleFEOp(r *wasm.InstrReader) error {
+	sub, err := r.ReadU32()
+	if err != nil {
+		return err
+	}
+	if sub == 0x03 { // atomic.fence: reserved byte, no operands
+		if _, err := r.ReadByte(); err != nil {
+			return err
+		}
+		ls.b.NewValueAux(ssa.OpAtomicCall, ssa.TypeI32, "atomicFence")
+		return nil
+	}
+	spec, ok := feAtomics[sub]
+	if !ok {
+		return fmt.Errorf("%w: 0xfe sub-opcode 0x%02x not implemented", ErrSSAUnsupported, sub)
+	}
+	if _, err := r.ReadU32(); err != nil { // memarg align (validated upstream)
+		return err
+	}
+	offset, err := r.ReadU32()
+	if err != nil {
+		return err
+	}
+	extras := make([]*ssa.Value, spec.extra)
+	for i := spec.extra - 1; i >= 0; i-- {
+		v, err := ls.pop()
+		if err != nil {
+			return err
+		}
+		extras[i] = v
+	}
+	addr, err := ls.pop()
+	if err != nil {
+		return err
+	}
+	args := append([]*ssa.Value{addr, ls.b.Const32(int32(offset))}, extras...)
+	v := ls.b.NewValueAux(ssa.OpAtomicCall, spec.resType, spec.helper, args...)
+	if strings.HasPrefix(spec.helper, "atomicStore") {
+		return nil // stores leave nothing on the stack
+	}
+	ls.push(v)
 	return nil
 }
 

--- a/internal/ssa/op.go
+++ b/internal/ssa/op.go
@@ -146,6 +146,13 @@ const (
 	// expanding the SSA Op enum for every wasm instruction.
 	OpHelperCall
 
+	// OpAtomicCall delegates to a MODULE-AWARE helper (emitted as
+	// helper(m, args...)) implementing a threads-proposal atomic op:
+	// loads/stores/RMWs/cmpxchg, memory.atomic.wait/notify, atomic.fence.
+	// Aux is the helper name. Always side-effecting: atomics synchronize
+	// with other agents, so they must never be DCE'd, CSE'd or reordered.
+	OpAtomicCall
+
 	// OpMemSize / OpMemGrow are the wasm linear-memory size queries.
 	// OpMemSize takes (mem) and returns the current page count.
 	// OpMemGrow takes (delta_pages, mem) and returns the previous page
@@ -277,6 +284,7 @@ var opNames = [...]string{
 	OpUnreachable: "OpUnreachable",
 
 	OpHelperCall: "OpHelperCall",
+	OpAtomicCall: "OpAtomicCall",
 
 	OpMemSize:    "OpMemSize",
 	OpMemGrow:    "OpMemGrow",
@@ -352,6 +360,7 @@ func (op Op) HasSideEffect() bool {
 		OpLocalSet, // writes a mutable local var (EH mutable-locals mode)
 		OpCallDirect, OpCallIndirect, OpCallImport,
 		OpHelperCall, // may trap (div, rem, non-saturating trunc-to-int)
+		OpAtomicCall, // synchronizes with other agents; never removable
 		OpUnreachable,
 		OpMemGrow, OpMemoryCopy, OpMemoryFill, OpMemoryInit, OpDataDrop:
 		return true
@@ -370,6 +379,9 @@ func (op Op) HasSideEffect() bool {
 func (v *Value) HasSideEffect() bool {
 	if v == nil {
 		return false
+	}
+	if v.Op == OpAtomicCall {
+		return true
 	}
 	if v.Op != OpHelperCall {
 		return v.Op.HasSideEffect()

--- a/internal/testfixture/fixture.go
+++ b/internal/testfixture/fixture.go
@@ -49,7 +49,7 @@ func Wasm(t testing.TB, name string) []byte {
 
 	// --enable-exceptions lets EH fixtures (try/catch/throw/tag) compile; it
 	// only enables the feature, so non-EH fixtures are unaffected.
-	cmd := exec.Command("wat2wasm", "--enable-exceptions", "--output=-", watPath)
+	cmd := exec.Command("wat2wasm", "--enable-exceptions", "--enable-threads", "--output=-", watPath)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/wasm/instr.go
+++ b/internal/wasm/instr.go
@@ -172,6 +172,25 @@ func (r *InstrReader) ReadVecU32() ([]uint32, error) {
 // drop real call edges (e.g. when an unknown opcode was followed by a
 // `call` opcode value that SkipImmediates then misread as raw bytes).
 func (r *InstrReader) SkipImmediates(op byte) error {
+	// 0xfe-prefixed threads-proposal atomics.
+	if op == OpPrefixFE {
+		sub, err := r.ReadU32()
+		if err != nil {
+			return err
+		}
+		if sub == 0x03 { // atomic.fence: one reserved 0x00 byte
+			_, err := r.ReadByte()
+			return err
+		}
+		if sub <= 0x4e { // wait/notify/loads/stores/RMWs: memarg (align, offset)
+			if _, err := r.ReadU32(); err != nil {
+				return err
+			}
+			_, err := r.ReadU32()
+			return err
+		}
+		return fmt.Errorf("unknown 0xfe sub-opcode 0x%02x", sub)
+	}
 	// 0xfc-prefixed extended ops.
 	if op == OpPrefixFC {
 		sub, err := r.ReadU32()

--- a/internal/wasm/ir.go
+++ b/internal/wasm/ir.go
@@ -44,6 +44,7 @@ type Limits struct {
 	Min    uint64
 	Max    uint64
 	HasMax bool
+	Shared bool // threads proposal: memory declared shared (limits flag 0x02)
 }
 
 // TableType describes a table.
@@ -140,8 +141,14 @@ type ElementSegment struct {
 // DataSegment is a (subset of) wasm data segment. Active segments only.
 type DataSegment struct {
 	MemIdx uint32
-	Offset []byte // raw const-expr including terminating 0x0b
+	Offset []byte // raw const-expr including terminating 0x0b; nil when Passive
 	Bytes  []byte
+	// Passive segments (flag 0x01) have no offset: they sit inert until a
+	// memory.init copies from them (data.drop then discards them). LLVM emits
+	// ALL data passive for shared-memory builds — the threads proposal forbids
+	// active segments re-initializing memory on every thread's instantiation —
+	// and initializes exactly once from a __wasm_init_memory start function.
+	Passive bool
 }
 
 // Module is the parsed in-memory representation of a wasm binary.

--- a/internal/wasm/opcodes.go
+++ b/internal/wasm/opcodes.go
@@ -211,4 +211,5 @@ const (
 	OpRefFunc byte = 0xd2
 
 	OpPrefixFC byte = 0xfc // saturating-trunc, bulk-memory
+	OpPrefixFE byte = 0xfe // threads proposal: atomics
 )

--- a/internal/wasm/parser.go
+++ b/internal/wasm/parser.go
@@ -206,6 +206,10 @@ func readLimits(r byteReader) (Limits, error) {
 		return Limits{}, err
 	}
 	lim := Limits{Min: min}
+	if flags&0x02 != 0 {
+		// Threads proposal: shared memories must also declare a maximum.
+		lim.Shared = true
+	}
 	if flags&0x01 != 0 {
 		max, err := readU64(r)
 		if err != nil {
@@ -570,6 +574,13 @@ func parseDataSection(m *Module, r byteReader) error {
 				return err
 			}
 			m.Datas = append(m.Datas, DataSegment{MemIdx: 0, Offset: off, Bytes: b})
+		case 0x01:
+			// passive: vec(byte) only
+			b, err := readByteVec(r)
+			if err != nil {
+				return err
+			}
+			m.Datas = append(m.Datas, DataSegment{Bytes: b, Passive: true})
 		case 0x02:
 			// active, memidx, offset, vec(byte)
 			mi, err := readU32(r)

--- a/testdata/cg_atomics.wat
+++ b/testdata/cg_atomics.wat
@@ -1,0 +1,50 @@
+;; cg_atomics.wat — threads-proposal atomics in a single agent: loads,
+;; stores, every RMW family incl. subword lanes, cmpxchg, fence, notify,
+;; and a zero-timeout wait. Results are observable values, so the fixture
+;; harness can diff them against wazero (threads feature enabled).
+(module
+  (memory 1 1 shared)
+  (func (export "rmw32") (result i32)
+    (i32.atomic.store (i32.const 16) (i32.const 100))
+    (drop (i32.atomic.rmw.add (i32.const 16) (i32.const 5)))
+    (drop (i32.atomic.rmw.sub (i32.const 16) (i32.const 1)))
+    (drop (i32.atomic.rmw.and (i32.const 16) (i32.const 0xff)))
+    (drop (i32.atomic.rmw.or (i32.const 16) (i32.const 0x100)))
+    (drop (i32.atomic.rmw.xor (i32.const 16) (i32.const 0x1)))
+    (i32.atomic.load (i32.const 16)))
+  (func (export "rmw64") (result i64)
+    (i64.atomic.store (i32.const 24) (i64.const 4000000000))
+    (drop (i64.atomic.rmw.add (i32.const 24) (i64.const 4000000000)))
+    (i64.atomic.load (i32.const 24)))
+  (func (export "xchg") (result i32)
+    (i32.atomic.store (i32.const 32) (i32.const 7))
+    ;; old value (7) + new value (9) observed
+    (i32.add (i32.atomic.rmw.xchg (i32.const 32) (i32.const 9))
+             (i32.atomic.load (i32.const 32))))
+  (func (export "cmpxchg") (result i32)
+    (i32.atomic.store (i32.const 40) (i32.const 5))
+    (drop (i32.atomic.rmw.cmpxchg (i32.const 40) (i32.const 5) (i32.const 6)))  ;; hits
+    (drop (i32.atomic.rmw.cmpxchg (i32.const 40) (i32.const 5) (i32.const 7)))  ;; misses
+    (i32.atomic.load (i32.const 40)))
+  (func (export "subword") (result i32)
+    ;; byte lanes at 48..51: store 0xAA at 49, add 1 at lane, read back word
+    (i32.atomic.store (i32.const 48) (i32.const 0))
+    (i32.atomic.store8 (i32.const 49) (i32.const 0xaa))
+    (drop (i32.atomic.rmw8.add_u (i32.const 49) (i32.const 1)))
+    (drop (i32.atomic.rmw16.xchg_u (i32.const 50) (i32.const 0x1234)))
+    (i32.atomic.load (i32.const 48)))
+  (func (export "subword_cmpxchg") (result i32)
+    (i32.atomic.store8 (i32.const 56) (i32.const 3))
+    (drop (i32.atomic.rmw8.cmpxchg_u (i32.const 56) (i32.const 3) (i32.const 9)))
+    (i32.atomic.load8_u (i32.const 56)))
+  (func (export "wait_notify") (result i32)
+    (i32.atomic.store (i32.const 64) (i32.const 1))
+    ;; not-equal (expected 0, actual 1) => 1; notify returns 0 woken
+    (i32.add
+      (memory.atomic.wait32 (i32.const 64) (i32.const 0) (i64.const 0))
+      (memory.atomic.notify (i32.const 64) (i32.const 5))))
+  (func (export "fenced_load") (result i32)
+    (i32.atomic.store (i32.const 72) (i32.const 42))
+    (atomic.fence)
+    (i32.atomic.load (i32.const 72)))
+)

--- a/testdata/cg_passive_data.wat
+++ b/testdata/cg_passive_data.wat
@@ -1,0 +1,20 @@
+;; Passive data segments + memory.init/data.drop — the shape LLVM emits for
+;; shared-memory builds (all data passive, initialized once from a start
+;; function). exports check both the init'd bytes and post-drop trapping.
+(module
+  (memory 1 4 shared)
+  (data $hello "Hello")
+  (data $world ", world")
+  (func $init
+    (memory.init $hello (i32.const 16) (i32.const 0) (i32.const 5))
+    (memory.init $world (i32.const 21) (i32.const 0) (i32.const 7))
+    (data.drop $hello))
+  (start $init)
+  (func (export "read_at") (param i32) (result i32)
+    (i32.load8_u (local.get 0)))
+  (func (export "reinit_dropped")
+    ;; memory.init on a dropped segment with n > 0 must trap
+    (memory.init $hello (i32.const 64) (i32.const 0) (i32.const 1)))
+  (func (export "reinit_zero_len")
+    ;; n == 0 on a dropped segment is allowed by the spec
+    (memory.init $hello (i32.const 64) (i32.const 0) (i32.const 0))))

--- a/testdata/cg_sharedimage.wat
+++ b/testdata/cg_sharedimage.wat
@@ -1,0 +1,58 @@
+;; A module shaped like LLVM's shared-memory output: the data segments are
+;; PASSIVE and a start function installs them with memory.init. That is the
+;; layout the shared-image runtime exists for — the segment destinations are
+;; wasm constants the host never sees until the start section runs them, which
+;; is why the Module has to learn dataEnd at run time rather than at codegen.
+;;
+;; Two segments, deliberately out of order, so dataEnd is a max and not "the
+;; last one wins".
+;;
+;; The start section also leaves two marks that let a test tell the two kinds of
+;; image apart: it BUMPS A COUNTER in memory (so a re-run is visible) and it
+;; SETS A MUTABLE GLOBAL to a value its declared initializer does not have (so a
+;; global that was not restored is visible). Between them they stand in for what
+;; a real toolchain's start section does — installing the segments and setting
+;; up the thread-local base — and for why a snapshot has to carry the globals.
+(module
+  (memory (export "memory") 2)
+
+  (global $marker (mut i32) (i32.const 0))
+
+  (data $late "END")   ;; goes high, installed first
+  (data $early "hello shared image")
+
+  (func $start
+    ;; memory.init dst src len
+    i32.const 4096
+    i32.const 0
+    i32.const 3
+    memory.init $late
+    i32.const 1024
+    i32.const 0
+    i32.const 18
+    memory.init $early
+
+    ;; runs++ at byte 100
+    i32.const 100
+    i32.const 100
+    i32.load8_u
+    i32.const 1
+    i32.add
+    i32.store8
+
+    ;; the global the declared initializer does not give us
+    i32.const 42
+    global.set $marker)
+  (start $start)
+
+  (func (export "peek") (param i32) (result i32)
+    local.get 0
+    i32.load8_u)
+
+  (func (export "poke") (param i32) (param i32)
+    local.get 0
+    local.get 1
+    i32.store8)
+
+  (func (export "marker") (result i32)
+    global.get $marker))

--- a/testdata/cg_threads.wat
+++ b/testdata/cg_threads.wat
@@ -1,0 +1,45 @@
+;; cg_threads.wat — shared memory + a real wasi_thread_spawn. The guest
+;; spawns N agents that each atomically bump a counter and notify; the
+;; main agent waits on the counter until they are done. Exercises the
+;; goroutine-backed spawn, cross-goroutine atomics on shared memory, and
+;; the wait/notify parking lot.
+(module
+  (import "wasi" "thread-spawn" (func $thread_spawn (param i32) (result i32)))
+  (memory (export "memory") 1 2 shared)
+
+  ;; wasi-libc's thread entry: called on a fresh agent with (tid, arg).
+  ;; arg is the address of the counter to bump.
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i32)
+    (drop (i32.atomic.rmw.add (local.get $arg) (i32.const 1)))
+    (drop (memory.atomic.notify (local.get $arg) (i32.const -1))))
+
+  ;; Spawn n agents on counter address 64 and spin-wait (with a bounded
+  ;; atomic wait, so a lost notify shows up as a timeout, not a hang)
+  ;; until the counter reaches n. Returns the final counter.
+  (func (export "spawn_and_join") (param $n i32) (result i32)
+    (local $i i32)
+    (i32.atomic.store (i32.const 64) (i32.const 0))
+    (block $spawned
+      (loop $spawn
+        (br_if $spawned (i32.ge_s (local.get $i) (local.get $n)))
+        (drop (call $thread_spawn (i32.const 64)))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $spawn)))
+    (block $done
+      (loop $wait
+        (br_if $done (i32.ge_s (i32.atomic.load (i32.const 64)) (local.get $n)))
+        ;; wait while the counter still holds its current value (1s cap)
+        (drop (memory.atomic.wait32 (i32.const 64)
+                                    (i32.atomic.load (i32.const 64))
+                                    (i64.const 1000000000)))
+        (br $wait)))
+    (i32.atomic.load (i32.const 64)))
+
+  ;; memory.grow on a shared memory must not relocate: the pointer other
+  ;; agents deref stays valid. Returns old size in pages, then the new one.
+  (func (export "grow_shared") (result i32)
+    (i32.atomic.store (i32.const 128) (i32.const 0xbeef))
+    (drop (memory.grow (i32.const 1)))
+    ;; data written before the grow must still be there, and the new size visible
+    (i32.add (i32.mul (memory.size) (i32.const 65536))
+             (i32.atomic.load (i32.const 128)))))

--- a/testdata/cg_threads_musl_lock.wat
+++ b/testdata/cg_threads_musl_lock.wat
@@ -1,0 +1,54 @@
+;; musl's 2-int internal lock (__lock/__unlock in src/thread/__lock.c): the
+;; futex word at l[0] and a WAITERS COUNTER at l[1]. The unlock side reads the
+;; counter with a PLAIN load to decide whether to notify, and the waiter spins
+;; on the futex word with PLAIN loads between futex waits. wasm's memory model
+;; gives plain accesses hardware-like coherence, so this is legal wasm — the
+;; translated Go must preserve it or malloc/stdio locks (and everything else
+;; built on __lock) can skip wakes and strand a thread forever.
+(module
+  (import "wasi" "thread-spawn" (func $spawn (param i32) (result i32)))
+  (memory 1 4 shared)
+  ;; 16: futex word / 20: waiters / 24: shared counter / 32: agent-done
+  (func $lock
+    (block $have
+      (br_if $have
+        (i32.eqz (i32.atomic.rmw.cmpxchg (i32.const 16) (i32.const 0) (i32.const 1))))
+      (loop $retry
+        (if (i32.ne (i32.atomic.rmw.xchg (i32.const 16) (i32.const 2)) (i32.const 0))
+          (then
+            ;; __wait: waiters++, wait while the PLAIN load still sees 2, waiters--
+            (drop (i32.atomic.rmw.add (i32.const 20) (i32.const 1)))
+            (block $awake (loop $w
+              (br_if $awake (i32.ne (i32.load (i32.const 16)) (i32.const 2)))
+              (drop (memory.atomic.wait32 (i32.const 16) (i32.const 2) (i64.const -1)))
+              (br $w)))
+            (drop (i32.atomic.rmw.sub (i32.const 20) (i32.const 1)))
+            (br $retry))))))
+  (func $unlock
+    ;; a_store(l, 0) then wake ONLY IF the PLAIN load of waiters is nonzero
+    (i32.atomic.store (i32.const 16) (i32.const 0))
+    (if (i32.ne (i32.load (i32.const 20)) (i32.const 0))
+      (then (drop (memory.atomic.notify (i32.const 16) (i32.const 1))))))
+  (func $bump (param $n i32)
+    (local $i i32)
+    (block $done (loop $l
+      (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+      (call $lock)
+      (i32.store (i32.const 24) (i32.add (i32.load (i32.const 24)) (i32.const 1)))
+      (call $unlock)
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $l))))
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i32)
+    (call $bump (i32.const 50000))
+    (i32.atomic.store (i32.const 32) (i32.const 1)))
+  (func (export "run") (result i32)
+    (local $i i32)
+    (drop (call $spawn (i32.const 0)))
+    (call $bump (i32.const 50000))
+    (block $got (loop $wait
+      (br_if $got (i32.eq (i32.atomic.load (i32.const 32)) (i32.const 1)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br_if $got (i32.ge_u (local.get $i) (i32.const 2000000000)))
+      (br $wait)))
+    (call $lock)
+    (i32.load (i32.const 24))))

--- a/testdata/cg_threads_mutex.wat
+++ b/testdata/cg_threads_mutex.wat
@@ -1,0 +1,46 @@
+;; A Drepper-style futex mutex (0=free,1=locked,2=locked+waiters) hammered from
+;; both the main thread and an agent — the exact handoff wasi-libc's
+;; pthread_mutex does. If the unlock's exchange ever fails to observe a
+;; waiter's 1->2 transition, one side sleeps forever and the test times out.
+(module
+  (import "wasi" "thread-spawn" (func $spawn (param i32) (result i32)))
+  (memory 1 4 shared)
+  ;; 16: mutex word / 24: shared counter / 32: agent-done flag
+  (func $lock
+    (block $acquired
+      ;; fast path
+      (br_if $acquired
+        (i32.eqz (i32.atomic.rmw.cmpxchg offset=12 (i32.const 4) (i32.const 0) (i32.const 1))))
+      (loop $retry
+        ;; mark contended and wait while it stays 2
+        (if (i32.ne (i32.atomic.rmw.xchg offset=12 (i32.const 4) (i32.const 2)) (i32.const 0))
+          (then
+            (drop (memory.atomic.wait32 offset=12 (i32.const 4) (i32.const 2) (i64.const -1)))
+            (br $retry))))))
+  (func $unlock
+    (if (i32.ne (i32.atomic.rmw.xchg offset=12 (i32.const 4) (i32.const 0)) (i32.const 1))
+      (then (drop (memory.atomic.notify offset=12 (i32.const 4) (i32.const 1))))))
+  (func $bump (param $n i32)
+    (local $i i32)
+    (block $done (loop $l
+      (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+      (call $lock)
+      (i32.store (i32.const 24) (i32.add (i32.load (i32.const 24)) (i32.const 1)))
+      (call $unlock)
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $l))))
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i32)
+    (call $bump (i32.const 50000))
+    (i32.atomic.store (i32.const 32) (i32.const 1)))
+  (func (export "run") (result i32)
+    (local $i i32)
+    (drop (call $spawn (i32.const 0)))
+    (call $bump (i32.const 50000))
+    ;; wait for the agent to finish (bounded spin: a wedged agent FAILS)
+    (block $got (loop $wait
+      (br_if $got (i32.eq (i32.atomic.load (i32.const 32)) (i32.const 1)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br_if $got (i32.ge_u (local.get $i) (i32.const 2000000000)))
+      (br $wait)))
+    (call $lock)
+    (i32.load (i32.const 24))))

--- a/testdata/cg_threads_visibility.wat
+++ b/testdata/cg_threads_visibility.wat
@@ -1,0 +1,28 @@
+;; Cross-thread visibility of PLAIN stores published via atomics: the main
+;; thread writes a value with a normal store, then publishes with an atomic
+;; store (release); the spawned thread spins on an atomic load (acquire) and
+;; must then observe the plain store. This is the C/C++ mutex fast-path shape
+;; (musl pthread_mutex uses a_cas/a_store around plain critical-section data).
+(module
+  (import "wasi" "thread-spawn" (func $spawn (param i32) (result i32)))
+  (memory 1 4 shared)
+  ;; addr 16: plain payload / addr 20: atomic flag / addr 24: agent's answer flag
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i32)
+    ;; spin until the flag publishes
+    (block $done
+      (loop $spin
+        (br_if $done (i32.eq (i32.atomic.load (i32.const 20)) (i32.const 1)))
+        (br $spin)))
+    ;; read the PLAIN store and publish the answer atomically
+    (i32.atomic.store (i32.const 24) (i32.load (i32.const 16))))
+  (func (export "run") (result i32)
+    (drop (call $spawn (i32.const 0)))
+    ;; plain store, then release-publish
+    (i32.store (i32.const 16) (i32.const 4242))
+    (i32.atomic.store (i32.const 20) (i32.const 1))
+    ;; wait for the agent's answer
+    (block $got
+      (loop $wait
+        (br_if $got (i32.ne (i32.atomic.load (i32.const 24)) (i32.const 0)))
+        (br $wait)))
+    (i32.atomic.load (i32.const 24))))

--- a/testdata/cg_threads_wake_dir.wat
+++ b/testdata/cg_threads_wake_dir.wat
@@ -1,0 +1,37 @@
+;; main->agent futex wake direction. The agent parks in memory.atomic.wait32;
+;; the MAIN thread (the primary Module, not a clone) stores + notifies. The
+;; reverse direction (agent notifies, main waits) is what cg_threads.wat
+;; already covers — this one is what a C mutex handoff does when the main
+;; thread unlocks while an agent sleeps on the futex.
+(module
+  (import "wasi" "thread-spawn" (func $spawn (param i32) (result i32)))
+  (memory 1 4 shared)
+  ;; 16: futex word / 24: agent result flag
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i32)
+    ;; park until the futex word becomes nonzero (wait while == 0)
+    (block $awake
+      (loop $again
+        (br_if $awake (i32.ne (i32.atomic.load (i32.const 16)) (i32.const 0)))
+        ;; wait(addr=16, expected=0, timeout=-1) -> 0 ok / 1 not-equal
+        (drop (memory.atomic.wait32 (i32.const 16) (i32.const 0) (i64.const -1)))
+        (br $again)))
+    (i32.atomic.store (i32.const 24) (i32.const 7777)))
+  (func (export "run") (result i32)
+    (local $i i32)
+    (drop (call $spawn (i32.const 0)))
+    ;; give the agent a moment to reach the wait (spin ~1M iterations)
+    (block $b (loop $l
+      (br_if $b (i32.ge_u (local.get $i) (i32.const 2000000)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $l)))
+    ;; publish and wake
+    (i32.atomic.store (i32.const 16) (i32.const 1))
+    (drop (memory.atomic.notify (i32.const 16) (i32.const 1)))
+    ;; wait for the agent's answer (bounded spin so a hang FAILS, not wedges)
+    (local.set $i (i32.const 0))
+    (block $got (loop $wait
+      (br_if $got (i32.ne (i32.atomic.load (i32.const 24)) (i32.const 0)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br_if $got (i32.ge_u (local.get $i) (i32.const 500000000)))
+      (br $wait)))
+    (i32.atomic.load (i32.const 24))))

--- a/transpile/threads_gcasm_test.go
+++ b/transpile/threads_gcasm_test.go
@@ -1,0 +1,70 @@
+package transpile_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+	"github.com/goccy/wasm2go/transpile"
+)
+
+// TestGcasmMutexHandoff is TestThreadsMutexHandoff through the FULL backend:
+// transpile.Translate emits the gcasm asm bundle (amd64/arm64), which is what
+// real deployments execute. The pure-Go twin in internal/codegen passing while
+// this one wedges would pin a lost futex wake inside the asm transform.
+func TestGcasmMutexHandoff(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_threads_mutex.wasm")
+	m, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := transpile.Translate(&buf, m, transpile.Options{
+		Package: "pkg", OutputImportPath: "gentest/pkg",
+	})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module gentest\n\ngo 1.25.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pkgDir := filepath.Join(dir, "pkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() > 0 {
+		if err := os.WriteFile(filepath.Join(pkgDir, "gen.go"), buf.Bytes(), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, set := range []map[string][]byte{res.Files, res.Sidecars} {
+		for name, data := range set {
+			p := filepath.Join(pkgDir, name)
+			if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, data, 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	mainSrc := "package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n\tfmt.Println(m.Run())\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainSrc), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "100000" {
+		t.Errorf("gcasm mutex handoff: got %q, want 100000", got)
+	}
+}


### PR DESCRIPTION
Implements the threads proposal + wasi-threads in the translator, so a wasm built for `wasm32-wasi-threads` runs its agents as **goroutines**. Pairs with goccy/wasmify's `HostThreads` capability (which emits such a wasm); together they give any Go embedder real concurrency with **no host implementation at all**.

## Atomics (67 ops)

Shared-memory limits (`0x02` flag) and the `0xFE` prefix now parse; every threads-proposal atomic — loads, stores, the seven RMW families across i32/i64 and 8/16/32-bit lanes, cmpxchg, `memory.atomic.wait/notify`, `atomic.fence` — lowers through a new `OpAtomicCall` (module-aware helper, always side-effecting, so atomics are never DCE'd, CSE'd or reordered).

Helpers are plain Go: `sync/atomic` over linear memory; misalignment and OOB trap as the proposal requires; 8/16-bit RMWs emulate subword atomicity with a CAS loop on the containing aligned 32-bit word; `atomic.fence` is a seq-cst barrier.

## Threads

`wasi thread-spawn` is intercepted in codegen — it never reaches the host import interface — and lowers to `threadSpawn`, which starts the guest's own `wasi_thread_start(tid, arg)` on a goroutine (wasi-libc builds that thread's stack and TLS *inside* linear memory, so Go owns nothing but the goroutine). `sync.WaitGroup` backs `ThreadsWait` for hosts that need quiescence.

`memory.atomic.wait/notify` are a real parking lot: channels keyed by effective address, compare-and-park under the lock a notifier also takes (so a notify landing between compare and park cannot be lost), `select` + timer for the bounded wait, and an infinite wait with no other agent traps instead of hanging.

## Shared memory: zero extra footprint

Generated loads/stores deref a cached data pointer with **no bounds check**, so the only thing that can break concurrent agents is a grow that *relocates* the backing array. The fix costs nothing:

- The declared maximum (which the proposal requires of a shared memory) is reserved once as the slice's **capacity** — Go takes those pages from a fresh mmap and untouched ones never become resident, so RSS still tracks what the guest actually touches.
- Growth becomes a lone atomic store to the new `memSize` field: no copy, no reslice, **no relocation**. The slice header never changes again.
- `memSize` (`atomic.Uint64`) is now the single source of truth for `memory.size` and every helper bounds check. The hot load/store path reads neither it nor the header, so **threads cost single-threaded code nothing**.

## Verification

- `cg_atomics.wat`: differential against wazero with `experimental.CoreFeaturesThreads` — every export matches.
- `cg_threads.wat`: the guest spawns 8 agents that bump a counter with atomics on shared memory and notify; the main agent joins them with `memory.atomic.wait32`; then it grows the shared memory and checks contents and pointers survive. The generated program runs under **`go run -race` and is race-clean** — with wasm threads as goroutines, the detector is the proof that the memory model holds.
- `go test ./...` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
