### PR TITLE
codegen: pass the resolved host to the WASI dial hook

### DIFF
--- a/internal/codegen/wasip1_native.go
+++ b/internal/codegen/wasip1_native.go
@@ -613,15 +613,22 @@ type WasiStubs struct {
 	// host-controlled-whitelist intent as fsHook, for the network surface.
 	netHook func(op string) bool
 	// dialHook, when non-nil, is consulted before an OUTBOUND connect
-	// (Sock_connect) with the resolved network ("tcp"), dotted-quad IP, and
-	// port. Returning false denies the connection (EACCES). This is the
-	// outbound-network whitelist control point.
-	dialHook func(network, ip string, port int) bool
+	// (Sock_connect) with the resolved network ("tcp"), the HOST the guest
+	// resolved to reach this address (from the preceding Sock_getaddrinfo, or ""
+	// if the guest dialed a literal IP), the dotted-quad IP, and the port.
+	// Returning false denies the connection (EACCES). Passing the host lets the
+	// policy match host+port jointly, which a port-scoped rule needs — the IP
+	// alone cannot be tied back to the rule that authorized the name.
+	dialHook func(network, host, ip string, port int) bool
 	// resolveHook, when non-nil, is consulted before a name lookup
 	// (Sock_getaddrinfo) with the requested host. Returning false denies the
 	// resolution (the guest sees a gaierror). This is the hostname-level
 	// whitelist control point (e.g. block "example.com" by name).
 	resolveHook func(host string) bool
+	// resolvedHosts maps a resolved dotted-quad IP back to the host name the
+	// guest looked it up under (populated by Sock_getaddrinfo, read by
+	// Sock_connect), so the dial hook can be given the host. Guarded by mu.
+	resolvedHosts map[string]string
 	// fsys is the filesystem backend every guest path operation is routed
 	// through. Defaults to an osFS scoped to preopenDir (the host filesystem);
 	// SetFS swaps in an alternative (e.g. an in-memory FS) so each module can
@@ -729,10 +736,12 @@ func (w *WasiStubs) SetNetAccessHook(hook func(op string) bool) {
 }
 
 // SetDialHook installs a host-controlled OUTBOUND-connection policy. hook is
-// called with ("tcp", dotted-quad-IP, port) before each Sock_connect;
-// returning false denies the connection (the guest sees a connect EACCES).
-// Pass nil to clear (all outbound allowed, the default once outbound is wired).
-func (w *WasiStubs) SetDialHook(hook func(network, ip string, port int) bool) {
+// called with ("tcp", host, dotted-quad-IP, port) before each Sock_connect,
+// where host is the name the guest resolved to reach the IP (from the preceding
+// Sock_getaddrinfo) or "" for a literal-IP dial; returning false denies the
+// connection (the guest sees a connect EACCES). Pass nil to clear (all outbound
+// allowed, the default once outbound is wired).
+func (w *WasiStubs) SetDialHook(hook func(network, host, ip string, port int) bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.dialHook = hook
@@ -1051,6 +1060,7 @@ func (w *WasiStubs) Sock_getaddrinfo(m *Module, nodePtr, nodeLen, outPtr int32) 
 	if ip := net.ParseIP(host); ip != nil {
 		if v4 := ip.To4(); v4 != nil {
 			out[0], out[1], out[2], out[3] = v4[0], v4[1], v4[2], v4[3]
+			w.recordResolvedHost(v4, host)
 			return _wasiESUCCESS
 		}
 		return -_wasiEAFNOSUPPORT // IPv6 not supported by this bridge
@@ -1064,7 +1074,20 @@ func (w *WasiStubs) Sock_getaddrinfo(m *Module, nodePtr, nodeLen, outPtr int32) 
 		return -_wasiEAFNOSUPPORT
 	}
 	out[0], out[1], out[2], out[3] = v4[0], v4[1], v4[2], v4[3]
+	w.recordResolvedHost(v4, host)
 	return _wasiESUCCESS
+}
+
+// recordResolvedHost remembers that host resolved to v4, so a later Sock_connect
+// to that IP can hand the dial hook the host name it was looked up under.
+func (w *WasiStubs) recordResolvedHost(v4 net.IP, host string) {
+	ip := fmt.Sprintf("%d.%d.%d.%d", v4[0], v4[1], v4[2], v4[3])
+	w.mu.Lock()
+	if w.resolvedHosts == nil {
+		w.resolvedHosts = make(map[string]string)
+	}
+	w.resolvedHosts[ip] = host
+	w.mu.Unlock()
 }
 
 // SetEnv overrides the environment the guest sees via environ_get /
@@ -2606,9 +2629,12 @@ func (w *WasiStubs) Sock_socket(m *Module, domain, typ int32) int32 {
 // existing Sock_send / Sock_recv / Fd_close paths drive it. Returns 0 or a
 // negative errno.
 func (w *WasiStubs) Sock_connect(m *Module, fd, ipBE, port int32) int32 {
+	u := uint32(ipBE)
+	ip := fmt.Sprintf("%d.%d.%d.%d", u&0xff, (u>>8)&0xff, (u>>16)&0xff, (u>>24)&0xff)
 	w.mu.Lock()
 	op := w.fdTable[fd]
 	hook := w.dialHook
+	host := w.resolvedHosts[ip] // "" for a literal-IP dial with no preceding lookup
 	w.mu.Unlock()
 	if op == nil || !op.isSocket {
 		return -_wasiENOTSOCK
@@ -2616,10 +2642,8 @@ func (w *WasiStubs) Sock_connect(m *Module, fd, ipBE, port int32) int32 {
 	if op.conn != nil {
 		return -_wasiEISCONN
 	}
-	u := uint32(ipBE)
-	ip := fmt.Sprintf("%d.%d.%d.%d", u&0xff, (u>>8)&0xff, (u>>16)&0xff, (u>>24)&0xff)
 	p := int(uint16(port))
-	if hook != nil && !hook("tcp", ip, p) {
+	if hook != nil && !hook("tcp", host, ip, p) {
 		return -_wasiEACCES
 	}
 	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, strconv.Itoa(p)), 30*time.Second)

--- a/internal/codegen/wasip1_native_test.go
+++ b/internal/codegen/wasip1_native_test.go
@@ -245,21 +245,27 @@ func TestWasi_SockSocketConnect(t *testing.T) {
 		t.Fatalf("Sock_socket returned bad fd %d", fd)
 	}
 
+	// Resolve the loopback host first so Sock_connect can hand the dial hook the
+	// host name that was looked up for this IP (host+port matched jointly).
+	hoff, hln := putPath(m, 512, "127.0.0.1")
+	if rc := w.Sock_getaddrinfo(m, hoff, hln, 600); rc != _wasiESUCCESS {
+		t.Fatalf("getaddrinfo for dial-hook host: rc=%d", rc)
+	}
 	// Whitelist denies first.
 	var dialed []string
-	w.SetDialHook(func(network, ip string, p int) bool {
-		dialed = append(dialed, fmt.Sprintf("%s/%s:%d", network, ip, p))
+	w.SetDialHook(func(network, host, ip string, p int) bool {
+		dialed = append(dialed, fmt.Sprintf("%s/%s/%s:%d", network, host, ip, p))
 		return false
 	})
 	if rc := w.Sock_connect(m, fd, loopbackBE, int32(port)); rc != -_wasiEACCES {
 		t.Fatalf("denied connect: want -EACCES, got %d", rc)
 	}
-	if len(dialed) != 1 || dialed[0] != fmt.Sprintf("tcp/127.0.0.1:%d", port) {
-		t.Fatalf("dial hook saw %v, want tcp/127.0.0.1:%d", dialed, port)
+	if len(dialed) != 1 || dialed[0] != fmt.Sprintf("tcp/127.0.0.1/127.0.0.1:%d", port) {
+		t.Fatalf("dial hook saw %v, want tcp/127.0.0.1/127.0.0.1:%d", dialed, port)
 	}
 
 	// Allow → connect succeeds and attaches the conn.
-	w.SetDialHook(func(network, ip string, p int) bool { return true })
+	w.SetDialHook(func(network, host, ip string, p int) bool { return true })
 	if rc := w.Sock_connect(m, fd, loopbackBE, int32(port)); rc != _wasiESUCCESS {
 		t.Fatalf("allowed connect: want SUCCESS, got %d", rc)
 	}


### PR DESCRIPTION
## Summary

The generated `wasi_snapshot_preview1` stubs gate outbound sockets with a dial hook, but it was called with only the resolved IP and port. An embedder whose network policy is **host-scoped** (e.g. "host X only on port 443") cannot enforce that from the IP alone — the IP cannot be tied back to the name the guest resolved, so the port ends up checked against a host-agnostic union of rules.

`Sock_getaddrinfo` already resolves the name, so this records `IP -> host` there and hands the host to the dial hook at `Sock_connect`.

## Change

- `WasiStubs.dialHook` / `SetDialHook`: signature gains a `host` parameter — `func(network, host, ip string, port int) bool`.
- `Sock_getaddrinfo`: records the resolved `IP -> host` (both the numeric fast path and the resolver path).
- `Sock_connect`: looks the host up for the dialed IP and passes it to the hook (`""` for a literal-IP dial with no preceding lookup).

This lets a host policy match **host+port jointly**, matching what an HTTP-layer policy can already do. `wasip1_native.go` is both compiled and `//go:embed`-ed into the emitted `base/base.go`, so consumers pick up the fix by regenerating.

## Test

`TestWasi_SockSocketConnect` now resolves a host via `Sock_getaddrinfo` first and asserts the dial hook receives that host alongside the IP/port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
