### PR TITLE
ssa: slot-granular frame-escape measurement in the promotion report

### DIFF
--- a/internal/ssa/coverage_test.go
+++ b/internal/ssa/coverage_test.go
@@ -1043,24 +1043,24 @@ func TestConstFoldAddrCopy(t *testing.T) {
 	}
 }
 
-func TestIsFrameOffsetSub32NonConst(t *testing.T) {
+func TestFrameOffsetOfSub32NonConst(t *testing.T) {
 	// fp - dynamicValue (not const) should NOT be frame-derived.
 	fp := &Value{ID: 1, Op: OpSub32}
 	dyn := &Value{ID: 2, Op: OpAdd32} // not a const
 	sub := &Value{Op: OpSub32, Args: []*Value{fp, dyn}}
-	fd := map[ValueID]bool{fp.ID: true}
-	if isFrameOffset(sub, fd) {
+	fd := map[ValueID]int64{fp.ID: 0}
+	if _, ok := frameOffsetOf(sub, fd); ok {
 		t.Error("sub with non-const should not be frame offset")
 	}
 }
 
-func TestIsFrameOffsetAdd32BothConst(t *testing.T) {
+func TestFrameOffsetOfAdd32BothConst(t *testing.T) {
 	// Two non-frame-derived constants: Add32 of them is not a frame offset.
 	c1 := &Value{ID: 10, Op: OpConst32, AuxInt: 4}
 	c2 := &Value{ID: 11, Op: OpConst32, AuxInt: 8}
 	add := &Value{Op: OpAdd32, Args: []*Value{c1, c2}}
-	fd := map[ValueID]bool{}
-	if isFrameOffset(add, fd) {
+	fd := map[ValueID]int64{}
+	if _, ok := frameOffsetOf(add, fd); ok {
 		t.Error("add of two unrelated consts should not be a frame offset")
 	}
 }

--- a/internal/ssa/memclass.go
+++ b/internal/ssa/memclass.go
@@ -1,5 +1,7 @@
 package ssa
 
+import "math"
+
 // AliasClass classifies where a memory access lands. It is the
 // observability backbone of memory promotion: every wasm
 // load / store is tagged so the transpiler can report — and act on —
@@ -53,6 +55,26 @@ type MemClass struct {
 	// EscapeReason, when FrameEscapes, names why (for the JSON / debug
 	// report).
 	EscapeReason string
+
+	// Slot-granular measurement (observability only — nothing rewrites
+	// on these yet). The whole-frame escape analysis above is
+	// all-or-nothing: one escaping pointer demotes EVERY frame access.
+	// These fields measure what a per-slot analysis would recover under
+	// the upward-extent model: an escaped pointer `fp+e` grants the
+	// callee/store access to [e, frameSize) — the C object the pointer
+	// names and everything above it — while slots strictly below every
+	// escaped offset remain provably private to the function.
+	//
+	// FrameAccesses counts every access through an fp-derived address
+	// (whether or not the frame escapes). SlotPromotable, meaningful
+	// only when FrameEscapes, counts the subset whose byte range lies
+	// entirely below EscapeMinOff. EscapeMinOff is the lowest
+	// fp-relative offset that escapes; -1 means an escape with no
+	// attributable offset (dynamic pointer arithmetic, an opaque use)
+	// poisons the whole frame.
+	FrameAccesses  int
+	SlotPromotable int
+	EscapeMinOff   int64
 }
 
 // ClassifyMemory analyses one SSA function and classifies every memory
@@ -74,22 +96,26 @@ func ClassifyMemory(f *Func) *MemClass {
 	// 1. Locate the frame pointer.
 	mc.FramePtr, mc.FrameSize = findFramePointer(f)
 
-	// 2. Compute the set of frame-pointer-derived values: fp itself,
-	// plus fp+const (any number of constant offsets), plus copies.
-	frameDerived := map[ValueID]bool{}
+	// 2. Compute the set of frame-pointer-derived values — fp itself,
+	// plus fp+const (any number of constant offsets), plus copies —
+	// each with its constant fp-relative offset.
+	frameOff := map[ValueID]int64{}
 	if mc.FramePtr != nil {
-		frameDerived[mc.FramePtr.ID] = true
+		frameOff[mc.FramePtr.ID] = 0
 		// Fixpoint: a value is frame-derived if it is OpAdd32 /
 		// OpSub32 of a frame-derived value and a constant, or a copy.
 		changed := true
 		for changed {
 			changed = false
 			for _, v := range f.Values {
-				if v == nil || frameDerived[v.ID] {
+				if v == nil {
 					continue
 				}
-				if isFrameOffset(v, frameDerived) {
-					frameDerived[v.ID] = true
+				if _, seen := frameOff[v.ID]; seen {
+					continue
+				}
+				if off, ok := frameOffsetOf(v, frameOff); ok {
+					frameOff[v.ID] = off
 					changed = true
 				}
 			}
@@ -97,9 +123,14 @@ func ClassifyMemory(f *Func) *MemClass {
 	}
 
 	// 3. Escape analysis: walk every use of every frame-derived value.
+	minEsc := int64(math.MaxInt64)
 	if mc.FramePtr != nil {
 		users := buildUseMap(f)
-		mc.FrameEscapes, mc.EscapeReason = frameEscapes(f, frameDerived, users)
+		mc.FrameEscapes, mc.EscapeReason, minEsc = frameEscapes(f, frameOff, users)
+		mc.EscapeMinOff = minEsc
+		if minEsc == math.MinInt64 {
+			mc.EscapeMinOff = -1
+		}
 	}
 
 	// 4. Classify each memory op.
@@ -108,8 +139,12 @@ func ClassifyMemory(f *Func) *MemClass {
 			continue
 		}
 		addr := constFoldAddr(memAddr(v))
+		off, isFrameAddr := int64(0), false
+		if addr != nil {
+			off, isFrameAddr = frameOff[addr.ID]
+		}
 		switch {
-		case mc.FramePtr != nil && addr != nil && frameDerived[addr.ID] && !mc.FrameEscapes:
+		case mc.FramePtr != nil && isFrameAddr && !mc.FrameEscapes:
 			mc.Class[v.ID] = AliasFrame
 		case addr != nil && addr.Op == OpConst32 && isLoadOp(v.Op):
 			// A load from a compile-time-constant linear-memory address
@@ -122,8 +157,29 @@ func ClassifyMemory(f *Func) *MemClass {
 		default:
 			mc.Class[v.ID] = AliasSlab
 		}
+		// Slot-granular measurement: the access's byte range is
+		// [off + AuxInt, off + AuxInt + width) relative to fp.
+		if mc.FramePtr != nil && isFrameAddr {
+			mc.FrameAccesses++
+			if mc.FrameEscapes && off+v.AuxInt+accessWidth(v.Op) <= minEsc {
+				mc.SlotPromotable++
+			}
+		}
 	}
 	return mc
+}
+
+// accessWidth returns the byte width a load/store touches.
+func accessWidth(op Op) int64 {
+	switch op {
+	case OpLoad8U, OpLoad8S, OpStore8:
+		return 1
+	case OpLoad16U, OpLoad16S, OpStore16:
+		return 2
+	case OpLoad32, OpLoad32U, OpLoad32S, OpLoadF32, OpStore32, OpStoreF32:
+		return 4
+	}
+	return 8
 }
 
 // isLoadOp reports whether op is a memory load (as opposed to a store).
@@ -177,26 +233,35 @@ func findFramePointer(f *Func) (*Value, int64) {
 	return nil, 0
 }
 
-// isFrameOffset reports whether v is `frameDerived ± const` or a copy
-// of a frame-derived value.
-func isFrameOffset(v *Value, frameDerived map[ValueID]bool) bool {
+// frameOffsetOf reports whether v is `frameDerived ± const` or a copy
+// of a frame-derived value, and if so its fp-relative offset.
+func frameOffsetOf(v *Value, frameOff map[ValueID]int64) (int64, bool) {
 	switch v.Op {
 	case OpCopy:
-		return len(v.Args) == 1 && v.Args[0] != nil && frameDerived[v.Args[0].ID]
+		if len(v.Args) == 1 && v.Args[0] != nil {
+			if o, ok := frameOff[v.Args[0].ID]; ok {
+				return o, true
+			}
+		}
 	case OpAdd32, OpSub32:
 		if len(v.Args) != 2 || v.Args[0] == nil || v.Args[1] == nil {
-			return false
+			return 0, false
 		}
 		a, b := v.Args[0], v.Args[1]
 		// frameDerived + const  (or const + frameDerived for Add)
-		if frameDerived[a.ID] && b.Op == OpConst32 {
-			return true
+		if o, ok := frameOff[a.ID]; ok && b.Op == OpConst32 {
+			if v.Op == OpAdd32 {
+				return o + b.AuxInt, true
+			}
+			return o - b.AuxInt, true
 		}
-		if v.Op == OpAdd32 && frameDerived[b.ID] && a.Op == OpConst32 {
-			return true
+		if v.Op == OpAdd32 {
+			if o, ok := frameOff[b.ID]; ok && a.Op == OpConst32 {
+				return o + a.AuxInt, true
+			}
 		}
 	}
-	return false
+	return 0, false
 }
 
 // buildUseMap returns, per value ID, the list of values that reference
@@ -217,10 +282,27 @@ func buildUseMap(f *Func) map[ValueID][]*Value {
 }
 
 // frameEscapes returns whether any frame-derived value is used in a way
-// that lets the frame escape the function.
-func frameEscapes(f *Func, frameDerived map[ValueID]bool, users map[ValueID][]*Value) (bool, string) {
+// that lets the frame escape the function, the first reason found, and
+// the minimum escaped fp-relative offset (math.MaxInt64 when nothing
+// escapes; math.MinInt64 when an escape has no attributable offset and
+// poisons the whole frame under the upward-extent model).
+func frameEscapes(f *Func, frameOff map[ValueID]int64, users map[ValueID][]*Value) (bool, string, int64) {
+	escaped, reason := false, ""
+	minOff := int64(math.MaxInt64)
+	escape := func(off int64, why string) {
+		if !escaped {
+			escaped, reason = true, why
+		}
+		if off < minOff {
+			minOff = off
+		}
+	}
 	for _, v := range f.Values {
-		if v == nil || !frameDerived[v.ID] {
+		if v == nil {
+			continue
+		}
+		off, ok := frameOff[v.ID]
+		if !ok {
 			continue
 		}
 		for _, u := range users[v.ID] {
@@ -229,31 +311,38 @@ func frameEscapes(f *Func, frameDerived map[ValueID]bool, users map[ValueID][]*V
 				// Frame management (prologue set / epilogue restore).
 			case OpAdd32, OpSub32:
 				// `fp ± const` stays frame-derived; non-const operands
-				// were already excluded from frameDerived, but a use
-				// of fp as `fp - dynamicValue` is opaque → escape.
-				if !frameDerived[u.ID] {
-					return true, "frame pointer used in non-constant arithmetic"
+				// were already excluded from frameOff, but a use of fp
+				// as `fp - dynamicValue` is opaque → the derived
+				// pointer can reach any slot: whole-frame poison.
+				if _, derived := frameOff[u.ID]; !derived {
+					escape(math.MinInt64, "frame pointer used in non-constant arithmetic")
 				}
 			case OpCopy:
 				// A copy of a frame value is itself frame-derived.
 			case OpStore8, OpStore16, OpStore32, OpStore64, OpStoreF32, OpStoreF64:
 				// Address operand (Args[0]) is fine — a frame store.
 				// Value operand (Args[1]) means the pointer itself is
-				// written into memory → escape.
+				// written into memory → escape at its offset.
 				if len(u.Args) >= 2 && u.Args[1] == v {
-					return true, "frame pointer stored to memory"
+					escape(off, "frame pointer stored to memory")
 				}
 			case OpLoad8U, OpLoad8S, OpLoad16U, OpLoad16S, OpLoad32,
 				OpLoad32U, OpLoad32S, OpLoad64, OpLoadF32, OpLoadF64:
 				// Address operand — a frame load. Fine.
+			case OpEq32, OpNe32, OpLtS32, OpLtU32, OpLeS32, OpLeU32:
+				// Comparing the frame pointer (stack-limit checks,
+				// pointer equality) consumes it as a NUMBER — no alias
+				// is created and no frame memory becomes reachable.
 			case OpCallDirect, OpCallIndirect, OpCallImport:
-				return true, "frame pointer passed to a call"
+				escape(off, "frame pointer passed to a call")
 			default:
-				return true, "frame pointer used by " + u.Op.String()
+				// Bulk-memory ops, selects, comparisons, … — no offset
+				// attribution attempted: whole-frame poison.
+				escape(math.MinInt64, "frame pointer used by "+u.Op.String())
 			}
 		}
 	}
-	return false, ""
+	return escaped, reason, minOff
 }
 
 // isMemoryAccess reports whether op is a load or store.

--- a/internal/ssa/memclass_test.go
+++ b/internal/ssa/memclass_test.go
@@ -69,6 +69,63 @@ func TestClassifyMemoryFrameEscaping(t *testing.T) {
 	}
 }
 
+// buildSlotFrameFunc builds an escaping-frame function with mixed slot
+// traffic: a 64-byte frame where fp+32 is passed to a call (the escape
+// root), fp+0/fp+8 hold private i64 slots (below the root), and fp+40
+// is a store above the root.
+func buildSlotFrameFunc(escapeOff int32) *Func {
+	b := NewFuncBuilder("slottest", FuncSig{Params: []Type{TypeI64}, Results: []Type{TypeI64}})
+	entry := b.NewBlock(BlockPlain)
+	b.SetEntry(entry)
+	b.SetCurrent(entry)
+
+	p0 := b.Param(0, TypeI64)
+	g0 := b.NewValueAuxInt(OpGlobalGet, TypeI32, 0)
+	fp := b.NewValue(OpSub32, TypeI32, g0, b.Const32(64))
+	b.NewValueAuxInt(OpGlobalSet, TypeMem, 0, fp)
+	b.NewValueAuxInt(OpStore64, TypeMem, 0, fp, p0)  // [fp+0]  private
+	b.NewValueAuxInt(OpStore64, TypeMem, 8, fp, p0)  // [fp+8]  private
+	ld := b.NewValueAuxInt(OpLoad64, TypeI64, 0, fp) // [fp+0]  private
+	esc := b.NewValue(OpAdd32, TypeI32, fp, b.Const32(escapeOff))
+	b.NewValueAux(OpCallDirect, TypeI32, nil, esc)   // fp+escapeOff escapes
+	b.NewValueAuxInt(OpStore64, TypeMem, 40, fp, p0) // [fp+40] above the root
+	restore := b.NewValue(OpAdd32, TypeI32, fp, b.Const32(64))
+	b.NewValueAuxInt(OpGlobalSet, TypeMem, 0, restore)
+	b.FinishRet(ld)
+	return b.Func()
+}
+
+func TestClassifyMemorySlotGranular(t *testing.T) {
+	f := buildSlotFrameFunc(32)
+	mc := ClassifyMemory(f)
+	if !mc.FrameEscapes {
+		t.Fatal("frame should escape (fp+32 passed to a call)")
+	}
+	if mc.EscapeMinOff != 32 {
+		t.Errorf("EscapeMinOff = %d, want 32", mc.EscapeMinOff)
+	}
+	if mc.FrameAccesses != 4 {
+		t.Errorf("FrameAccesses = %d, want 4", mc.FrameAccesses)
+	}
+	// [fp+0]x2 + [fp+8] end at 8/16 <= 32 → promotable; [fp+40] is not.
+	if mc.SlotPromotable != 3 {
+		t.Errorf("SlotPromotable = %d, want 3", mc.SlotPromotable)
+	}
+}
+
+func TestClassifyMemorySlotBoundary(t *testing.T) {
+	// Escape root at fp+8: the i64 store/load pair at [fp+0] ends
+	// exactly at the root (8 <= 8 → private); [fp+8] overlaps it.
+	f := buildSlotFrameFunc(8)
+	mc := ClassifyMemory(f)
+	if mc.EscapeMinOff != 8 {
+		t.Fatalf("EscapeMinOff = %d, want 8", mc.EscapeMinOff)
+	}
+	if mc.SlotPromotable != 2 {
+		t.Errorf("SlotPromotable = %d, want 2 ([fp+0] store+load only)", mc.SlotPromotable)
+	}
+}
+
 func TestMemMetricsAggregate(t *testing.T) {
 	m := NewMemMetrics()
 	f1 := buildFrameFunc(false) // 2 frame accesses

--- a/internal/ssa/metrics.go
+++ b/internal/ssa/metrics.go
@@ -25,6 +25,12 @@ type MemMetrics struct {
 	FuncsWithFrame int // functions with a detected stack frame
 	FuncsFrameKept int // ... whose frame did not escape (promotable)
 
+	// Slot-granular measurement over ESCAPED frames (see
+	// MemClass.SlotPromotable): how much frame traffic a per-slot
+	// escape analysis would additionally recover.
+	EscapedFrameAccesses int // fp-derived accesses in escaped-frame fns
+	SlotPromotable       int // ... provably below every escaped offset
+
 	// PerFunc keeps a one-line record per analysed function for the
 	// sidecar report. Keyed insertion order is preserved via the
 	// parallel funcOrder slice.
@@ -55,6 +61,13 @@ type FuncMemRecord struct {
 	FrameSize    int64  `json:"frame_size"`
 	FrameEscaped bool   `json:"frame_escaped"`
 	EscapeReason string `json:"escape_reason,omitempty"`
+	// Slot-granular measurement, set when the frame escaped: accesses
+	// through fp-derived addresses, the subset a per-slot analysis
+	// would keep private, and the lowest escaped fp offset (-1 =
+	// whole-frame poison).
+	FrameAccesses  int   `json:"frame_accesses,omitempty"`
+	SlotPromotable int   `json:"slot_promotable,omitempty"`
+	EscapeMinOff   int64 `json:"escape_min_off,omitempty"`
 }
 
 // NewMemMetrics returns an empty accumulator.
@@ -84,6 +97,12 @@ func (m *MemMetrics) Add(f *Func, mc *MemClass) {
 		rec.EscapeReason = mc.EscapeReason
 		if !mc.FrameEscapes {
 			m.FuncsFrameKept++
+		} else {
+			rec.FrameAccesses = mc.FrameAccesses
+			rec.SlotPromotable = mc.SlotPromotable
+			rec.EscapeMinOff = mc.EscapeMinOff
+			m.EscapedFrameAccesses += mc.FrameAccesses
+			m.SlotPromotable += mc.SlotPromotable
 		}
 	}
 	m.Total += rec.Total
@@ -149,6 +168,11 @@ func (m *MemMetrics) Summary() string {
 	s += fmt.Sprintf("    frame:                 %8d  (%s)\n", m.Frame, pct(m.Frame))
 	s += fmt.Sprintf("    rodata:                %8d  (%s)\n", m.Rodata, pct(m.Rodata))
 	s += fmt.Sprintf("  slab (not promoted):     %8d  (%s)\n", m.Slab, pct(m.Slab))
+	if m.EscapedFrameAccesses > 0 {
+		s += fmt.Sprintf("  slot-promotable (escaped frames): %8d / %d  (%.1f%%)\n",
+			m.SlotPromotable, m.EscapedFrameAccesses,
+			100*float64(m.SlotPromotable)/float64(m.EscapedFrameAccesses))
+	}
 	return s
 }
 
@@ -178,28 +202,32 @@ func (m *MemMetrics) TopSlabFunctions(n int) []FuncMemRecord {
 // `-promotion-report` sidecar.
 func (m *MemMetrics) JSON() ([]byte, error) {
 	type doc struct {
-		SSAFunctions   int             `json:"ssa_functions"`
-		FuncsWithFrame int             `json:"funcs_with_frame"`
-		FuncsFrameKept int             `json:"funcs_frame_non_escaping"`
-		Total          int             `json:"total_accesses"`
-		Promoted       int             `json:"promoted"`
-		Frame          int             `json:"frame"`
-		Rodata         int             `json:"rodata"`
-		Slab           int             `json:"slab"`
-		Rate           float64         `json:"promotion_rate"`
-		Functions      []FuncMemRecord `json:"functions"`
+		SSAFunctions         int             `json:"ssa_functions"`
+		FuncsWithFrame       int             `json:"funcs_with_frame"`
+		FuncsFrameKept       int             `json:"funcs_frame_non_escaping"`
+		Total                int             `json:"total_accesses"`
+		Promoted             int             `json:"promoted"`
+		Frame                int             `json:"frame"`
+		Rodata               int             `json:"rodata"`
+		Slab                 int             `json:"slab"`
+		Rate                 float64         `json:"promotion_rate"`
+		EscapedFrameAccesses int             `json:"escaped_frame_accesses"`
+		SlotPromotable       int             `json:"slot_promotable"`
+		Functions            []FuncMemRecord `json:"functions"`
 	}
 	d := doc{
-		SSAFunctions:   m.SSAFunctions,
-		FuncsWithFrame: m.FuncsWithFrame,
-		FuncsFrameKept: m.FuncsFrameKept,
-		Total:          m.Total,
-		Promoted:       m.Promoted(),
-		Frame:          m.Frame,
-		Rodata:         m.Rodata,
-		Slab:           m.Slab,
-		Rate:           m.Rate(),
-		Functions:      m.FuncRecords(),
+		SSAFunctions:         m.SSAFunctions,
+		FuncsWithFrame:       m.FuncsWithFrame,
+		FuncsFrameKept:       m.FuncsFrameKept,
+		Total:                m.Total,
+		Promoted:             m.Promoted(),
+		Frame:                m.Frame,
+		Rodata:               m.Rodata,
+		Slab:                 m.Slab,
+		Rate:                 m.Rate(),
+		EscapedFrameAccesses: m.EscapedFrameAccesses,
+		SlotPromotable:       m.SlotPromotable,
+		Functions:            m.FuncRecords(),
 	}
 	return json.MarshalIndent(d, "", "  ")
 }


### PR DESCRIPTION
## Summary

Measurement infrastructure (observability only — nothing rewrites on it) answering the question: *would promoting linear-memory shadow-stack slots to Go locals be worth implementing?*

The existing `ClassifyMemory` escape analysis is all-or-nothing: one escaping frame pointer demotes every frame access to slab. This PR extends it to slot granularity:

- frame-derived values now carry their constant fp-relative offset;
- escape sites record the lowest escaped offset under the upward-extent model (an escaped `fp+e` grants the callee access to `[e, frameSize)`; slots strictly below every escaped offset stay private); dynamic pointer arithmetic and unattributable uses poison the whole frame;
- comparisons of the frame pointer (stack-limit checks) are now recognized as non-escaping — they consume the pointer as a number and create no alias;
- the per-function report gains `frame_accesses` / `slot_promotable` / `escape_min_off`; the module summary and JSON gain the totals.

## Measured answer (spidermonkey.wasm, PBL, sha 3db0e6fc)

| metric | value |
|---|---:|
| total memory accesses | 644,300 |
| accesses via fp-derived addresses in escaped-frame fns | 107,018 |
| slot-promotable under the upward-extent model | **728 (0.7% of those; 0.11% of all traffic)** |
| Fn6321 (PBL interpreter, 85% of runtime profile): fp-derived accesses | 650 of 10,377 (6.3%) — frame stays whole-poisoned |

Conclusion recorded in the commit: a shadow-stack → Go-locals rewrite has near-zero headroom on this corpus. The hot traffic is heap/bytecode pointer chasing through dynamically computed addresses, not frame slots — LLVM already keeps register-like values in wasm locals, and what remains on the shadow stack is address-taken state whose pointers escape into VM helper calls.

## Verification

- `go test ./...` exit 0; `make lint` 0 issues.
- `make test-cover`: exit 0 at 85.6% (>= 84% gate) measured in a fresh `git worktree` per the local measurement rule — the main working dir reads ~5pt low on this machine with identical per-package coverage (verified on unmodified main too; a local-environment artifact, not a coverage regression).
- Generated code is unaffected: `ClassifyMemory` feeds only the metrics/report sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
