### PR TITLE
gcasm: route large-jump-table functions to the pure fallback

### DIFF
--- a/internal/gcasm/a64fixture_test.go
+++ b/internal/gcasm/a64fixture_test.go
@@ -22,6 +22,10 @@ import (
 // transformed vs pure over an input sweep on GOARCH=arm64 (native on
 // Apple Silicon).
 func a64FixtureGate(t *testing.T, fixture string) {
+	// Like fixtureGate: Transform is called directly (no Build), so the
+	// large-jump-table fallback policy cannot route to a pure body, and
+	// the gate exists to pin the compare-tree rewrite itself. Disable it.
+	t.Setenv("GCASM_JT_FALLBACK", "off")
 	bin := testfixture.Wasm(t, fixture)
 	mod, err := wasm.Parse(bytes.NewReader(bin))
 	if err != nil {

--- a/internal/gcasm/a64jumptable_flags_test.go
+++ b/internal/gcasm/a64jumptable_flags_test.go
@@ -151,15 +151,37 @@ func TestA64JumpTableFlagReplayRun(t *testing.T) {
 	for _, d := range datas {
 		dm[d.Name] = d
 	}
-	body, err := TransformARM64(disp, TransformOptions{
-		SymName:   "fdispatchAsm",
-		CalleeSig: func(string) ([]ArgKind, bool, ArgKind, string, bool) { return nil, false, 0, "", false },
-		Params:    []ArgKind{ArgI32, ArgI32},
-		HasResult: true,
-		Result:    ArgI32,
-		ArgNames:  []string{"sel", "v0"},
-		Datas:     dm,
-	})
+	xform := func() (string, error) {
+		return TransformARM64(disp, TransformOptions{
+			SymName:   "fdispatchAsm",
+			CalleeSig: func(string) ([]ArgKind, bool, ArgKind, string, bool) { return nil, false, 0, "", false },
+			Params:    []ArgKind{ArgI32, ArgI32},
+			HasResult: true,
+			Result:    ArgI32,
+			ArgNames:  []string{"sel", "v0"},
+			Datas:     dm,
+		})
+	}
+
+	// The 48-case fixture crosses the large-table fallback threshold, so
+	// under the default policy the arm64 transform must route to the pure
+	// fallback — this pins the arm64 policy wiring.
+	body, err := xform()
+	switch {
+	case errors.Is(err, errLargeJumpTable):
+		// Expected: policy fired. Disable it below to pin the tree itself.
+	case err == nil && (!strings.Contains(body, "jt") || strings.Contains(body, ".jump")):
+		t.Skipf("gc did not emit a jump table for FDispatch on this toolchain")
+	case err != nil && strings.Contains(err.Error(), "jump"):
+		t.Skipf("no jump table emitted for this fixture on this toolchain: %v", err)
+	case err != nil:
+		t.Fatal(err)
+	default:
+		t.Fatal("default policy: transform succeeded with a jump table, want errLargeJumpTable")
+	}
+
+	t.Setenv("GCASM_JT_FALLBACK", "off")
+	body, err = xform()
 	if err != nil {
 		if strings.Contains(err.Error(), "jump") {
 			t.Skipf("no jump table emitted for this fixture on this toolchain: %v", err)

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -620,10 +620,11 @@ func buildPkg(
 			Types:     types,
 		})
 		if terr != nil {
-			// A duff body, or a jump table whose flag state cannot be replayed
-			// at the leaf asm, falls back to the pure Go body (transparent to
-			// callers) rather than aborting the whole bundle.
-			if errors.Is(terr, errUnsupportedDuff) || errors.Is(terr, errUnsupportedJumpTable) {
+			// A duff body, a jump table whose flag state cannot be replayed
+			// at the leaf asm, or a jump table too large for the compare-tree
+			// rewrite falls back to the pure Go body (transparent to callers)
+			// rather than aborting the whole bundle.
+			if errors.Is(terr, errUnsupportedDuff) || errors.Is(terr, errUnsupportedJumpTable) || errors.Is(terr, errLargeJumpTable) {
 				fallbackNames[name] = true
 				stats.Fallback++
 				continue

--- a/internal/gcasm/duff.go
+++ b/internal/gcasm/duff.go
@@ -2,6 +2,9 @@ package gcasm
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -23,6 +26,49 @@ var errUnsupportedDuff = errors.New("gcasm: DUFFZERO/DUFFCOPY pseudo-op unsuppor
 // case, Build routes such a function to its pure fallback (a Go switch handles
 // the jump table fine) rather than aborting the whole bundle.
 var errUnsupportedJumpTable = errors.New("gcasm: jump-table flag state not replayable in hand-written asm")
+
+// errLargeJumpTable signals that a captured body dispatches through a jump
+// table large enough that the compare-tree rewrite (emitJumpTree /
+// a64EmitJumpTree) is a measurable pessimization: gc's O(1) indirect jump
+// becomes O(log n) compare+branch per dispatch. On interpreter-style guests
+// (a dense several-hundred-case opcode switch executed once per VM
+// instruction) the pure Go body — where gc keeps its real jump table —
+// outruns the transformed asm, so Build routes such functions to their
+// pure fallback like the duff case.
+var errLargeJumpTable = errors.New("gcasm: jump table too large for the compare-tree rewrite")
+
+// jtFallbackMinRuns is the default dispatch-run threshold above which a
+// jump-table site routes its function to the pure fallback. Runs (not raw
+// table entries) are what emitJumpTree compares over, so they set the tree
+// depth: 32 runs ≈ 5 compares per dispatch vs gc's single indirect jump.
+const jtFallbackMinRuns = 32
+
+// jumpTableFallbackErr applies the large-jump-table fallback policy to the
+// detected sites of one function. It returns an error wrapping
+// errLargeJumpTable when any site's run count reaches the threshold, nil
+// when the function should stay on the transform path.
+//
+// GCASM_JT_FALLBACK overrides the threshold: "off" disables the policy,
+// a positive integer replaces jtFallbackMinRuns.
+func jumpTableFallbackErr(sites map[int]*jtSite) error {
+	min := jtFallbackMinRuns
+	if v := os.Getenv("GCASM_JT_FALLBACK"); v != "" {
+		if v == "off" {
+			return nil
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("bad GCASM_JT_FALLBACK %q: want a positive integer or \"off\"", v)
+		}
+		min = n
+	}
+	for _, s := range sites {
+		if len(s.runs) >= min {
+			return fmt.Errorf("%w: %d dispatch runs (threshold %d)", errLargeJumpTable, len(s.runs), min)
+		}
+	}
+	return nil
+}
 
 // hasDuffPseudo reports whether any instruction is a DUFFZERO/DUFFCOPY.
 func hasDuffPseudo(insns []Insn) bool {

--- a/internal/gcasm/gate1_test.go
+++ b/internal/gcasm/gate1_test.go
@@ -150,6 +150,12 @@ func goTypeOfKind(k ArgKind) string {
 // outcomes must agree). Determinism is asserted by capturing the same
 // tree from two different directories.
 func fixtureGate(t *testing.T, fixture string) {
+	// The gate calls Transform directly (no Build), so the large-jump-
+	// table fallback policy cannot route to a pure body here — and the
+	// gate's job is to pin the compare-tree rewrite itself (e.g.
+	// cg_bigdispatch, cg_brtable64). Disable the policy; it is pinned by
+	// TestJumpTableFallbackPolicy and the jumptable gates.
+	t.Setenv("GCASM_JT_FALLBACK", "off")
 	bin := testfixture.Wasm(t, fixture)
 	mod, err := wasm.Parse(bytes.NewReader(bin))
 	if err != nil {

--- a/internal/gcasm/jtfallback_test.go
+++ b/internal/gcasm/jtfallback_test.go
@@ -1,0 +1,58 @@
+package gcasm
+
+import (
+	"errors"
+	"testing"
+)
+
+// jtSitesWithRuns builds one synthetic dispatch site with n runs.
+func jtSitesWithRuns(n int) map[int]*jtSite {
+	s := &jtSite{}
+	for i := 0; i < n; i++ {
+		s.runs = append(s.runs, jtRun{start: i, target: i * 8})
+	}
+	return map[int]*jtSite{0: s}
+}
+
+func TestJumpTableFallbackPolicy(t *testing.T) {
+	t.Run("no sites", func(t *testing.T) {
+		if err := jumpTableFallbackErr(nil); err != nil {
+			t.Fatalf("nil sites: %v", err)
+		}
+	})
+	t.Run("below default threshold", func(t *testing.T) {
+		if err := jumpTableFallbackErr(jtSitesWithRuns(jtFallbackMinRuns - 1)); err != nil {
+			t.Fatalf("below threshold: %v", err)
+		}
+	})
+	t.Run("at default threshold", func(t *testing.T) {
+		err := jumpTableFallbackErr(jtSitesWithRuns(jtFallbackMinRuns))
+		if !errors.Is(err, errLargeJumpTable) {
+			t.Fatalf("at threshold: got %v, want errLargeJumpTable", err)
+		}
+	})
+	t.Run("env off", func(t *testing.T) {
+		t.Setenv("GCASM_JT_FALLBACK", "off")
+		if err := jumpTableFallbackErr(jtSitesWithRuns(500)); err != nil {
+			t.Fatalf("off: %v", err)
+		}
+	})
+	t.Run("env custom threshold", func(t *testing.T) {
+		t.Setenv("GCASM_JT_FALLBACK", "8")
+		if err := jumpTableFallbackErr(jtSitesWithRuns(7)); err != nil {
+			t.Fatalf("7 runs under custom 8: %v", err)
+		}
+		if err := jumpTableFallbackErr(jtSitesWithRuns(8)); !errors.Is(err, errLargeJumpTable) {
+			t.Fatalf("8 runs at custom 8: got %v, want errLargeJumpTable", err)
+		}
+	})
+	t.Run("env invalid", func(t *testing.T) {
+		for _, v := range []string{"zero", "0", "-3"} {
+			t.Setenv("GCASM_JT_FALLBACK", v)
+			err := jumpTableFallbackErr(jtSitesWithRuns(1))
+			if err == nil || errors.Is(err, errLargeJumpTable) {
+				t.Fatalf("GCASM_JT_FALLBACK=%q: got %v, want a config error", v, err)
+			}
+		}
+	})
+}

--- a/internal/gcasm/jumptable_flags_test.go
+++ b/internal/gcasm/jumptable_flags_test.go
@@ -39,6 +39,11 @@ func flagDispatchSrc(fnName string) string {
 // false-negative holes and some leaves got no replay, so the tree's
 // leftover flags leaked into the arms and picked the wrong branch.
 func TestJumpTableFlagReplayRun(t *testing.T) {
+	// The 48-case fixture crosses the large-table fallback threshold;
+	// this gate pins the compare-tree flag replay itself, so disable
+	// the policy (covered by TestJumpTableFallbackPolicy and the
+	// jumptable gate).
+	t.Setenv("GCASM_JT_FALLBACK", "off")
 	dir := t.TempDir()
 	src := "package lib\n\n//go:noinline\n" + flagDispatchSrc("FDispatch")
 	for name, content := range map[string]string{

--- a/internal/gcasm/jumptable_test.go
+++ b/internal/gcasm/jumptable_test.go
@@ -1,6 +1,7 @@
 package gcasm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -49,7 +50,7 @@ func TestJumpTableTransformRun(t *testing.T) {
 		}
 	}
 
-	transformOnce := func() string {
+	transformOnce := func() (string, error) {
 		fns, datas, err := Capture(dir, "jtgate/lib")
 		if err != nil {
 			t.Fatal(err)
@@ -67,7 +68,7 @@ func TestJumpTableTransformRun(t *testing.T) {
 		for _, d := range datas {
 			dm[d.Name] = d
 		}
-		body, err := Transform(disp, TransformOptions{
+		return Transform(disp, TransformOptions{
 			SymName:   "dispatchAsm",
 			CalleeSig: func(string) ([]ArgKind, bool, ArgKind, string, bool) { return nil, false, 0, "", false },
 			Params:    []ArgKind{ArgI32, ArgI32},
@@ -76,13 +77,26 @@ func TestJumpTableTransformRun(t *testing.T) {
 			ArgNames:  []string{"sel", "v0"},
 			Datas:     dm,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		return body
 	}
-	body := transformOnce()
-	if body2 := transformOnce(); body2 != body {
+
+	// Under the default policy a 64-case dispatch (≥ jtFallbackMinRuns
+	// runs) must route to the pure fallback, not transform.
+	if _, err := transformOnce(); !errors.Is(err, errLargeJumpTable) {
+		t.Fatalf("default policy: got %v, want errLargeJumpTable", err)
+	}
+
+	// The rest of the gate exercises the compare-tree rewrite itself,
+	// so disable the large-table fallback policy.
+	t.Setenv("GCASM_JT_FALLBACK", "off")
+	body, err := transformOnce()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, err := transformOnce()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body2 != body {
 		t.Fatalf("transform not deterministic:\n--- run1\n%s\n--- run2\n%s", body, body2)
 	}
 	if !strings.Contains(body, "jt") || strings.Contains(body, ".jump") {

--- a/internal/gcasm/transform.go
+++ b/internal/gcasm/transform.go
@@ -563,6 +563,9 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", fn.Name, err)
 	}
+	if err := jumpTableFallbackErr(jtSites); err != nil {
+		return "", fmt.Errorf("%s: %w", fn.Name, err)
+	}
 
 	// Const pool (shared across the file when the caller provides
 	// one) and the in-package symbol operand rewrite.

--- a/internal/gcasm/transform_a64gen.go
+++ b/internal/gcasm/transform_a64gen.go
@@ -118,6 +118,9 @@ func TransformARM64(fn *Fn, opts TransformOptions) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", fn.Name, err)
 	}
+	if err := jumpTableFallbackErr(jtSites); err != nil {
+		return "", fmt.Errorf("%s: %w", fn.Name, err)
+	}
 
 	pool := opts.Consts
 	ownPool := false


### PR DESCRIPTION
## Summary

gcasm cannot represent gc's jump tables (Plan9 hand-written asm has no address-of-label data), so `emitJumpTree`/`a64EmitJumpTree` rewrite the `LEAQ table + indirect JMP` dispatch into a run-compressed compare tree — O(log n) compare+branch per dispatch instead of O(1) indirect jump. On interpreter-style guests (SpiderMonkey PBL's dense 203-case opcode switch, CPython's eval loop) this made the transformed asm measurably slower than the pure Go body, where gc keeps its real jump table.

This PR adds a fallback policy: when any detected jump-table site has >= 32 dispatch **runs** (runs, not raw entries, set the tree depth), the transform returns `errLargeJumpTable` and `Build` routes the function to its pure Go body — exactly the existing duff / non-replayable-flag mechanism, transparent to callers. Applies to both amd64 and arm64. `GCASM_JT_FALLBACK` overrides the threshold (`off` disables; a positive integer replaces the default 32).

Reach (functions flipped `.s` -> pure fallback, same wasm before/after): spidermonkey PBL 43 fns (incl. Fn6321, the interpreter), python 15 fns, googlesql 104 fns.

## Bench (arm64 native, interleaved pairs, idle, wasm sha-pinned per generation)

| Workload | base | this PR | delta |
|---|---:|---:|---:|
| go-spidermonkey cpubench, gcasm lane (5 pairs) | 57.86 ms | 51.59 ms | **-10.8%** (5/5 pairs, ranges disjoint) |
| — gcasm/pure ratio | 1.11x | **0.99x** | jump-table penalty fully recovered |
| go-python FibRecursive, gcasm lane (3 pairs) | 82.79 ms | 64.95 ms | **-21.6%** (3/3) |
| go-python LoopSum | 42.71 ms | 39.06 ms | -8.5% (3/3) |
| googlesqlite window suite (200x, count=5) | — | — | all 5 queries within noise (no regression) |

## Verification (exit 0 observed for every line)

- wasm2go: `go test ./...`, `make lint` (0 issues), `make test-cover`
- go-spidermonkey: `go test ./...` and `-race`, amd64 + arm64 (wasmify-pipeline bundle)
- go-python: 4-config matrix (amd64 +/- race, arm64 +/- race)
- googlesqlite: `go test -race -timeout 30m ./...` amd64 AND arm64 — 35 packages ok / 0 FAIL
- go-googlesql: smoke `-count=1` ok

## Tests

- `TestJumpTableFallbackPolicy` pins the threshold/env-knob policy.
- The jumptable gate and the a64 flag-replay gate additionally pin that the default policy fires on their over-threshold fixtures.
- Compare-tree gates (`fixtureGate`, `a64FixtureGate`, run gates) set `GCASM_JT_FALLBACK=off` — they call `Transform` directly with no `Build` to route the fallback, and exist to pin the tree rewrite itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
