### PR TITLE
codegen: inline full-width atomic loads/stores as sync/atomic intrinsics

### DIFF
--- a/internal/codegen/emit_memops.go
+++ b/internal/codegen/emit_memops.go
@@ -402,3 +402,102 @@ func storeSpec(v *ssa.Value) (memOpSpec, bool) {
 	}
 	return memOpSpec{}, false
 }
+
+// Inline atomics
+//
+// The four full-width aligned atomic accesses (i32/i64 atomic
+// load/store) are emitted inline as sync/atomic intrinsics instead of
+// the base.AtomicLoad*/AtomicStore* helper calls:
+//
+//	int32(atomic.LoadUint32((*uint32)(unsafe.Add(mBase, <off>))))
+//	atomic.StoreUint32((*uint32)(unsafe.Add(mBase, <off>)), uint32(vN))
+//
+// The helper chain is three //go:noinline calls deep (AtomicLoad32 →
+// AtomicPtr32 → AtomicEA — noinline so the closure-taking RMW helpers
+// stay representable in the gcasm bundler, see helpers.go), which is
+// what a wasm engine emits as ONE machine instruction. Interpreter-style
+// guests hit an atomic load on every dispatch (interrupt-flag checks),
+// so the call chain shows up as tens of percent of runtime.
+// sync/atomic Load/Store are Go compiler intrinsics — a plain MOV /
+// LDAR / STLR-class instruction, no CALL — and give exactly the
+// seq-cst ordering the wasm threads proposal requires.
+//
+// Alignment and bounds checks are dropped, mirroring the plain
+// load/store rationale at the top of this file: validated wasm from a
+// C/C++/Rust toolchain only issues ABI-aligned atomics, so a
+// misaligned or out-of-bounds atomic indicates a bug in the input, not
+// a runtime condition. (A misaligned inline atomic fails loudly anyway:
+// LDAR/STLR fault, and Go's race-free unaligned 64-bit atomics panic on
+// 32-bit-aligned addresses.)
+//
+// Everything else — sub-word loads/stores (CAS-loop lane math), RMW
+// families, cmpxchg, wait/notify, fence — keeps the helper form; those
+// either take closures or are far off any hot path.
+
+// atomicInlineSpec describes one inlineable atomic helper: the
+// sync/atomic function stem, the unsigned element type, the load
+// result cast, and where the value operand sits for stores.
+type atomicInlineSpec struct {
+	elemType string // uint32 / uint64: deref target and atomic operand type
+	fn       string // sync/atomic function name
+	loadCast string // int32 / int64 wrap on load results; "" for stores
+	isStore  bool
+}
+
+// atomicInlineSpecs maps OpAtomicCall helper names (lower.go feAtomics)
+// to their inline form. Only the four full-width aligned accesses
+// appear here; absence means "keep the helper call".
+var atomicInlineSpecs = map[string]atomicInlineSpec{
+	"atomicLoad32":  {elemType: "uint32", fn: "LoadUint32", loadCast: "int32"},
+	"atomicLoad64":  {elemType: "uint64", fn: "LoadUint64", loadCast: "int64"},
+	"atomicStore32": {elemType: "uint32", fn: "StoreUint32", isStore: true},
+	"atomicStore64": {elemType: "uint64", fn: "StoreUint64", isStore: true},
+}
+
+// emitAtomicInline renders an OpAtomicCall as an inline sync/atomic
+// expression when the helper has an entry in atomicInlineSpecs and the
+// op's static offset operand is the OpConst32 the lowering built
+// (anything else — e.g. a future pass rewriting the operand — falls
+// back to the helper call). Loads return the value expression; stores
+// return the atomic.Store call expression, which the side-effect
+// statement path wraps in an ExprStmt.
+func (em *ssaEmitter) emitAtomicInline(v *ssa.Value, name string, emitExpr func(*ssa.Value) (ast.Expr, error)) (ast.Expr, bool, error) {
+	spec, ok := atomicInlineSpecs[name]
+	if !ok {
+		return nil, false, nil
+	}
+	off := ssaConstBase(v.Args[1])
+	if off == nil {
+		return nil, false, nil
+	}
+	baseExpr, err := emitExpr(v.Args[0])
+	if err != nil {
+		return nil, false, err
+	}
+	em.useImport("unsafe")
+	em.useImport("sync/atomic")
+	added := &ast.CallExpr{
+		Fun: &ast.SelectorExpr{X: newID("unsafe"), Sel: newID("Add")},
+		Args: []ast.Expr{
+			em.memBasePtrExpr(),
+			em.memOffsetExpr(baseExpr, uint64(uint32(off.AuxInt)), v.Args[0]),
+		},
+	}
+	ptr := &ast.CallExpr{
+		Fun:  &ast.ParenExpr{X: &ast.StarExpr{X: newID(spec.elemType)}},
+		Args: []ast.Expr{added},
+	}
+	atomicFn := &ast.SelectorExpr{X: newID("atomic"), Sel: newID(spec.fn)}
+	if spec.isStore {
+		valExpr, err := emitExpr(v.Args[2])
+		if err != nil {
+			return nil, false, err
+		}
+		return &ast.CallExpr{
+			Fun:  atomicFn,
+			Args: []ast.Expr{ptr, &ast.CallExpr{Fun: newID(spec.elemType), Args: []ast.Expr{valExpr}}},
+		}, true, nil
+	}
+	loaded := &ast.CallExpr{Fun: atomicFn, Args: []ast.Expr{ptr}}
+	return &ast.CallExpr{Fun: newID(spec.loadCast), Args: []ast.Expr{loaded}}, true, nil
+}

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -1044,6 +1044,13 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 		if !ok || name == "" {
 			return nil, fmt.Errorf("ssa emit: OpAtomicCall without name aux")
 		}
+		// Full-width aligned loads/stores skip the helper chain and
+		// emit sync/atomic intrinsics directly; see emit_memops.go.
+		if expr, done, err := em.emitAtomicInline(v, name, emit); err != nil {
+			return nil, err
+		} else if done {
+			return expr, nil
+		}
 		em.useHelper(name)
 		args := []ast.Expr{newID("m")}
 		for _, a := range v.Args {

--- a/internal/codegen/fixtures_test.go
+++ b/internal/codegen/fixtures_test.go
@@ -160,6 +160,7 @@ var fixtures = []fixture{
 			{export: "subword_cmpxchg", resType: wasm.ValI32},
 			{export: "wait_notify", resType: wasm.ValI32},
 			{export: "fenced_load", resType: wasm.ValI32},
+			{export: "store_neg", resType: wasm.ValI32},
 		},
 	},
 	{

--- a/internal/emit/hoist.go
+++ b/internal/emit/hoist.go
@@ -9,6 +9,8 @@
 package emit
 
 import (
+	"strings"
+
 	"github.com/goccy/wasm2go/internal/ssa"
 )
 
@@ -66,7 +68,7 @@ func ComputeHoist(f *ssa.Func, usage map[ssa.ValueID]int) map[ssa.ValueID]bool {
 			case v.Op == ssa.OpParam:
 				// never hoisted
 			case v.HasSideEffect():
-				if IsScalarType(v.Type) {
+				if IsScalarType(v.Type) && !IsVoidAtomicStore(v) {
 					hoist[v.ID] = true
 				}
 			case IsLoadOp(v.Op):
@@ -206,6 +208,22 @@ func IsLoadOp(op ssa.Op) bool {
 		return true
 	}
 	return false
+}
+
+// IsVoidAtomicStore reports whether v is an OpAtomicCall atomic store.
+// The lowering never pushes a store's result (wasm atomic stores leave
+// nothing on the operand stack), so the value only ever appears in
+// statement position. It must NOT be hoisted: the Go emitter renders
+// the full-width forms as sync/atomic Store intrinsics, which yield no
+// value, so a hoisted `vN = <store>` would not compile. (The remaining
+// sub-word store helpers still return a dummy scalar; discarding it in
+// an expression statement is fine.)
+func IsVoidAtomicStore(v *ssa.Value) bool {
+	if v == nil || v.Op != ssa.OpAtomicCall {
+		return false
+	}
+	name, _ := v.Aux.(string)
+	return strings.HasPrefix(name, "atomicStore")
 }
 
 // IsNarrowingStore reports whether v is a memory store that writes

--- a/internal/emit/hoist.go
+++ b/internal/emit/hoist.go
@@ -80,11 +80,19 @@ func ComputeHoist(f *ssa.Func, usage map[ssa.ValueID]int) map[ssa.ValueID]bool {
 	}
 	for _, blk := range f.Blocks {
 		for _, v := range blk.Values {
-			if !IsNarrowingStore(v) {
+			if IsNarrowingStore(v) {
+				if len(v.Args) >= 2 && v.Args[1] != nil {
+					hoist[v.Args[1].ID] = true
+				}
 				continue
 			}
-			if len(v.Args) >= 2 && v.Args[1] != nil {
-				hoist[v.Args[1].ID] = true
+			// Atomic stores render as `atomic.StoreUint32(ptr, uint32(vN))`;
+			// the unsigned cast needs a typed-variable operand for the same
+			// constant-overflow reason as narrowing stores (uint32 of a
+			// negative constant is a compile-time error, uint32 of a typed
+			// local is a runtime conversion).
+			if IsVoidAtomicStore(v) && len(v.Args) >= 3 && v.Args[2] != nil {
+				hoist[v.Args[2].ID] = true
 			}
 		}
 	}

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -706,7 +706,7 @@ func buildPkg(
 	// unsafe is always imported: gcasmTypePtr needs it, and the
 	// //go:linkname forwards require it in scope. Chunk packages
 	// reference the shared Module type as base.Module.
-	mathUsed, bitsUsed := false, false
+	mathUsed, bitsUsed, atomicUsed := false, false, false
 	for k := range stdlibUsed {
 		if strings.HasPrefix(k, "math/bits.") {
 			bitsUsed = true
@@ -715,13 +715,18 @@ func buildPkg(
 		}
 	}
 	// Extracted fallback bodies may reference math/bits directly
-	// (float NaN/Inf constants, rotate helpers inlined by gofmt).
+	// (float NaN/Inf constants, rotate helpers inlined by gofmt) and
+	// sync/atomic (the inline full-width atomic loads/stores, see
+	// codegen/emit_memops.go).
 	for _, body := range fallbackBodies {
 		if strings.Contains(body, "math.") {
 			mathUsed = true
 		}
 		if strings.Contains(body, "bits.") {
 			bitsUsed = true
+		}
+		if strings.Contains(body, "atomic.") {
+			atomicUsed = true
 		}
 	}
 	decl.WriteString("import (\n")
@@ -730,6 +735,9 @@ func buildPkg(
 	}
 	if bitsUsed {
 		decl.WriteString("\t\"math/bits\"\n")
+	}
+	if atomicUsed {
+		decl.WriteString("\t\"sync/atomic\"\n")
 	}
 	decl.WriteString("\t\"unsafe\"\n")
 	if rel != "" && rel != "base" {

--- a/testdata/cg_atomics.wat
+++ b/testdata/cg_atomics.wat
@@ -47,4 +47,14 @@
     (i32.atomic.store (i32.const 72) (i32.const 42))
     (atomic.fence)
     (i32.atomic.load (i32.const 72)))
+  (func (export "store_neg") (result i32)
+    ;; Negative constant operands: the inline-atomic emitter renders the
+    ;; store value through an unsigned cast, which must be a runtime
+    ;; conversion — `uint32(-1)` as a constant expression fails to
+    ;; compile. Locks the force-hoist of atomic-store value operands.
+    (i32.atomic.store (i32.const 80) (i32.const -1))
+    (i64.atomic.store (i32.const 88) (i64.const -0x8000000000000000))
+    (i32.add
+      (i32.atomic.load (i32.const 80))
+      (i32.wrap_i64 (i64.atomic.load (i32.const 88)))))
 )


### PR DESCRIPTION
# codegen: inline full-width atomic loads/stores as sync/atomic intrinsics

## Problem

Every `i32/i64 atomic.load` and `atomic.store` was emitted as a call into the
generated base helpers, and the helper chain is three `//go:noinline` frames
deep (`AtomicLoad32 → AtomicPtr32 → AtomicEA`) — where a wasm engine emits a
single machine instruction. The `noinline` exists for the closure-taking RMW
helpers (the gcasm bundler cannot represent cross-package closure symbols), but
it was applied to the whole atomic family.

Interpreter-style guests hit an atomic load on every dispatch iteration
(interrupt-flag polling). Profiling SpiderMonkey's portable baseline
interpreter transpiled by wasm2go put the helper chain at ~34% flat of a
fib(30) benchmark.

## Change

Emit the four full-width aligned forms inline:

```go
int32(atomic.LoadUint32((*uint32)(unsafe.Add(mBase, off))))
atomic.StoreUint32((*uint32)(unsafe.Add(mBase, off)), uint32(vN))
```

`sync/atomic` Load/Store are Go compiler intrinsics (plain `MOV` on amd64,
`LDAR`/`STLR` on arm64) with the seq-cst ordering the threads proposal
requires. Alignment and bounds checks are dropped, mirroring the documented
plain load/store rationale in `emit_memops.go`. Sub-word forms, RMW families,
cmpxchg, wait/notify and fence keep the helper form.

Three commits:

1. **codegen: inline full-width atomic loads/stores** — the emitter
   (`emitAtomicInline`) plus the `ComputeHoist` change: atomic stores never
   push a result, so they stay in statement position instead of being hoisted
   as `vN = <store>` (which would not compile once the store is a no-value
   intrinsic call).
2. **emit: force-hoist atomic-store value operands** — `uint32(vN)` must be a
   runtime conversion; with a constant operand it is a Go constant expression
   and `uint32` of a negative constant fails to compile. Same treatment (and
   reason) as narrowing stores. Found on the SpiderMonkey bundle (`-1` and
   `i32.min` store operands); locked with a negative-constant case in the
   `cg_atomics` fixture.
3. **gcasm: import sync/atomic in decls files when fallback bodies use it** —
   pure-fallback bodies now carry `atomic.*` references; the
   `decls_<arch>.go` writer sniffed only math/math-bits.

## Measured effect

go-spidermonkey fib(30) benchmark (SpiderMonkey portable baseline
interpreter, gcasm bundle, darwin/amd64): **479 ms → 193 ms per op (2.48x)**.
The atomic helper chain disappears from the profile (was ~34% flat).
Consumers whose wasm contains no atomic ops (googlesql, single-threaded
builds) produce byte-identical output.

## Verification (all exit codes observed in-session)

- `go test ./...` — exit 0 (amd64; includes the extended `cg_atomics`
  wazero-diff fixture and the threads matrix)
- `GOARCH=arm64 go test ./...` — `internal/codegen` (incl. the arm64
  `cg_atomics` lane) ok; the `internal/gcasm` gate harness fails locally
  under cross-arch GOARCH with an **identical failure set on main**
  (pre-existing local-toolchain issue, not introduced here)
- `make lint` — exit 0 (0 issues)
- `make test-cover` — exit 0, coverage 85.6% ≥ 84% threshold (clean
  worktree, same figure as main)
- googlesql e2e chain: plugin install → `buf generate` on googlesql-wasm →
  bridge copy → `go build ./...` in go-googlesql (exit 0) →
  go-googlesql `go test -count=1 ./...` (exit 0) →
  googlesqlite `go test -race -timeout 30m ./...` (exit 0, 35 ok / 0 FAIL)
- go-spidermonkey full suite against a bundle regenerated with this branch —
  exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
