### PR TITLE
gcasm: O(1) jump tables — init-scanned address tables replace the compare tree

### DIFF
--- a/internal/gcasm/a64fixture_test.go
+++ b/internal/gcasm/a64fixture_test.go
@@ -100,6 +100,7 @@ func a64FixtureGate(t *testing.T, fixture string) {
 	}
 	pool := &ConstPool{}
 	types := &TypeTable{}
+	jt := &JTTable{}
 	var asmB, declB strings.Builder
 	asmB.WriteString("//go:build arm64\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n")
 	declB.WriteString("//go:build arm64\n\npackage pkg\n")
@@ -145,6 +146,7 @@ func a64FixtureGate(t *testing.T, fixture string) {
 			Datas:     dm,
 			Consts:    pool,
 			Types:     types,
+			JT:        jt,
 		})
 		if err != nil {
 			t.Fatalf("transform %s: %v", f.Name, err)
@@ -162,6 +164,9 @@ func a64FixtureGate(t *testing.T, fixture string) {
 		t.Fatalf("unresolved callees: %v", unresolved)
 	}
 	asmB.WriteString(pool.Emit())
+	asmB.WriteString(jt.EmitAsm("arm64"))
+	declB.WriteString("\n")
+	declB.WriteString(jt.EmitGo("arm64"))
 	if len(types.Names) > 0 {
 		t.Skipf("type refs present (%d) — arm64 type-desc wiring TODO", len(types.Names))
 	}

--- a/internal/gcasm/a64jumptable_flags_test.go
+++ b/internal/gcasm/a64jumptable_flags_test.go
@@ -46,7 +46,7 @@ func a64JtDatas() map[string]*DataSym {
 // went the wrong way, corrupting linear memory).
 func TestA64JumpTableFlagReplayDetect(t *testing.T) {
 	t.Run("clean setter replayed at leaves", func(t *testing.T) {
-		sites, err := a64FindJumpTables("lib.FDispatch", a64JtInsns("CMPW\t$40, R1"), a64JtDatas())
+		sites, err := a64FindJumpTables("lib.FDispatch", a64JtInsns("CMPW\t$40, R1"), a64JtDatas(), false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -81,7 +81,7 @@ func TestA64JumpTableFlagReplayDetect(t *testing.T) {
 		// Replace the compare with a flag-neutral instruction: the
 		// backward scan finds no clean setter, and target 100 (BLT)
 		// consumes flags → errUnsupportedJumpTable → pure fallback.
-		_, err := a64FindJumpTables("lib.FDispatch", a64JtInsns("MOVD\t$40, R3"), a64JtDatas())
+		_, err := a64FindJumpTables("lib.FDispatch", a64JtInsns("MOVD\t$40, R3"), a64JtDatas(), false)
 		if !errors.Is(err, errUnsupportedJumpTable) {
 			t.Fatalf("err = %v, want errUnsupportedJumpTable", err)
 		}
@@ -92,7 +92,7 @@ func TestA64JumpTableFlagReplayDetect(t *testing.T) {
 		// the dispatch clobbers both. With target 100 consuming flags
 		// the site must fall back rather than replay a clobbered
 		// operand.
-		_, err := a64FindJumpTables("lib.FDispatch", a64JtInsns("CMPW\t$40, R17"), a64JtDatas())
+		_, err := a64FindJumpTables("lib.FDispatch", a64JtInsns("CMPW\t$40, R17"), a64JtDatas(), false)
 		if !errors.Is(err, errUnsupportedJumpTable) {
 			t.Fatalf("err = %v, want errUnsupportedJumpTable (replay operand clobbered)", err)
 		}
@@ -101,7 +101,7 @@ func TestA64JumpTableFlagReplayDetect(t *testing.T) {
 	t.Run("no setter, flag-neutral targets stay transformed", func(t *testing.T) {
 		insns := a64JtInsns("MOVD\t$40, R3")
 		insns[5].Text = "MOVD\t$3, R0" // target 100 no longer reads flags
-		sites, err := a64FindJumpTables("lib.FDispatch", insns, a64JtDatas())
+		sites, err := a64FindJumpTables("lib.FDispatch", insns, a64JtDatas(), false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -151,6 +151,7 @@ func TestA64JumpTableFlagReplayRun(t *testing.T) {
 	for _, d := range datas {
 		dm[d.Name] = d
 	}
+	jt := &JTTable{}
 	body, err := TransformARM64(disp, TransformOptions{
 		SymName:   "fdispatchAsm",
 		CalleeSig: func(string) ([]ArgKind, bool, ArgKind, string, bool) { return nil, false, 0, "", false },
@@ -159,6 +160,7 @@ func TestA64JumpTableFlagReplayRun(t *testing.T) {
 		Result:    ArgI32,
 		ArgNames:  []string{"sel", "v0"},
 		Datas:     dm,
+		JT:        jt,
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "jump") {
@@ -166,15 +168,16 @@ func TestA64JumpTableFlagReplayRun(t *testing.T) {
 		}
 		t.Fatal(err)
 	}
-	if !strings.Contains(body, "jt") || strings.Contains(body, ".jump") {
+	if !strings.Contains(body, "_jt") || strings.Contains(body, ".jump") {
 		t.Skipf("gc did not emit a jump table for FDispatch on this toolchain")
 	}
+	body += jt.EmitAsm("arm64")
 
 	run := t.TempDir()
 	files := map[string]string{
 		"go.mod": "module fjtrun\n\ngo 1.25.0\n",
-		"decl.go": "//go:build arm64\n\npackage fjtrun\n\nfunc fdispatchAsm(sel int32, v0 int32) (r0 int32)\n\n//go:noinline\n" +
-			flagDispatchSrc("fdispatchRef"),
+		"decl.go": "//go:build arm64\n\npackage fjtrun\n\nimport \"unsafe\"\n\nvar _ unsafe.Pointer\n\nfunc fdispatchAsm(sel int32, v0 int32) (r0 int32)\n\n//go:noinline\n" +
+			flagDispatchSrc("fdispatchRef") + "\n" + jt.EmitGo("arm64"),
 		"body_arm64.s": "#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + body,
 		"run_test.go": `package fjtrun
 

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -503,8 +503,8 @@ type archSpec struct {
 }
 
 var archSpecs = []archSpec{
-	{name: "amd64", transform: Transform, jtMarker: "\tJCC jt"},
-	{name: "arm64", transform: TransformARM64, jtMarker: "\tBHS jt"},
+	{name: "amd64", transform: Transform, jtMarker: "_jt"},
+	{name: "arm64", transform: TransformARM64, jtMarker: "_jt"},
 }
 
 func buildPkg(
@@ -534,6 +534,7 @@ func buildPkg(
 	fallbackNames := map[string]bool{}
 	pool := &ConstPool{}
 	types := &TypeTable{}
+	jt := &JTTable{}
 	var asmB strings.Builder
 	// The build tag pins GOARCH explicitly: the bundle uses bare
 	// arch filenames (amd64.s/arm64.s), which — having no prefix
@@ -618,6 +619,7 @@ func buildPkg(
 			Datas:     dm,
 			Consts:    pool,
 			Types:     types,
+			JT:        jt,
 		})
 		if terr != nil {
 			// A duff body, or a jump table whose flag state cannot be replayed
@@ -697,6 +699,7 @@ func buildPkg(
 	}
 
 	asmB.WriteString(pool.Emit())
+	asmB.WriteString(jt.EmitAsm(arch.name))
 
 	// Decls file.
 	var decl strings.Builder
@@ -865,6 +868,13 @@ var (
 			decl.WriteString(body)
 			decl.WriteString("\n\n")
 		}
+	}
+
+	// O(1) jump-table support: table vars + the init that fills them
+	// by scanning for the pad signatures (see jumppad.go).
+	if jtGo := jt.EmitGo(arch.name); jtGo != "" {
+		decl.WriteString("\n// Jump-table dispatch tables, filled at init by signature scan.\n\n")
+		decl.WriteString(jtGo)
 	}
 
 	prefix := ""

--- a/internal/gcasm/gate1_test.go
+++ b/internal/gcasm/gate1_test.go
@@ -296,6 +296,7 @@ func gcasmBitsTrailingZeros64(x uint64) int  { return bits.TrailingZeros64(x) }
 		declB.WriteString("\n")
 		pool := &ConstPool{}
 		types := &TypeTable{}
+		jt := &JTTable{}
 		for _, f := range fns {
 			m := fnIdxRe.FindStringSubmatch(f.Name)
 			if m == nil {
@@ -335,6 +336,7 @@ func gcasmBitsTrailingZeros64(x uint64) int  { return bits.TrailingZeros64(x) }
 				Datas:     dm,
 				Consts:    pool,
 				Types:     types,
+				JT:        jt,
 			})
 			if err != nil {
 				t.Fatalf("transform %s: %v", f.Name, err)
@@ -352,6 +354,9 @@ func gcasmBitsTrailingZeros64(x uint64) int  { return bits.TrailingZeros64(x) }
 			t.Fatalf("unresolved in-module callees (silent ABI mismatch): %v", unresolved)
 		}
 		asmB.WriteString(pool.Emit())
+		asmB.WriteString(jt.EmitAsm("amd64"))
+		declB.WriteString("\n")
+		declB.WriteString(jt.EmitGo("amd64"))
 		// Type descriptor vars: initialise each from an eface's type
 		// word — the same descriptor `LEAQ type:F(SB)` would produce.
 		// The captured spelling qualifies identifiers with the import

--- a/internal/gcasm/jumppad.go
+++ b/internal/gcasm/jumppad.go
@@ -1,0 +1,301 @@
+package gcasm
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+// O(1) jump-table dispatch for hand-written asm.
+//
+// Plan9 asm cannot express address-of-label DATA, so gc's captured
+// `LEAQ table(SB) + JMP (base)(idx*8)` cannot be reproduced literally.
+// The historical rewrite (emitJumpTree) degrades the O(1) indirect
+// jump into an O(log n) compare tree — a measured pessimization on
+// interpreter-style dispatch. This file restores O(1):
+//
+//   - The dispatch keeps gc's ORIGINAL shape, retargeted at a
+//     Go-declared table var:
+//
+//     amd64:  LEAQ ·tab(SB), base           (RIP-relative, PIE-safe)
+//             JMP  (base)(idx*8)
+//     arm64:  MOVD $·tab(SB), R16
+//             MOVD (R16)(idx<<3), R17
+//             JMP  (R17)
+//
+//     Exactly the registers gc's own dispatch clobbered, and — like
+//     gc's dispatch — NO flag-register writes: the pre-dispatch flag
+//     state gc lets targets consume arrives intact, so the whole
+//     flag-replay machinery the compare tree needed does not apply.
+//
+//   - Each distinct dispatch target gets a STUB right after the
+//     dispatch: a signature marker and a direct jump to the real pcN
+//     label. Entries hold the stubs' ABSOLUTE addresses — computed and
+//     written at init, never baked, so PIE/relocation is a non-issue.
+//
+//   - Stub addresses cannot be known at generation time (the consumer's
+//     assembler picks final encodings), so the table is FILLED AT INIT:
+//     each stub starts with an executable no-op signature unique to
+//     (function, site, target), and a generated package init() scans
+//     the function's code bytes for those signatures and writes the
+//     entries. A missing signature panics at init — a mis-set table can
+//     never silently wild-jump.
+//
+// Signature encodings (executable no-ops, checked byte-for-byte by the
+// scanner):
+//
+//	amd64: two long NOPs `0F 1F 80 <sig32>` + `0F 1F 80 <^sig32>`
+//	       (14 bytes; the complement pair rules out accidental matches)
+//	arm64: MOVZ/MOVK/MOVK into R17 (a dispatch scratch) carrying a
+//	       48-bit signature across three fixed-form instructions.
+
+// JTTable accumulates jump-table dispatch sites for one output .s
+// file, like ConstPool/TypeTable. The caller appends EmitAsm() to the
+// .s and EmitGo() to the same package's Go declarations file.
+type JTTable struct {
+	Fns []JTFn
+}
+
+// JTFn is one transformed function's jump-table metadata.
+type JTFn struct {
+	Sym   string // asm/Go symbol (e.g. "Fn6321")
+	Sites []JTSite
+}
+
+// JTSite is one dispatch site.
+type JTSite struct {
+	TabVar  string   // Go table var name (·TabVar(SB) from asm)
+	Entries []uint16 // selector k → index into Sigs
+	Sigs    []uint64 // distinct-target signatures (amd64: 32-bit; arm64: 48-bit)
+}
+
+func (jt *JTTable) fn(sym string) *JTFn {
+	if n := len(jt.Fns); n > 0 && jt.Fns[n-1].Sym == sym {
+		return &jt.Fns[n-1]
+	}
+	jt.Fns = append(jt.Fns, JTFn{Sym: sym})
+	return &jt.Fns[len(jt.Fns)-1]
+}
+
+// jtSig derives the deterministic signature for one dispatch target.
+// bits selects the architecture's signature width.
+func jtSig(fnSym string, siteOff, target, bits int) uint64 {
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "%s+%d>%d", fnSym, siteOff, target)
+	s := h.Sum64() & (1<<bits - 1)
+	// All-zero / all-one signatures resemble alignment padding; nudge.
+	if s == 0 || s == 1<<bits-1 {
+		s = 0x5A5A5A5A & (1<<bits - 1)
+	}
+	return s
+}
+
+// jtExpandEntries expands run-compressed targets to a per-selector
+// stub-index list plus the distinct-target order.
+func jtExpandEntries(site *jtSite) (entries []uint16, targets []int) {
+	tIndex := map[int]int{}
+	for _, r := range site.runs {
+		if _, ok := tIndex[r.target]; !ok {
+			tIndex[r.target] = len(targets)
+			targets = append(targets, r.target)
+		}
+	}
+	entries = make([]uint16, site.entryCount)
+	for i, r := range site.runs {
+		end := site.entryCount
+		if i+1 < len(site.runs) {
+			end = site.runs[i+1].start
+		}
+		for k := r.start; k < end; k++ {
+			entries[k] = uint16(tIndex[r.target])
+		}
+	}
+	return entries, targets
+}
+
+// emitJumpPad writes the amd64 O(1) dispatch + stubs for one site and
+// registers its table metadata on jt.
+func emitJumpPad(b *strings.Builder, jt *JTTable, symName string, site *jtSite, siteOff int) {
+	fn := jt.fn(symName)
+	tab := fmt.Sprintf("%s_jt%d", symName, siteOff)
+	entries, targets := jtExpandEntries(site)
+
+	fmt.Fprintf(b, "\tLEAQ ·%s(SB), %s\n", tab, site.baseReg)
+	fmt.Fprintf(b, "\tJMP (%s)(%s*8)\n", site.baseReg, site.idxReg)
+
+	sigs := make([]uint64, len(targets))
+	for i, t := range targets {
+		sig := jtSig(symName, siteOff, t, 32)
+		sigs[i] = sig
+		writeAmd64SigNop(b, uint32(sig))
+		writeAmd64SigNop(b, ^uint32(sig))
+		fmt.Fprintf(b, "\tJMP pc%d\n", t)
+	}
+	fn.Sites = append(fn.Sites, JTSite{TabVar: tab, Entries: entries, Sigs: sigs})
+}
+
+// writeAmd64SigNop emits `0F 1F 80 imm32` — NOPL imm32(AX), a 7-byte
+// executable no-op carrying a 4-byte signature.
+func writeAmd64SigNop(b *strings.Builder, imm uint32) {
+	fmt.Fprintf(b, "\tBYTE $0x0F; BYTE $0x1F; BYTE $0x80\n")
+	for i := 0; i < 4; i++ {
+		fmt.Fprintf(b, "\tBYTE $0x%02X\n", byte(imm>>(8*i)))
+	}
+}
+
+// a64EmitJumpPad is the arm64 twin — the same triple gc emitted,
+// pointed at the Go table var.
+func a64EmitJumpPad(b *strings.Builder, jt *JTTable, symName string, site *jtSite, siteOff int) {
+	fn := jt.fn(symName)
+	tab := fmt.Sprintf("%s_jt%d", symName, siteOff)
+	entries, targets := jtExpandEntries(site)
+
+	fmt.Fprintf(b, "\tMOVD $·%s(SB), R16\n", tab)
+	fmt.Fprintf(b, "\tMOVD (R16)(%s<<3), R17\n", site.idxReg)
+	fmt.Fprintf(b, "\tJMP (R17)\n")
+
+	sigs := make([]uint64, len(targets))
+	for i, t := range targets {
+		sig := jtSig(symName, siteOff, t, 48)
+		sigs[i] = sig
+		// MOVZ x17,#lo / MOVK x17,#mid,lsl16 / MOVK x17,#hi,lsl32 —
+		// three fixed-form writes to the R17 scratch the dispatch
+		// already clobbers, carrying the 48-bit signature.
+		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xD2800011|uint32(sig&0xFFFF)<<5)
+		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xF2A00011|uint32(sig>>16&0xFFFF)<<5)
+		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xF2C00011|uint32(sig>>32&0xFFFF)<<5)
+		fmt.Fprintf(b, "\tJMP pc%d\n", t)
+	}
+	fn.Sites = append(fn.Sites, JTSite{TabVar: tab, Entries: entries, Sigs: sigs})
+}
+
+// EmitAsm renders the per-function address helpers (`<Sym>_jtpc`) the
+// generated init uses as its scan origin. Tables themselves are Go
+// vars (see EmitGo) — asm references them, Go owns the storage.
+func (jt *JTTable) EmitAsm(arch string) string {
+	var b strings.Builder
+	for _, fn := range jt.Fns {
+		if arch == "arm64" {
+			fmt.Fprintf(&b, "TEXT ·%s_jtpc(SB), NOSPLIT|NOFRAME, $0-8\n\tMOVD $·%s(SB), R0\n\tMOVD R0, ret+0(FP)\n\tRET\n", fn.Sym, fn.Sym)
+			continue
+		}
+		fmt.Fprintf(&b, "TEXT ·%s_jtpc(SB), NOSPLIT, $0-8\n\tLEAQ ·%s(SB), AX\n\tMOVQ AX, ret+0(FP)\n\tRET\n", fn.Sym, fn.Sym)
+	}
+	return b.String()
+}
+
+// EmitGo renders the table vars, the init() that fills them, and (once
+// per file) the code-byte scanner. The output belongs in the same
+// package as the .s file, in an arch-tagged Go file.
+func (jt *JTTable) EmitGo(arch string) string {
+	if len(jt.Fns) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, fn := range jt.Fns {
+		fmt.Fprintf(&b, "func %s_jtpc() unsafe.Pointer\n\n", fn.Sym)
+		for _, s := range fn.Sites {
+			fmt.Fprintf(&b, "var %s [%d]uint64\n", s.TabVar, len(s.Entries))
+		}
+	}
+	b.WriteString("\nfunc init() {\n")
+	for _, fn := range jt.Fns {
+		fmt.Fprintf(&b, "\tgcasmJTInit(%s_jtpc(), []gcasmJTSpec{\n", fn.Sym)
+		for _, s := range fn.Sites {
+			fmt.Fprintf(&b, "\t\t{tab: %s[:], entries: %#v, sigs: %#v},\n", s.TabVar, s.Entries, s.Sigs)
+		}
+		b.WriteString("\t})\n")
+	}
+	b.WriteString("}\n\n")
+	if arch == "arm64" {
+		b.WriteString(jtScannerGoARM64)
+	} else {
+		b.WriteString(jtScannerGoAMD64)
+	}
+	return b.String()
+}
+
+// jtScannerGoAMD64 locates each stub by its 14-byte double-NOP
+// signature and writes the stubs' absolute addresses.
+const jtScannerGoAMD64 = `type gcasmJTSpec struct {
+	tab     []uint64
+	entries []uint16
+	sigs    []uint64
+}
+
+func gcasmJTInit(pc unsafe.Pointer, specs []gcasmJTSpec) {
+	need := 0
+	for _, s := range specs {
+		need += len(s.sigs)
+	}
+	found := make(map[uint64]unsafe.Pointer, need)
+	const maxScan = 1 << 26
+	for off, n := 0, 0; n < need; off++ {
+		if off >= maxScan {
+			panic("gcasm: jump-table signature scan overflow")
+		}
+		p := (*[14]byte)(unsafe.Add(pc, off))
+		if p[0] != 0x0F || p[1] != 0x1F || p[2] != 0x80 || p[7] != 0x0F || p[8] != 0x1F || p[9] != 0x80 {
+			continue
+		}
+		sig := uint32(p[3]) | uint32(p[4])<<8 | uint32(p[5])<<16 | uint32(p[6])<<24
+		inv := uint32(p[10]) | uint32(p[11])<<8 | uint32(p[12])<<16 | uint32(p[13])<<24
+		if inv != ^sig {
+			continue
+		}
+		if _, dup := found[uint64(sig)]; !dup {
+			found[uint64(sig)] = unsafe.Add(pc, off)
+			n++
+		}
+	}
+	for _, s := range specs {
+		for k, ti := range s.entries {
+			stub, ok := found[s.sigs[ti]]
+			if !ok {
+				panic("gcasm: jump-table signature missing")
+			}
+			s.tab[k] = uint64(uintptr(stub))
+		}
+	}
+}
+`
+
+// jtScannerGoARM64 locates each stub by its MOVZ/MOVK/MOVK triple.
+const jtScannerGoARM64 = `type gcasmJTSpec struct {
+	tab     []uint64
+	entries []uint16
+	sigs    []uint64
+}
+
+func gcasmJTInit(pc unsafe.Pointer, specs []gcasmJTSpec) {
+	need := 0
+	for _, s := range specs {
+		need += len(s.sigs)
+	}
+	found := make(map[uint64]unsafe.Pointer, need)
+	const maxScan = 1 << 26
+	for off, n := 0, 0; n < need; off += 4 {
+		if off >= maxScan {
+			panic("gcasm: jump-table signature scan overflow")
+		}
+		w := (*[3]uint32)(unsafe.Add(pc, off))
+		if w[0]&0xFFE0001F != 0xD2800011 || w[1]&0xFFE0001F != 0xF2A00011 || w[2]&0xFFE0001F != 0xF2C00011 {
+			continue
+		}
+		sig := uint64(w[0]>>5&0xFFFF) | uint64(w[1]>>5&0xFFFF)<<16 | uint64(w[2]>>5&0xFFFF)<<32
+		if _, dup := found[sig]; !dup {
+			found[sig] = unsafe.Add(pc, off)
+			n++
+		}
+	}
+	for _, s := range specs {
+		for k, ti := range s.entries {
+			stub, ok := found[s.sigs[ti]]
+			if !ok {
+				panic("gcasm: jump-table signature missing")
+			}
+			s.tab[k] = uint64(uintptr(stub))
+		}
+	}
+}
+`

--- a/internal/gcasm/jumppad.go
+++ b/internal/gcasm/jumppad.go
@@ -2,7 +2,6 @@ package gcasm
 
 import (
 	"fmt"
-	"hash/fnv"
 	"strings"
 )
 
@@ -80,9 +79,13 @@ func (jt *JTTable) fn(sym string) *JTFn {
 // jtSig derives the deterministic signature for one dispatch target.
 // bits selects the architecture's signature width.
 func jtSig(fnSym string, siteOff, target, bits int) uint64 {
-	h := fnv.New64a()
-	_, _ = fmt.Fprintf(h, "%s+%d>%d", fnSym, siteOff, target)
-	s := h.Sum64() & (1<<bits - 1)
+	key := fmt.Sprintf("%s+%d>%d", fnSym, siteOff, target)
+	h := uint64(14695981039346656037) // FNV-1a 64
+	for i := 0; i < len(key); i++ {
+		h ^= uint64(key[i])
+		h *= 1099511628211
+	}
+	s := h & (1<<bits - 1)
 	// All-zero / all-one signatures resemble alignment padding; nudge.
 	if s == 0 || s == 1<<bits-1 {
 		s = 0x5A5A5A5A & (1<<bits - 1)

--- a/internal/gcasm/jumppad.go
+++ b/internal/gcasm/jumppad.go
@@ -18,9 +18,10 @@ import (
 //
 //     amd64:  LEAQ ·tab(SB), base           (RIP-relative, PIE-safe)
 //             JMP  (base)(idx*8)
-//     arm64:  MOVD $·tab(SB), R16
-//             MOVD (R16)(idx<<3), R17
-//             JMP  (R17)
+//     arm64:  MOVD  $·tab(SB), base
+//             MOVWU idx, t                  (uxtw — see a64EmitJumpPad)
+//             MOVD  (base)(t<<3), t
+//             JMP   (t)
 //
 //     Exactly the registers gc's own dispatch clobbered, and — like
 //     gc's dispatch — NO flag-register writes: the pre-dispatch flag
@@ -45,8 +46,9 @@ import (
 //
 //	amd64: two long NOPs `0F 1F 80 <sig32>` + `0F 1F 80 <^sig32>`
 //	       (14 bytes; the complement pair rules out accidental matches)
-//	arm64: MOVZ/MOVK/MOVK into R17 (a dispatch scratch) carrying a
-//	       48-bit signature across three fixed-form instructions.
+//	arm64: MOVZ/MOVK/MOVK into the dispatch's dead target register,
+//	       carrying a 48-bit signature across three fixed-form
+//	       instructions (the scanner ignores the Rd bits).
 
 // JTTable accumulates jump-table dispatch sites for one output .s
 // file, like ConstPool/TypeTable. The caller appends EmitAsm() to the
@@ -153,23 +155,45 @@ func a64EmitJumpPad(b *strings.Builder, jt *JTTable, symName string, site *jtSit
 	tab := fmt.Sprintf("%s_jt%d", symName, siteOff)
 	entries, targets := jtExpandEntries(site)
 
-	fmt.Fprintf(b, "\tMOVD $·%s(SB), R16\n", tab)
-	fmt.Fprintf(b, "\tMOVD (R16)(%s<<3), R17\n", site.idxReg)
-	fmt.Fprintf(b, "\tJMP (R17)\n")
+	// Register discipline: gc's arm64 allocator may keep LIVE values in
+	// any register (R16/R17 included), so the pad clobbers exactly what
+	// the ORIGINAL dispatch clobbered — the captured table-base and
+	// jump-target registers — and nothing else.
+	//
+	// The captured `(Rb)(Ri<<3)` text is also LOSSY: gc's original
+	// load is `ldr xt,[xb,w_i,uxtw #3]` — a 32-BIT index,
+	// zero-extended — but Plan9 `<<3` re-assembles as the 64-bit
+	// X-form, so garbage in the selector's high bits (legal under gc's
+	// original!) would poison the address. Re-establish uxtw
+	// explicitly: br_table selectors are wasm i32, so MOVWU is exact.
+	fmt.Fprintf(b, "\tMOVD $·%s(SB), %s\n", tab, site.baseReg)
+	fmt.Fprintf(b, "\tMOVWU %s, %s\n", site.idxReg, site.tReg)
+	fmt.Fprintf(b, "\tMOVD (%s)(%s<<3), %s\n", site.baseReg, site.tReg, site.tReg)
+	fmt.Fprintf(b, "\tJMP (%s)\n", site.tReg)
 
 	sigs := make([]uint64, len(targets))
 	for i, t := range targets {
 		sig := jtSig(symName, siteOff, t, 48)
 		sigs[i] = sig
-		// MOVZ x17,#lo / MOVK x17,#mid,lsl16 / MOVK x17,#hi,lsl32 —
-		// three fixed-form writes to the R17 scratch the dispatch
-		// already clobbers, carrying the 48-bit signature.
-		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xD2800011|uint32(sig&0xFFFF)<<5)
-		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xF2A00011|uint32(sig>>16&0xFFFF)<<5)
-		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xF2C00011|uint32(sig>>32&0xFFFF)<<5)
+		// MOVZ/MOVK/MOVK into the captured target register (already
+		// clobbered by the dispatch that landed here), carrying the
+		// 48-bit signature. The scanner masks the Rd bits out.
+		rd := a64RegNum(site.tReg)
+		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xD2800000|uint32(sig&0xFFFF)<<5|rd)
+		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xF2A00000|uint32(sig>>16&0xFFFF)<<5|rd)
+		fmt.Fprintf(b, "\tWORD $0x%08X\n", 0xF2C00000|uint32(sig>>32&0xFFFF)<<5|rd)
 		fmt.Fprintf(b, "\tJMP pc%d\n", t)
 	}
 	fn.Sites = append(fn.Sites, JTSite{TabVar: tab, Entries: entries, Sigs: sigs})
+}
+
+// a64RegNum parses "R17" → 17 for instruction encoding.
+func a64RegNum(reg string) uint32 {
+	n := 0
+	for i := 1; i < len(reg); i++ {
+		n = n*10 + int(reg[i]-'0')
+	}
+	return uint32(n & 31)
 }
 
 // EmitAsm renders the per-function address helpers (`<Sym>_jtpc`) the
@@ -231,6 +255,12 @@ func gcasmJTInit(pc unsafe.Pointer, specs []gcasmJTSpec) {
 	for _, s := range specs {
 		need += len(s.sigs)
 	}
+	expected := make(map[uint64]bool, need)
+	for _, s := range specs {
+		for _, sig := range s.sigs {
+			expected[sig] = true
+		}
+	}
 	found := make(map[uint64]unsafe.Pointer, need)
 	const maxScan = 1 << 26
 	for off, n := 0, 0; n < need; off++ {
@@ -243,7 +273,7 @@ func gcasmJTInit(pc unsafe.Pointer, specs []gcasmJTSpec) {
 		}
 		sig := uint32(p[3]) | uint32(p[4])<<8 | uint32(p[5])<<16 | uint32(p[6])<<24
 		inv := uint32(p[10]) | uint32(p[11])<<8 | uint32(p[12])<<16 | uint32(p[13])<<24
-		if inv != ^sig {
+		if inv != ^sig || !expected[uint64(sig)] {
 			continue
 		}
 		if _, dup := found[uint64(sig)]; !dup {
@@ -275,6 +305,12 @@ func gcasmJTInit(pc unsafe.Pointer, specs []gcasmJTSpec) {
 	for _, s := range specs {
 		need += len(s.sigs)
 	}
+	expected := make(map[uint64]bool, need)
+	for _, s := range specs {
+		for _, sig := range s.sigs {
+			expected[sig] = true
+		}
+	}
 	found := make(map[uint64]unsafe.Pointer, need)
 	const maxScan = 1 << 26
 	for off, n := 0, 0; n < need; off += 4 {
@@ -282,10 +318,13 @@ func gcasmJTInit(pc unsafe.Pointer, specs []gcasmJTSpec) {
 			panic("gcasm: jump-table signature scan overflow")
 		}
 		w := (*[3]uint32)(unsafe.Add(pc, off))
-		if w[0]&0xFFE0001F != 0xD2800011 || w[1]&0xFFE0001F != 0xF2A00011 || w[2]&0xFFE0001F != 0xF2C00011 {
+		if w[0]&0xFFE00000 != 0xD2800000 || w[1]&0xFFE00000 != 0xF2A00000 || w[2]&0xFFE00000 != 0xF2C00000 {
 			continue
 		}
 		sig := uint64(w[0]>>5&0xFFFF) | uint64(w[1]>>5&0xFFFF)<<16 | uint64(w[2]>>5&0xFFFF)<<32
+		if !expected[sig] {
+			continue
+		}
 		if _, dup := found[sig]; !dup {
 			found[sig] = unsafe.Add(pc, off)
 			n++

--- a/internal/gcasm/jumptable_flags_test.go
+++ b/internal/gcasm/jumptable_flags_test.go
@@ -71,6 +71,7 @@ func TestJumpTableFlagReplayRun(t *testing.T) {
 	for _, d := range datas {
 		dm[d.Name] = d
 	}
+	jt := &JTTable{}
 	body, err := Transform(disp, TransformOptions{
 		SymName:   "fdispatchAsm",
 		CalleeSig: func(string) ([]ArgKind, bool, ArgKind, string, bool) { return nil, false, 0, "", false },
@@ -79,6 +80,7 @@ func TestJumpTableFlagReplayRun(t *testing.T) {
 		Result:    ArgI32,
 		ArgNames:  []string{"sel", "v0"},
 		Datas:     dm,
+		JT:        jt,
 	})
 	if err != nil {
 		// If gc chose NOT to emit a jump table (compiler-version
@@ -89,15 +91,16 @@ func TestJumpTableFlagReplayRun(t *testing.T) {
 		}
 		t.Fatal(err)
 	}
-	if !strings.Contains(body, "jt") || strings.Contains(body, ".jump") {
+	if !strings.Contains(body, "_jt") || strings.Contains(body, ".jump") {
 		t.Skipf("gc did not emit a jump table for FDispatch on this toolchain")
 	}
+	body += jt.EmitAsm("amd64")
 
 	run := t.TempDir()
 	files := map[string]string{
 		"go.mod": "module fjtrun\n\ngo 1.25.0\n",
-		"decl.go": "package fjtrun\n\nfunc fdispatchAsm(sel int32, v0 int32) (r0 int32)\n\n//go:noinline\n" +
-			flagDispatchSrc("fdispatchRef"),
+		"decl.go": "package fjtrun\n\nimport \"unsafe\"\n\nvar _ unsafe.Pointer\n\nfunc fdispatchAsm(sel int32, v0 int32) (r0 int32)\n\n//go:noinline\n" +
+			flagDispatchSrc("fdispatchRef") + "\n" + jt.EmitGo("amd64"),
 		"body_amd64.s": "#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + body,
 		"run_test.go": `package fjtrun
 

--- a/internal/gcasm/jumptable_test.go
+++ b/internal/gcasm/jumptable_test.go
@@ -49,7 +49,7 @@ func TestJumpTableTransformRun(t *testing.T) {
 		}
 	}
 
-	transformOnce := func() string {
+	transformOnce := func() (string, string) {
 		fns, datas, err := Capture(dir, "jtgate/lib")
 		if err != nil {
 			t.Fatal(err)
@@ -67,6 +67,7 @@ func TestJumpTableTransformRun(t *testing.T) {
 		for _, d := range datas {
 			dm[d.Name] = d
 		}
+		jt := &JTTable{}
 		body, err := Transform(disp, TransformOptions{
 			SymName:   "dispatchAsm",
 			CalleeSig: func(string) ([]ArgKind, bool, ArgKind, string, bool) { return nil, false, 0, "", false },
@@ -75,25 +76,26 @@ func TestJumpTableTransformRun(t *testing.T) {
 			Result:    ArgI32,
 			ArgNames:  []string{"sel", "v0"},
 			Datas:     dm,
+			JT:        jt,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		return body
+		return body + jt.EmitAsm("amd64"), jt.EmitGo("amd64")
 	}
-	body := transformOnce()
-	if body2 := transformOnce(); body2 != body {
+	body, jtGo := transformOnce()
+	if body2, jtGo2 := transformOnce(); body2 != body || jtGo2 != jtGo {
 		t.Fatalf("transform not deterministic:\n--- run1\n%s\n--- run2\n%s", body, body2)
 	}
-	if !strings.Contains(body, "jt") || strings.Contains(body, ".jump") {
-		t.Fatalf("jump table not rewritten to a tree:\n%s", body)
+	if !strings.Contains(body, "_jt") || strings.Contains(body, ".jump") {
+		t.Fatalf("jump table not rewritten to an O(1) pad:\n%s", body)
 	}
 
 	run := t.TempDir()
 	files := map[string]string{
 		"go.mod": "module jtrun\n\ngo 1.25.0\n",
-		"decl.go": "package jtrun\n\nfunc dispatchAsm(sel int32, v0 int32) (r0 int32)\n\n//go:noinline\n" +
-			dispatchSrc("dispatchRef"),
+		"decl.go": "package jtrun\n\nimport \"unsafe\"\n\nvar _ unsafe.Pointer\n\nfunc dispatchAsm(sel int32, v0 int32) (r0 int32)\n\n//go:noinline\n" +
+			dispatchSrc("dispatchRef") + "\n" + jtGo,
 		"body_amd64.s": "#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + body,
 		"run_test.go": `package jtrun
 

--- a/internal/gcasm/transform.go
+++ b/internal/gcasm/transform.go
@@ -47,6 +47,12 @@ type TransformOptions struct {
 	// the type's descriptor pointer (extracted from an eface). nil ⇒
 	// type references are a transform error.
 	Types *TypeTable
+	// JT, when non-nil, selects the O(1) jump-pad dispatch for gc jump
+	// tables (see jumppad.go) and accumulates the table metadata the
+	// caller must render: EmitAsm() into the same .s file and EmitGo()
+	// into the same package's arch-tagged Go file (the generated init
+	// fills the tables). nil ⇒ the legacy O(log n) compare tree.
+	JT *JTTable
 }
 
 // TypeTable accumulates runtime-type references for one output file.
@@ -222,9 +228,16 @@ type jtSite struct {
 	idx    int
 	jmpIdx int
 	idxReg string
+	// baseReg is the captured table-base register (the LEAQ/MOVD
+	// destination) — dead after the dispatch, so the O(1) jump pad may
+	// clobber it (amd64 only; arm64 uses the R16/R17 scratch pair).
+	baseReg string
+	// entryCount is the table's total selector count (len(Relocs)).
+	entryCount int
 	// replay is the captured flag-setting instruction to re-execute
-	// on every tree leaf, when some dispatch target consumes EFLAGS
-	// (see findJumpTables). Empty when no target reads flags.
+	// on every tree leaf / pad stub, when some dispatch target
+	// consumes EFLAGS (see findJumpTables). Empty when no target
+	// reads flags.
 	replay string
 	runs   []jtRun
 }
@@ -276,7 +289,12 @@ func readsFlags(txt string) bool {
 
 // findJumpTables detects gc jump-table dispatch pairs and resolves
 // their tables to run-compressed target lists.
-func findJumpTables(fnName string, insns []Insn, datas map[string]*DataSym) (map[int]*jtSite, error) {
+//
+// flagTransparent declares that the dispatch REWRITE preserves EFLAGS
+// (the O(1) jump pad — LEAQ + memory-operand JMP, like gc's original),
+// making the flag-liveness analysis moot: no replay is captured and no
+// site can fail as unreplayable. The compare tree passes false.
+func findJumpTables(fnName string, insns []Insn, datas map[string]*DataSym, flagTransparent bool) (map[int]*jtSite, error) {
 	sites := map[int]*jtSite{}
 	for i, in := range insns {
 		lm := jtLeaqRe.FindStringSubmatch(in.Text)
@@ -303,7 +321,7 @@ func findJumpTables(fnName string, insns []Insn, datas map[string]*DataSym) (map
 		if len(tab.Relocs) == 0 || len(tab.Relocs)*8 != tab.Size {
 			return nil, fmt.Errorf("jump table %s: %d relocs for size %d", lm[1], len(tab.Relocs), tab.Size)
 		}
-		site := &jtSite{idx: i, jmpIdx: j, idxReg: jm[2]}
+		site := &jtSite{idx: i, jmpIdx: j, idxReg: jm[2], baseReg: lm[2], entryCount: len(tab.Relocs)}
 		for k, r := range tab.Relocs {
 			if r.Off != k*8 {
 				return nil, fmt.Errorf("jump table %s: reloc %d at offset %d", lm[1], k, r.Off)
@@ -348,6 +366,10 @@ func findJumpTables(fnName string, insns []Insn, datas map[string]*DataSym) (map
 		// nearest pre-dispatch flag-writer is NOT cleanly replayable do we
 		// need to know whether any target actually consumes flags; there
 		// we keep the conservative scan and fall back to pure if it might.
+		if flagTransparent {
+			sites[i] = site
+			continue
+		}
 		replay, replayClean := "", false
 		for k := i - 1; k >= 0 && i-k <= 8; k-- {
 			t := insns[k].Text
@@ -559,7 +581,7 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 
 	// Jump-table dispatch sites: LEAQ+JMP pairs replaced by binary
 	// search trees over the table's captured target offsets.
-	jtSites, err := findJumpTables(fn.Name, insns, opts.Datas)
+	jtSites, err := findJumpTables(fn.Name, insns, opts.Datas, opts.JT != nil)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", fn.Name, err)
 	}
@@ -615,7 +637,11 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 		in := insns[idx]
 		emitPending(in.Off)
 		if site, ok := jtSites[idx]; ok {
-			emitJumpTree(&b, site, in.Off)
+			if opts.JT != nil {
+				emitJumpPad(&b, opts.JT, opts.SymName, site, in.Off)
+			} else {
+				emitJumpTree(&b, site, in.Off)
+			}
 			idx = site.jmpIdx // swallow padding NOPs + the indirect JMP
 			continue
 		}

--- a/internal/gcasm/transform.go
+++ b/internal/gcasm/transform.go
@@ -229,9 +229,11 @@ type jtSite struct {
 	jmpIdx int
 	idxReg string
 	// baseReg is the captured table-base register (the LEAQ/MOVD
-	// destination) — dead after the dispatch, so the O(1) jump pad may
-	// clobber it (amd64 only; arm64 uses the R16/R17 scratch pair).
+	// destination) and tReg (arm64) the captured jump-target register —
+	// both dead after the dispatch, so the O(1) jump pad clobbers
+	// exactly these and nothing else.
 	baseReg string
+	tReg    string
 	// entryCount is the table's total selector count (len(Relocs)).
 	entryCount int
 	// replay is the captured flag-setting instruction to re-execute

--- a/internal/gcasm/transform_a64gen.go
+++ b/internal/gcasm/transform_a64gen.go
@@ -114,7 +114,7 @@ func TransformARM64(fn *Fn, opts TransformOptions) (string, error) {
 		fmt.Fprintf(&b, "\t%s %s+%d(FP), %s\n", loadForARM64(a.Kind), opts.argName(i), a.StackOf, a.Reg)
 	}
 
-	jtSites, err := a64FindJumpTables(fn.Name, insns, opts.Datas)
+	jtSites, err := a64FindJumpTables(fn.Name, insns, opts.Datas, opts.JT != nil)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", fn.Name, err)
 	}
@@ -160,7 +160,11 @@ func TransformARM64(fn *Fn, opts TransformOptions) (string, error) {
 		in := insns[idx]
 		emitPending(in.Off)
 		if site, ok := jtSites[idx]; ok {
-			a64EmitJumpTree(&b, site, in.Off)
+			if opts.JT != nil {
+				a64EmitJumpPad(&b, opts.JT, opts.SymName, site, in.Off)
+			} else {
+				a64EmitJumpTree(&b, site, in.Off)
+			}
 			idx = site.jmpIdx
 			continue
 		}

--- a/internal/gcasm/transform_a64gen_strip.go
+++ b/internal/gcasm/transform_a64gen_strip.go
@@ -177,7 +177,7 @@ func a64FindJumpTables(fnName string, insns []Insn, datas map[string]*DataSym, f
 		if len(tab.Relocs) == 0 || len(tab.Relocs)*8 != tab.Size {
 			return nil, fmt.Errorf("jump table %s: %d relocs for size %d", lm[1], len(tab.Relocs), tab.Size)
 		}
-		site := &jtSite{idx: i, jmpIdx: k, idxReg: idxReg, baseReg: lm[2], entryCount: len(tab.Relocs)}
+		site := &jtSite{idx: i, jmpIdx: k, idxReg: idxReg, baseReg: lm[2], tReg: tReg, entryCount: len(tab.Relocs)}
 		for ri, r := range tab.Relocs {
 			if r.Off != ri*8 {
 				return nil, fmt.Errorf("jump table %s: reloc %d at offset %d", lm[1], ri, r.Off)

--- a/internal/gcasm/transform_a64gen_strip.go
+++ b/internal/gcasm/transform_a64gen_strip.go
@@ -136,7 +136,12 @@ func a64StripPrologueEpilogue(insns []Insn) ([]Insn, error) {
 // a64FindJumpTables detects gc arm64 jump-table dispatch triples
 // (`MOVD $tab(SB),Rb; MOVD (Rb)(Ri<<3),Rt; JMP (Rt)`) and resolves the
 // table's R_ADDR relocs to run-compressed target lists.
-func a64FindJumpTables(fnName string, insns []Insn, datas map[string]*DataSym) (map[int]*jtSite, error) {
+//
+// flagTransparent declares that the dispatch REWRITE preserves NZCV
+// (the O(1) jump pad — arm64 ADD writes no flags), making the whole
+// flag-liveness analysis moot: no replay is captured and no site can
+// fail as unreplayable. The compare tree passes false.
+func a64FindJumpTables(fnName string, insns []Insn, datas map[string]*DataSym, flagTransparent bool) (map[int]*jtSite, error) {
 	sites := map[int]*jtSite{}
 	for i, in := range insns {
 		lm := a64JtLeaqRe.FindStringSubmatch(in.Text)
@@ -172,7 +177,7 @@ func a64FindJumpTables(fnName string, insns []Insn, datas map[string]*DataSym) (
 		if len(tab.Relocs) == 0 || len(tab.Relocs)*8 != tab.Size {
 			return nil, fmt.Errorf("jump table %s: %d relocs for size %d", lm[1], len(tab.Relocs), tab.Size)
 		}
-		site := &jtSite{idx: i, jmpIdx: k, idxReg: idxReg}
+		site := &jtSite{idx: i, jmpIdx: k, idxReg: idxReg, baseReg: lm[2], entryCount: len(tab.Relocs)}
 		for ri, r := range tab.Relocs {
 			if r.Off != ri*8 {
 				return nil, fmt.Errorf("jump table %s: reloc %d at offset %d", lm[1], ri, r.Off)
@@ -207,6 +212,10 @@ func a64FindJumpTables(fnName string, insns []Insn, datas map[string]*DataSym) (
 		// operands exclude the table-base and target registers, which
 		// the captured dispatch clobbers between the compare and the
 		// leaf (the tree itself only READS the selector register).
+		if flagTransparent {
+			sites[i] = site
+			continue
+		}
 		replay, replayClean := "", false
 		for k2 := i - 1; k2 >= 0 && i-k2 <= 8; k2-- {
 			t := insns[k2].Text


### PR DESCRIPTION
## Summary

Supersedes #34. The pure-fallback approach measured a cold-build regression of up to **+49%** on consumers (spidermonkey bundle 23.7s → 35.3s) because it hands exactly the largest functions back to gc — defeating gcasm's purpose (keeping giant generated functions out of the Go compiler). This PR instead implements a **real O(1) jump table inside gcasm**, replacing the O(log n) compare tree.

## Design

Plan9 asm cannot put address-of-label into DATA, so the table cannot be reproduced literally. Instead:

- **Dispatch keeps gc's original shape**, retargeted at a Go-declared table var:
  - amd64: `LEAQ ·fnN_jtOFF(SB), base` + `JMP (base)(idx*8)`
  - arm64: `MOVD $·tab(SB), base; MOVWU idx, t; MOVD (base)(t<<3), t; JMP (t)` — the explicit `MOVWU` re-establishes the `uxtw` semantics of gc's original `ldr xt,[xb,w_i,uxtw #3]`, which the captured Plan9 text loses.
  - Clobbers exactly the registers gc's own dispatch clobbered (captured per site — arm64's R16/R17 are gc-allocatable, so nothing is hardcoded), and — like gc's dispatch — **writes no flags**, so the compare tree's entire flag-replay machinery (and its unreplayable-flags pure-fallback class) does not apply.
- **Per-target stubs** right after the dispatch: an executable no-op signature + `JMP pcN`. Table entries are the stubs' absolute addresses.
- **Filled at init, never baked**: the consumer's assembler picks final encodings, so a generated package `init()` scans the function's code bytes for the signatures (amd64: `0F 1F 80 sig32` + complement twin; arm64: MOVZ/MOVK/MOVK triple, matched against the expected-signature set to reject real-code constant materializations) and writes the entries. PIE-safe, toolchain-version-safe; a missing signature **panics at init** instead of ever wild-jumping (this fail-fast caught both arm64 bugs during bring-up).

Plumbing follows the ConstPool/TypeTable pattern (`TransformOptions.JT`); `JT=nil` keeps the legacy tree.

## Measurements (arm64 native, interleaved pairs, idle, wasm sha-pinned)

| | base (tree) | #34 fallback | this PR (O(1) pad) |
|---|---:|---:|---:|
| spidermonkey cpubench | 60.29 ms | (−10.8% same-day pairs) | **55.56 ms (−7.9%, 5/5 pairs disjoint)** |
| spidermonkey cold build | 23.7s | 35.3s (+49%) | **25.2s (+6%)** |
| googlesql cold build | 45.3s | 51.8s (+14%) | **45.2s (±0)** |
| python cold build | 15.2s | 16.1s | **15.0s (±0)** |
| go-python fib/loop | — | (−21.6% — a pure-beats-gcasm effect, not a jump-table effect) | neutral (3 pairs, within noise) |
| googlesqlite window suite | — | — | all 5 queries within noise |

The dispatch win lands where dispatch is hot (SpiderMonkey PBL); CPython's gcasm gap is call-marshalling, not dispatch, so it is correctly neutral there.

## Verification (exit 0 observed for every line)

- wasm2go: `go test ./...`, `make lint` (0 issues), `make test-cover` **85.3%** in a clean worktree.
- Runtime gates now execute the pad end to end: 64-case amd64 dispatch gate, flag-consuming replay gates on both arches (arm64 natively — its fixture previously could not transform at all on this toolchain), cg_bigdispatch / cg_brtable64 / cg_dispatchif fixture gates.
- go-spidermonkey: amd64±race + arm64±race vs the regenerated wasmify bundle.
- go-python: 4-config matrix (amd64±race, arm64±race).
- googlesqlite: `-race -timeout 30m` amd64 AND arm64 — 35 packages ok / 0 FAIL.
- go-googlesql smoke `-count=1`: ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
