### PR TITLE
Support C++-shaped exception handling: multi-clause catch, delegate targets, rethrow depths

### DIFF
--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -29,6 +29,20 @@ type ssaEmitter struct {
 	// region so OpCatchArg can read its operand slots. Empty outside a
 	// handler.
 	catchExcVar string
+
+	// excVarOfRegion maps a try region to the Go variable holding its caught
+	// *wasmExc. Handlers nest, so a `rethrow l` can name an OUTER region's
+	// exception while an inner handler's catchExcVar is current; throwStmt
+	// resolves Block.RethrowRegion through this map. Both emit paths register
+	// their per-region variables here (structured: __exc<entryID>; trampoline:
+	// __excR<entryID>). Reset per function.
+	excVarOfRegion map[*ssa.TryRegion]string
+
+	// excVarOfHandlerBlock maps a handler landing-pad block to the exception
+	// variable its OpCatchArg values read. Set alongside excVarOfRegion; used
+	// by the trampoline path, whose handler blocks are emitted flat (outside
+	// any per-region lexical context). Reset per function.
+	excVarOfHandlerBlock map[ssa.BlockID]string
 }
 
 // newSSAEmitter constructs an emitter bound to a translator. nil t
@@ -334,24 +348,31 @@ type emitCtx struct {
 
 // trampCtx is the recover-trampoline protocol (see emitTrampoline): a BlockRet
 // records the function return in flags and exits the closure with `return nil`;
-// entering a try body sets its __inTryN flag; an edge to a try's Post clears it.
+// entering a try body sets its __inTryN flag; any edge LEAVING a try's body
+// clears it. Exit edges — not just edges to the try's Post — matter: a br out
+// of a protected body (a break crossing the try, which is exactly what routes
+// a function to the trampoline) must drop the flag, or a later unrelated
+// throw would misroute into this try's handler.
 type trampCtx struct {
-	retVar    string
-	rvVars    []string
-	entrySet  map[ssa.BlockID]string // try-entry block → __inTryN var to set true
-	postClear map[ssa.BlockID]string // try Post block → __inTryN var to clear on entry
+	retVar   string
+	rvVars   []string
+	entrySet map[ssa.BlockID]string // try-entry block → __inTryN var to set true
+	// edgeClears returns the __inTryN vars to clear on the pred→succ edge
+	// (the trys whose body contains pred but not succ). Nil outside
+	// emitTrampoline.
+	edgeClears func(pred, succ ssa.BlockID) []string
 }
 
-// edge emits the pred→succ transition: phi edge-copies, an optional __inTryN
-// clear when succ is a try Post (trampoline), then the goto.
+// edge emits the pred→succ transition: phi edge-copies, the __inTryN clears
+// for every try body this edge leaves (trampoline), then the goto.
 func (ec *emitCtx) edge(pred, succ *ssa.Block, predIdx int) ([]ast.Stmt, error) {
 	tmp := &ast.BlockStmt{}
 	if err := emitPhiAssignsFor(tmp, pred, succ, predIdx, ec.emitExpr, ec.stagedPhi); err != nil {
 		return nil, err
 	}
 	out := tmp.List
-	if ec.tramp != nil {
-		if v := ec.tramp.postClear[succ.ID]; v != "" {
+	if ec.tramp != nil && ec.tramp.edgeClears != nil {
+		for _, v := range ec.tramp.edgeClears(pred.ID, succ.ID) {
 			out = append(out, assignBool(v, false))
 		}
 	}
@@ -549,48 +570,85 @@ func (em *ssaEmitter) emitBlockInto(blk *ssa.Block, out *[]ast.Stmt, ec *emitCtx
 // __inTryN tracks — dynamically, as control flows — whether execution is inside
 // try N's body, so a caught panic routes to the right handler even when a loop
 // re-enters "body" blocks after the try has exited (the block runs with
-// __inTryN=false then). Only non-nested handler trys are supported; anything
-// else returns an error (the function then cannot be emitted, as before).
+// __inTryN=false then). Every region gets a flag, including delegate regions:
+// a delegate's dispatch arm clears the flags of every try nested between it
+// and its resolved target, so the fall-through skips their handlers — the
+// wasm `delegate l` semantics. Each region also keeps its caught exception in
+// its own __excR<N> variable, so nested handlers and outer-targeting rethrows
+// see the right exception.
 func (em *ssaEmitter) emitTrampoline(f *ssa.Func, body *ast.BlockStmt, flatEc *emitCtx, gotoTargets map[ssa.BlockID]bool) (*ast.BlockStmt, error) {
 	byID := map[ssa.BlockID]*ssa.Block{}
 	for _, b := range f.Blocks {
 		byID[b.ID] = b
 	}
 	type htPlan struct {
-		tr      *ssa.TryRegion
-		inTry   string
-		handler *ssa.Block // first (only supported) handler landing pad
+		tr     *ssa.TryRegion
+		inTry  string
+		excVar string // per-region caught-exception variable ("" for delegates)
 	}
 	var plans []*htPlan
 	bodySets := map[*ssa.TryRegion]map[ssa.BlockID]bool{}
 	for _, tr := range f.TryRegions {
-		if len(tr.Handlers) == 0 {
-			continue // delegate — throws propagate to the enclosing recover
-		}
-		if tr.Entry == nil || tr.Post == nil || tr.Handlers[0].Block == nil {
+		if tr.Entry == nil || tr.Post == nil {
 			return nil, fmt.Errorf("ssa emit: malformed try region")
 		}
-		// The single-handler restriction keeps the catch dispatch a plain
-		// tag check; multi-tag catch cascades are not needed by clang SjLj.
-		if len(tr.Handlers) != 1 || tr.Handlers[0].CatchAll {
-			return nil, fmt.Errorf("ssa emit: trampoline supports a single non-catch_all handler")
-		}
-		stop := map[ssa.BlockID]bool{tr.Post.ID: true, tr.Handlers[0].Block.ID: true}
-		bodySet := map[ssa.BlockID]bool{}
-		work := []*ssa.Block{tr.Entry}
-		for len(work) > 0 {
-			b := work[len(work)-1]
-			work = work[:len(work)-1]
-			if b == nil || bodySet[b.ID] || stop[b.ID] {
-				continue
+		for _, h := range tr.Handlers {
+			if h.Block == nil {
+				return nil, fmt.Errorf("ssa emit: malformed try region")
 			}
-			bodySet[b.ID] = true
-			for _, e := range b.Succs {
-				work = append(work, e.Block)
+		}
+		// Protected-body membership comes from the lowering's structural
+		// record, NOT a CFG walk: a br that exits the try early makes its
+		// (unprotected) continuation reachable from inside the body.
+		bodySet := map[ssa.BlockID]bool{}
+		if tr.Body != nil {
+			for _, b := range tr.Body {
+				bodySet[b.ID] = true
+			}
+		} else {
+			// Hand-built SSA (unit tests) has no structural record; fall
+			// back to reachability, stopping at Post and the landing pads.
+			stop := map[ssa.BlockID]bool{tr.Post.ID: true}
+			for _, h := range tr.Handlers {
+				stop[h.Block.ID] = true
+			}
+			work := []*ssa.Block{tr.Entry}
+			for len(work) > 0 {
+				b := work[len(work)-1]
+				work = work[:len(work)-1]
+				if b == nil || bodySet[b.ID] || stop[b.ID] {
+					continue
+				}
+				bodySet[b.ID] = true
+				for _, e := range b.Succs {
+					work = append(work, e.Block)
+				}
 			}
 		}
 		bodySets[tr] = bodySet
-		plans = append(plans, &htPlan{tr: tr, inTry: fmt.Sprintf("__inTry%d", tr.Entry.ID), handler: tr.Handlers[0].Block})
+		p := &htPlan{tr: tr, inTry: fmt.Sprintf("__inTry%d", tr.Entry.ID)}
+		if len(tr.Handlers) > 0 {
+			p.excVar = fmt.Sprintf("__excR%d", tr.Entry.ID)
+		}
+		plans = append(plans, p)
+	}
+	// Register the per-region exception variables so OpCatchArg (in flat-
+	// emitted landing pads) and rethrow (possibly targeting an outer region)
+	// resolve to the right one.
+	if em.excVarOfRegion == nil {
+		em.excVarOfRegion = map[*ssa.TryRegion]string{}
+	}
+	if em.excVarOfHandlerBlock == nil {
+		em.excVarOfHandlerBlock = map[ssa.BlockID]string{}
+	}
+	for _, p := range plans {
+		if p.excVar == "" {
+			continue
+		}
+		em.excVarOfRegion[p.tr] = p.excVar
+		for _, h := range p.tr.Handlers {
+			em.excVarOfHandlerBlock[h.Block.ID] = p.excVar
+		}
 	}
 	// Nested handler trys are supported: each has its own __inTry flag, and a
 	// caught panic routes to the INNERMOST active try. Order the catch dispatch
@@ -615,11 +673,22 @@ func (em *ssaEmitter) emitTrampoline(f *ssa.Func, body *ast.BlockStmt, flatEc *e
 	}
 	labels[f.Entry.ID] = true
 	entrySet := map[ssa.BlockID]string{}
-	postClear := map[ssa.BlockID]string{}
 	for _, p := range plans {
-		labels[p.handler.ID] = true
+		for _, h := range p.tr.Handlers {
+			labels[h.Block.ID] = true
+		}
 		entrySet[p.tr.Entry.ID] = p.inTry
-		postClear[p.tr.Post.ID] = p.inTry
+	}
+	// A try's flag drops on every edge that leaves its protected body — the
+	// fall-through to Post, but also any br out of the region.
+	edgeClears := func(pred, succ ssa.BlockID) []string {
+		var vars []string
+		for _, p := range plans {
+			if bodySets[p.tr][pred] && !bodySets[p.tr][succ] {
+				vars = append(vars, p.inTry)
+			}
+		}
+		return vars
 	}
 
 	const pcVar, retVar, excVar = "__pc", "__ret", "__exc"
@@ -647,6 +716,9 @@ func (em *ssaEmitter) emitTrampoline(f *ssa.Func, body *ast.BlockStmt, flatEc *e
 	}
 	for _, p := range plans {
 		decl(p.inTry, newID("bool"), "")
+		if p.excVar != "" {
+			decl(p.excVar, &ast.StarExpr{X: em.wasmExcType()}, "")
+		}
 	}
 	if em.t != nil {
 		em.t.usesWasmExc = true
@@ -657,7 +729,7 @@ func (em *ssaEmitter) emitTrampoline(f *ssa.Func, body *ast.BlockStmt, flatEc *e
 	trampEc := &emitCtx{
 		f: f, hoist: flatEc.hoist, stagedPhi: flatEc.stagedPhi, emitExpr: flatEc.emitExpr,
 		labelSet: labels,
-		tramp:    &trampCtx{retVar: retVar, rvVars: rvVars, entrySet: entrySet, postClear: postClear},
+		tramp:    &trampCtx{retVar: retVar, rvVars: rvVars, entrySet: entrySet, edgeClears: edgeClears},
 	}
 	deferStmt := &ast.DeferStmt{Call: &ast.CallExpr{Fun: &ast.FuncLit{
 		Type: &ast.FuncType{Params: &ast.FieldList{}},
@@ -672,10 +744,12 @@ func (em *ssaEmitter) emitTrampoline(f *ssa.Func, body *ast.BlockStmt, flatEc *e
 		Body: []ast.Stmt{&ast.BranchStmt{Tok: token.GOTO, Label: newID(labelForBlock(f.Entry))}},
 	})
 	for _, p := range plans {
-		pcCases = append(pcCases, &ast.CaseClause{
-			List: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(p.handler.ID)}},
-			Body: []ast.Stmt{&ast.BranchStmt{Tok: token.GOTO, Label: newID(labelForBlock(p.handler))}},
-		})
+		for _, h := range p.tr.Handlers {
+			pcCases = append(pcCases, &ast.CaseClause{
+				List: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(h.Block.ID)}},
+				Body: []ast.Stmt{&ast.BranchStmt{Tok: token.GOTO, Label: newID(labelForBlock(h.Block))}},
+			})
+		}
 	}
 	closureBody := []ast.Stmt{deferStmt, &ast.SwitchStmt{Tag: newID(pcVar), Body: &ast.BlockStmt{List: pcCases}}}
 	// Catch landing pads read their exception via em.catchExcVar (the function-
@@ -709,24 +783,59 @@ func (em *ssaEmitter) emitTrampoline(f *ssa.Func, body *ast.BlockStmt, flatEc *e
 		Cond: newID(retVar),
 		Body: &ast.BlockStmt{List: []ast.Stmt{&ast.ReturnStmt{Results: retExprs}}},
 	})
-	// Dispatch the caught exception to the innermost active try's handler, else
-	// re-panic (uncaught / propagates out of this function).
+	// Dispatch the caught exception. The arms run innermost-first as an
+	// if-chain: the innermost ACTIVE try gets the exception; if none of its
+	// clauses matches the tag, control falls through to the next enclosing
+	// active try (wasm propagation), and past the last arm the exception
+	// re-panics out of the function. A delegate arm clears the flags of every
+	// try nested between it and its resolved target and falls through, so
+	// the skipped trys' arms see a false flag — `delegate l` semantics.
+	takeHandler := func(p *htPlan, h ssa.TryHandler) []ast.Stmt {
+		return []ast.Stmt{
+			&ast.AssignStmt{Tok: token.ASSIGN, Lhs: []ast.Expr{newID(p.excVar)}, Rhs: []ast.Expr{newID(excVar)}},
+			&ast.AssignStmt{Tok: token.ASSIGN, Lhs: []ast.Expr{newID(pcVar)},
+				Rhs: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(h.Block.ID)}}},
+			&ast.BranchStmt{Tok: token.CONTINUE},
+		}
+	}
 	var dispatch []ast.Stmt
 	for _, p := range plans {
-		dispatch = append(dispatch, &ast.CaseClause{
-			List: []ast.Expr{newID(p.inTry)},
-			Body: []ast.Stmt{
-				assignBool(p.inTry, false),
-				&ast.AssignStmt{Tok: token.ASSIGN, Lhs: []ast.Expr{newID(pcVar)},
-					Rhs: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(p.handler.ID)}}},
-				&ast.BranchStmt{Tok: token.CONTINUE},
-			},
-		})
+		arm := []ast.Stmt{assignBool(p.inTry, false)}
+		if p.tr.Delegate {
+			// Clear every try between this delegate and its target (all of
+			// them for a to-caller delegate), then fall through.
+			for _, q := range plans {
+				if q == p || q.tr == p.tr.DelegateTarget {
+					continue
+				}
+				if !bodySets[q.tr][p.tr.Entry.ID] {
+					continue // q does not enclose the delegate
+				}
+				if p.tr.DelegateTarget != nil && !bodySets[p.tr.DelegateTarget][q.tr.Entry.ID] {
+					continue // q is outside the target — still eligible to catch
+				}
+				arm = append(arm, assignBool(q.inTry, false))
+			}
+		} else {
+			for _, h := range p.tr.Handlers {
+				if h.CatchAll {
+					arm = append(arm, takeHandler(p, h)...)
+					break // clauses after catch_all are unreachable
+				}
+				arm = append(arm, &ast.IfStmt{
+					Cond: &ast.BinaryExpr{
+						X:  &ast.SelectorExpr{X: newID(excVar), Sel: newID("Tag")},
+						Op: token.EQL,
+						Y:  &ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(h.TagIndex)},
+					},
+					Body: &ast.BlockStmt{List: takeHandler(p, h)},
+				})
+			}
+		}
+		dispatch = append(dispatch, &ast.IfStmt{Cond: newID(p.inTry), Body: &ast.BlockStmt{List: arm}})
 	}
-	dispatch = append(dispatch, &ast.CaseClause{Body: []ast.Stmt{
-		&ast.ExprStmt{X: &ast.CallExpr{Fun: newID("panic"), Args: []ast.Expr{newID(excVar)}}},
-	}})
-	loopBody = append(loopBody, &ast.SwitchStmt{Body: &ast.BlockStmt{List: dispatch}})
+	dispatch = append(dispatch, &ast.ExprStmt{X: &ast.CallExpr{Fun: newID("panic"), Args: []ast.Expr{newID(excVar)}}})
+	loopBody = append(loopBody, dispatch...)
 
 	body.List = append(body.List, &ast.ForStmt{Body: &ast.BlockStmt{List: loopBody}})
 	return body, nil
@@ -871,13 +980,23 @@ func (em *ssaEmitter) throwStmt(blk *ssa.Block, emitExpr func(*ssa.Value) (ast.E
 	if em.t != nil {
 		em.t.usesWasmExc = true
 	}
-	// rethrow: re-raise the exception currently held by the enclosing catch
-	// handler. panic(<catch exc>) — no fresh wasmExc is built.
+	// rethrow: re-raise the exception caught by the handler the rethrow's
+	// label resolved to. panic(<caught exc>) — no fresh wasmExc is built.
+	// RethrowRegion picks the right exception when handlers nest (`rethrow 1`
+	// inside an inner catch re-raises the OUTER try's exception); a nil
+	// region falls back to the lexically-current handler variable.
 	if blk.IsRethrow {
-		if em.catchExcVar == "" {
+		excVar := ""
+		if blk.RethrowRegion != nil {
+			excVar = em.excVarOfRegion[blk.RethrowRegion]
+		}
+		if excVar == "" {
+			excVar = em.catchExcVar
+		}
+		if excVar == "" {
 			return nil, fmt.Errorf("ssa emit: rethrow outside a catch handler")
 		}
-		return &ast.ExprStmt{X: &ast.CallExpr{Fun: newID("panic"), Args: []ast.Expr{newID(em.catchExcVar)}}}, nil
+		return &ast.ExprStmt{X: &ast.CallExpr{Fun: newID("panic"), Args: []ast.Expr{newID(excVar)}}}, nil
 	}
 	n := blk.ThrowArgc
 	if len(blk.Values) < n {
@@ -1016,12 +1135,19 @@ func (em *ssaEmitter) emitOp(v *ssa.Value, emit func(*ssa.Value) (ast.Expr, erro
 		return newID(fmt.Sprintf("l%d", v.AuxInt)), nil
 	case ssa.OpCatchArg:
 		// The i-th operand of the exception being handled, narrowed from its
-		// uint64 slot back to the operand's wasm type.
-		if em.catchExcVar == "" {
+		// uint64 slot back to the operand's wasm type. The exception variable
+		// is the landing pad's own (trampoline path: handler blocks are
+		// emitted flat, each region has its own variable), falling back to
+		// the lexically-current handler variable (structured path).
+		excVar := em.excVarOfHandlerBlock[v.Block.ID]
+		if excVar == "" {
+			excVar = em.catchExcVar
+		}
+		if excVar == "" {
 			return nil, fmt.Errorf("ssa emit: OpCatchArg outside a catch handler")
 		}
 		slot := &ast.IndexExpr{
-			X:     &ast.SelectorExpr{X: newID(em.catchExcVar), Sel: newID("Vals")},
+			X:     &ast.SelectorExpr{X: newID(excVar), Sel: newID("Vals")},
 			Index: &ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(v.AuxInt)},
 		}
 		return em.narrowExcSlot(slot, v.Type), nil

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -88,6 +88,12 @@ type structEmitter struct {
 	// recursive region() call for the protected body does not re-trigger the
 	// try wrapper on its own entry block.
 	tryOpened map[ssa.BlockID]bool
+	// tryStack is the stack of try regions whose protected BODY is being
+	// emitted, innermost last. It answers "where does a re-panic from here
+	// land": the innermost stack entry with handlers. Handler bodies are
+	// emitted with their own region popped (a throw inside a catch handler
+	// propagates out of that try, not back into it).
+	tryStack []*ssa.TryRegion
 	// emitCount counts block emissions; dupCap bounds duplication of shared
 	// forward-join blocks (see the re-entry handling in region). Exceeding it
 	// aborts structured emission (fall back to the goto emitter) rather than
@@ -365,12 +371,69 @@ func (se *structEmitter) emitTryRegion(tr *ssa.TryRegion) ([]ast.Stmt, bool) {
 	}
 	excVar := fmt.Sprintf("__exc%d", tr.Entry.ID)
 
+	// A delegate region forwards its exceptions to a specific outer try,
+	// skipping any try nested in between. Structured emission expresses
+	// forwarding as a plain re-panic, which always lands at the INNERMOST
+	// enclosing region with handlers — so it can only represent a delegate
+	// whose resolved target IS that region (enclosing delegate regions are
+	// transparent: they re-panic onward, and each verified its own target
+	// when it was emitted). Anything else routes the function to the
+	// trampoline, whose flag-based dispatch can skip regions.
+	if tr.Delegate {
+		var natural *ssa.TryRegion
+		for i := len(se.tryStack) - 1; i >= 0; i-- {
+			if len(se.tryStack[i].Handlers) > 0 {
+				natural = se.tryStack[i]
+				break
+			}
+		}
+		if tr.DelegateTarget != natural {
+			return nil, false
+		}
+	}
+	if len(tr.Handlers) > 0 {
+		if se.em.excVarOfRegion == nil {
+			se.em.excVarOfRegion = map[*ssa.TryRegion]string{}
+		}
+		if se.em.excVarOfHandlerBlock == nil {
+			se.em.excVarOfHandlerBlock = map[ssa.BlockID]string{}
+		}
+		se.em.excVarOfRegion[tr] = excVar
+		for _, h := range tr.Handlers {
+			se.em.excVarOfHandlerBlock[h.Block.ID] = excVar
+		}
+	}
+
+	// The closure must contain exactly the PROTECTED body. region() walks
+	// every reachable block until Post, so a br that exits the try early
+	// would get its continuation duplicated INSIDE the closure — code that
+	// must run unprotected would run under this try's recover. Bail to the
+	// trampoline (whose per-edge flag clears express the early exit) when
+	// any body block escapes to something other than Post. Membership comes
+	// from the lowering's structural record (tr.Body), not reachability —
+	// the escaped continuation IS reachable from the body.
+	{
+		bodySet := map[ssa.BlockID]bool{}
+		for _, b := range tr.Body {
+			bodySet[b.ID] = true
+		}
+		for _, b := range tr.Body {
+			for _, e := range b.Succs {
+				if !bodySet[e.Block.ID] && e.Block.ID != tr.Post.ID {
+					return nil, false
+				}
+			}
+		}
+	}
+
 	// Body region, emitted inside the closure. A function return reached inside
 	// the body cannot be represented in the *wasmExc closure (see inTryDepth);
 	// region() bails when it hits one, routing the whole function to the
 	// trampoline.
 	se.inTryDepth++
+	se.tryStack = append(se.tryStack, tr)
 	bodyStmts, ok := se.region(tr.Entry, tr.Post)
+	se.tryStack = se.tryStack[:len(se.tryStack)-1]
 	se.inTryDepth--
 	if !ok {
 		return nil, false
@@ -477,6 +540,16 @@ func (se *structEmitter) region(b, stop *ssa.Block) ([]ast.Stmt, bool) {
 			if tr.Post != nil && len(tr.Post.Preds) > 0 {
 				b = tr.Post
 			} else {
+				// No path falls out of this try: the body always throws (a
+				// return or br out bails to the trampoline instead), and
+				// every handler terminates too. Go's termination analysis
+				// cannot see that through the closure + dispatch, so close
+				// the region the same way the flat emitter renders
+				// unreachable code.
+				se.em.useHelper("wasm_trap_unreachable")
+				out = append(out,
+					&ast.ExprStmt{X: &ast.CallExpr{Fun: se.em.helperRef("wasm_trap_unreachable")}},
+					&ast.ForStmt{Body: &ast.BlockStmt{}})
 				b = nil
 			}
 			continue

--- a/internal/gcasm/duff.go
+++ b/internal/gcasm/duff.go
@@ -53,6 +53,14 @@ func hasEHRuntimeCall(insns []Insn) bool {
 				return true
 			}
 		}
+		// A structured-EH function wraps its try body in a func literal and
+		// calls it (`__exc := func() *wasmExc { ... }()`). The OUTER function
+		// need not call any panic/recover runtime symbol itself — the defer /
+		// recover lives inside the closure — so detect the closure call: gc
+		// names function literals "<outer>.funcN".
+		if strings.Contains(in.Text, "CALL") && strings.Contains(in.Text, ".func") {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/lower/lower.go
+++ b/internal/lower/lower.go
@@ -256,6 +256,12 @@ type ctrlFrame struct {
 	// and Post are set when the frame opens; each catch / catch_all
 	// appends a handler. target / fallthrough_ both point at Post.
 	tryRegion *ssa.TryRegion
+	// inHandler, for ctrlTry frames, is true once the first catch /
+	// catch_all has been seen: lowering is inside a handler, not the
+	// protected body. `rethrow l` labels must resolve to such a frame, and
+	// `delegate l` targeting one keeps searching outward (a try whose
+	// handler is already running cannot catch again).
+	inHandler bool
 }
 
 type ctrlKind uint8
@@ -350,6 +356,22 @@ func (ls *lowerState) lowerBodyUntil(r *wasm.InstrReader, baseCtrl int) error {
 						return err
 					}
 				} else if err := ls.handleCatchAll(); err != nil {
+					return err
+				}
+			case wasm.OpDelegate:
+				// `delegate` closes its try like an `end` does: a
+				// dead-region-opened try just drops the depth count; a
+				// delegate at the live frame's depth must pop the open
+				// ctrlTry frame (handleDelegate re-establishes a
+				// reachable cursor at Post when it has incoming edges).
+				if ls.unreachableDepth > 0 {
+					ls.unreachableDepth--
+					if err := r.SkipImmediates(op); err != nil {
+						return err
+					}
+					break
+				}
+				if err := ls.handleDelegate(r); err != nil {
 					return err
 				}
 			case wasm.OpEnd:
@@ -1018,17 +1040,17 @@ func (ls *lowerState) handleTry(r *wasm.InstrReader) error {
 }
 
 // handleDelegate closes a `try ... delegate N` — a try whose protected body
-// forwards any exception to the N-th enclosing label instead of catching it.
-// We close the body into post with NO handler; emitTryRegion turns a
-// handler-less TryRegion into `body-closure; if exc != nil { panic(exc) }`,
-// i.e. it recovers and re-panics, which IS delegate's forward-to-enclosing-
-// handler behaviour under Go's panic propagation (the re-panic unwinds to the
-// nearest enclosing recover, matching the target for the tag the SjLj runtime
-// uses). The label operand is consumed but not otherwise needed: Go propagation
-// reaches the enclosing handler without an explicit target. Mirrors the ctrlTry
-// arm of handleEnd, minus any handler.
+// forwards any exception to the catching context of the N-th enclosing label,
+// skipping every try nested between the two. We close the body into post with
+// NO handler and record the resolved forwarding target on the region:
+// label depth N (relative to the context enclosing the try) is walked on the
+// control stack, and the catching context is the nearest enclosing try that is
+// still in its protected body at or outside that label (a try whose handler is
+// already running cannot catch again). No frame at all means the exception
+// leaves the function. Mirrors the ctrlTry arm of handleEnd, minus any handler.
 func (ls *lowerState) handleDelegate(r *wasm.InstrReader) error {
-	if _, err := r.ReadU32(); err != nil { // labelidx (relative depth)
+	depth, err := r.ReadU32() // labelidx, relative to the try's outer context
+	if err != nil {
 		return err
 	}
 	if len(ls.ctrl) == 0 || ls.ctrl[len(ls.ctrl)-1].kind != ctrlTry {
@@ -1036,6 +1058,21 @@ func (ls *lowerState) handleDelegate(r *wasm.InstrReader) error {
 	}
 	f := ls.ctrl[len(ls.ctrl)-1]
 	ls.ctrl = ls.ctrl[:len(ls.ctrl)-1]
+
+	ls.captureTryBody(f)
+	f.tryRegion.Delegate = true
+	// Resolve the label to its catching context. The label indexes the
+	// control stack with the delegate's own try frame already popped; depth
+	// == len(ls.ctrl) names the function body (forward to the caller).
+	if int(depth) < len(ls.ctrl) {
+		for i := len(ls.ctrl) - 1 - int(depth); i >= 0; i-- {
+			fr := ls.ctrl[i]
+			if fr.kind == ctrlTry && !fr.inHandler && fr.tryRegion != nil {
+				f.tryRegion.DelegateTarget = fr.tryRegion
+				break
+			}
+		}
+	}
 
 	if !ls.unreachable {
 		ls.recordIncoming(f.target, f.resultCount)
@@ -1053,13 +1090,55 @@ func (ls *lowerState) handleDelegate(r *wasm.InstrReader) error {
 	return nil
 }
 
+// captureTryBody records, once, a try region's protected-body block set:
+// Entry plus every block created while the try was open (nested regions
+// included), minus Post. Called when the body closes — at the first catch /
+// catch_all, at delegate, or at a handler-less end. The CFG alone cannot
+// delimit the body (a br exiting the try early makes its continuation
+// reachable from inside), so the emit passes rely on this structural record.
+func (ls *lowerState) captureTryBody(f *ctrlFrame) {
+	tr := f.tryRegion
+	if tr == nil || tr.Body != nil {
+		return
+	}
+	blocks := ls.b.Func().Blocks
+	start := -1
+	for i, b := range blocks {
+		if b == tr.Entry {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return
+	}
+	body := []*ssa.Block{tr.Entry}
+	for _, b := range blocks[start+1:] {
+		if b != tr.Post {
+			body = append(body, b)
+		}
+	}
+	tr.Body = body
+}
+
 // handleRethrow implements `rethrow N` — re-raise the exception caught by the
-// N-th enclosing catch. It terminates the current block by re-panicking the
-// in-scope caught exception (the emit pass renders it as panic(<catch exc>)).
+// catch handler the N-th enclosing label resolves to. Handlers nest, so the
+// label does not always name the innermost catch: `rethrow 1` inside an inner
+// catch re-raises the OUTER try's exception. The label is resolved to its try
+// region here so the emit pass panics the right region's caught exception.
 func (ls *lowerState) handleRethrow(r *wasm.InstrReader) error {
-	if _, err := r.ReadU32(); err != nil { // labelidx (relative depth to a try's catch)
+	depth, err := r.ReadU32() // labelidx; must name a try frame in handler state
+	if err != nil {
 		return err
 	}
+	if int(depth) >= len(ls.ctrl) {
+		return fmt.Errorf("%w: rethrow depth %d exceeds control stack", ErrSSAUnsupported, depth)
+	}
+	fr := ls.ctrl[len(ls.ctrl)-1-int(depth)]
+	if fr.kind != ctrlTry || !fr.inHandler || fr.tryRegion == nil {
+		return fmt.Errorf("%w: rethrow label does not name a catch handler", ErrSSAUnsupported)
+	}
+	ls.b.Current().RethrowRegion = fr.tryRegion
 	ls.b.FinishRethrow()
 	ls.unreachable = true
 	return nil
@@ -1089,6 +1168,8 @@ func (ls *lowerState) beginHandler(catchAll bool, tagIdx uint32) error {
 		return fmt.Errorf("%w: catch/catch_all with no open try", ErrSSAUnsupported)
 	}
 	f := ls.ctrl[len(ls.ctrl)-1]
+	ls.captureTryBody(f) // no-op after the first handler
+	f.inHandler = true
 
 	// Close the current sub-region into post (skip if it threw/branched away).
 	if !ls.unreachable {
@@ -1924,6 +2005,7 @@ func (ls *lowerState) handleEnd() (bool, error) {
 		// post (the body and earlier handlers were closed at each catch).
 		// Every sub-region — body and handlers — is a pred of post; the
 		// handler entry blocks are landing pads with no CFG pred.
+		ls.captureTryBody(f) // no-op unless this is a handler-less try..end
 		if !ls.unreachable {
 			ls.recordIncoming(f.target, f.resultCount)
 			cur := ls.b.Current()

--- a/internal/ssa/ssa.go
+++ b/internal/ssa/ssa.go
@@ -64,6 +64,25 @@ type TryRegion struct {
 	Entry    *Block // first block of the protected (try) body
 	Post     *Block // continuation after the try's `end`
 	Handlers []TryHandler
+
+	// Body is the protected-body block set, recorded by the lowering when
+	// the body closes (first catch, delegate, or a handler-less end):
+	// Entry plus every block created while the try was open, nested
+	// regions included, minus Post. The emit passes use this instead of a
+	// CFG reachability walk — a br that exits the try early makes its
+	// continuation reachable FROM the body, but that continuation is not
+	// protected by it. May contain blocks later emptied by optimization;
+	// consumers treat it purely as a membership set.
+	Body []*Block
+
+	// Delegate marks a `try ... delegate l` region: it has no handlers and
+	// forwards any exception thrown in its body to DelegateTarget's catching
+	// context, skipping every try nested between the two. A nil
+	// DelegateTarget with Delegate set forwards out of the function (to the
+	// caller). The wasm label operand is resolved to the region at lowering
+	// time, so the emit passes never see label depths.
+	Delegate       bool
+	DelegateTarget *TryRegion
 }
 
 // TryHandler is one catch / catch_all clause of a TryRegion.
@@ -150,8 +169,16 @@ type Block struct {
 	// IsRethrow marks a BlockThrow that re-raises the exception caught by the
 	// enclosing catch handler (the wasm `rethrow` op) instead of constructing a
 	// fresh one. Such a block has ThrowArgc == 0; the emit pass renders it as
-	// panic(<current catch exc>).
+	// panic(<caught exc>).
 	IsRethrow bool
+
+	// RethrowRegion, for an IsRethrow block, is the try region whose caught
+	// exception is re-raised — the region the wasm `rethrow l` label resolved
+	// to at lowering time. Handlers can nest, so this is not always the
+	// innermost enclosing catch: `rethrow 1` inside an inner catch re-raises
+	// the OUTER try's exception. Nil means the innermost enclosing handler
+	// (the pre-resolution behaviour, kept for builder-level callers).
+	RethrowRegion *TryRegion
 
 	f *Func
 }

--- a/internal/ssa/verify.go
+++ b/internal/ssa/verify.go
@@ -282,7 +282,31 @@ func verifyUseDominance(f *Func) error {
 // computeDominators returns the immediate-dominator map (idom) and a
 // reverse-postorder numbering, using the Cooper-Harvey-Kennedy
 // iterative algorithm. idom[entry] == entry.
+//
+// EH catch landing pads have no CFG predecessors (they are entered by
+// unwinding), so the plain CFG leaves them — and every block only they
+// reach — outside the dominator tree, and any use of a pre-try value in a
+// handler would fail verification. The runtime guarantee is that a
+// handler runs only after its try's Entry was reached, so dominance is
+// computed over the CFG augmented with a virtual edge Entry → handler
+// for every catch clause: a handler is then dominated by whatever
+// dominates its try's Entry.
 func computeDominators(f *Func) (idom map[BlockID]*Block, rpoNum map[BlockID]int) {
+	// Virtual Entry → handler edges per try region (see doc comment).
+	virtSuccs := map[BlockID][]*Block{}
+	virtPred := map[BlockID]*Block{}
+	for _, tr := range f.TryRegions {
+		if tr.Entry == nil {
+			continue
+		}
+		for _, h := range tr.Handlers {
+			if h.Block == nil {
+				continue
+			}
+			virtSuccs[tr.Entry.ID] = append(virtSuccs[tr.Entry.ID], h.Block)
+			virtPred[h.Block.ID] = tr.Entry
+		}
+	}
 	// Reverse-postorder via iterative DFS.
 	var post []*Block
 	seen := map[BlockID]bool{}
@@ -294,8 +318,14 @@ func computeDominators(f *Func) (idom map[BlockID]*Block, rpoNum map[BlockID]int
 	seen[f.Entry.ID] = true
 	for len(stack) > 0 {
 		top := &stack[len(stack)-1]
-		if top.i < len(top.b.Succs) {
-			s := top.b.Succs[top.i].Block
+		succs := top.b.Succs
+		if top.i < len(succs)+len(virtSuccs[top.b.ID]) {
+			var s *Block
+			if top.i < len(succs) {
+				s = succs[top.i].Block
+			} else {
+				s = virtSuccs[top.b.ID][top.i-len(succs)]
+			}
 			top.i++
 			if !seen[s.ID] {
 				seen[s.ID] = true
@@ -339,8 +369,14 @@ func computeDominators(f *Func) (idom map[BlockID]*Block, rpoNum map[BlockID]int
 				continue
 			}
 			var newIdom *Block
+			preds := make([]*Block, 0, len(b.Preds)+1)
 			for _, pe := range b.Preds {
-				p := pe.Block
+				preds = append(preds, pe.Block)
+			}
+			if vp := virtPred[b.ID]; vp != nil {
+				preds = append(preds, vp)
+			}
+			for _, p := range preds {
 				if idom[p.ID] == nil {
 					continue // pred not yet processed
 				}

--- a/testdata/eh_catch_all_rethrow.wat
+++ b/testdata/eh_catch_all_rethrow.wat
@@ -1,0 +1,16 @@
+;; A catch_all that re-raises (the C++ "cleanup during unwind" shape: run the
+;; cleanup, then rethrow 0). The rethrown exception keeps its tag and payload,
+;; so the enclosing catch $a still receives 42.
+(module
+  (tag $a (param i32))
+  (func (export "run") (result i32)
+    try (result i32)
+      try
+        i32.const 42
+        throw $a
+      catch_all
+        rethrow 0
+      end
+      i32.const 0
+    catch $a
+    end))

--- a/testdata/eh_delegate_skip.wat
+++ b/testdata/eh_delegate_skip.wat
@@ -1,0 +1,19 @@
+;; `delegate l` must skip every try between it and its target. The inner
+;; delegate 1 targets the OUTER try (catch $a), so the middle catch_all —
+;; which would otherwise swallow the exception — must never run.
+;; Expected: 42 (999 would mean the delegate stopped at the middle try).
+(module
+  (tag $a (param i32))
+  (func (export "run") (result i32)
+    try (result i32)
+      try (result i32)
+        try
+          i32.const 42
+          throw $a
+        delegate 1
+        i32.const 0
+      catch_all
+        i32.const 999
+      end
+    catch $a
+    end))

--- a/testdata/eh_multi_catch.wat
+++ b/testdata/eh_multi_catch.wat
@@ -1,0 +1,45 @@
+;; Multi-clause catch dispatch: one try with catch $a / catch $b / catch_all.
+;; $f(0) throws $a(10) -> 10+1 = 11; $f(1) throws $b(20) -> 20+2 = 22;
+;; $f(2) throws $c (no payload) -> catch_all = 99. run = 11+22+99 = 132.
+(module
+  (tag $a (param i32))
+  (tag $b (param i32))
+  (tag $c)
+  (func $throw_sel (param i32)
+    local.get 0
+    i32.eqz
+    if
+      i32.const 10
+      throw $a
+    end
+    local.get 0
+    i32.const 1
+    i32.eq
+    if
+      i32.const 20
+      throw $b
+    end
+    throw $c)
+  (func $f (param i32) (result i32)
+    try (result i32)
+      local.get 0
+      call $throw_sel
+      i32.const 0
+    catch $a
+      i32.const 1
+      i32.add
+    catch $b
+      i32.const 2
+      i32.add
+    catch_all
+      i32.const 99
+    end)
+  (func (export "run") (result i32)
+    i32.const 0
+    call $f
+    i32.const 1
+    call $f
+    i32.add
+    i32.const 2
+    call $f
+    i32.add))

--- a/testdata/eh_multi_catch_tramp.wat
+++ b/testdata/eh_multi_catch_tramp.wat
@@ -1,0 +1,56 @@
+;; Same multi-clause dispatch as eh_multi_catch, but a `return` inside the try
+;; body forces the recover-trampoline emit path (a function return cannot be
+;; expressed inside the structured emitter's try closure). $f(3) takes that
+;; return. run = 11 + 22 + 99 + 7 = 139.
+(module
+  (tag $a (param i32))
+  (tag $b (param i32))
+  (tag $c)
+  (func $throw_sel (param i32)
+    local.get 0
+    i32.eqz
+    if
+      i32.const 10
+      throw $a
+    end
+    local.get 0
+    i32.const 1
+    i32.eq
+    if
+      i32.const 20
+      throw $b
+    end
+    throw $c)
+  (func $f (param i32) (result i32)
+    try (result i32)
+      local.get 0
+      i32.const 3
+      i32.eq
+      if
+        i32.const 7
+        return
+      end
+      local.get 0
+      call $throw_sel
+      i32.const 0
+    catch $a
+      i32.const 1
+      i32.add
+    catch $b
+      i32.const 2
+      i32.add
+    catch_all
+      i32.const 99
+    end)
+  (func (export "run") (result i32)
+    i32.const 0
+    call $f
+    i32.const 1
+    call $f
+    i32.add
+    i32.const 2
+    call $f
+    i32.add
+    i32.const 3
+    call $f
+    i32.add))

--- a/testdata/eh_rethrow_outer.wat
+++ b/testdata/eh_rethrow_outer.wat
@@ -1,0 +1,21 @@
+;; `rethrow l` with a non-zero depth re-raises an OUTER catch's exception.
+;; The inner catch_all holds $a(99) but rethrow 1 names the outer catch $a,
+;; whose exception is $a(42); the top-level try must observe 42, not 99.
+(module
+  (tag $a (param i32))
+  (func (export "run") (result i32)
+    try (result i32)
+      try (result i32)
+        i32.const 42
+        throw $a
+      catch $a
+        drop
+        try (result i32)
+          i32.const 99
+          throw $a
+        catch_all
+          rethrow 1
+        end
+      end
+    catch $a
+    end))

--- a/testdata/eh_try_exit_flag.wat
+++ b/testdata/eh_try_exit_flag.wat
@@ -1,0 +1,23 @@
+;; A br out of a protected body leaves the try WITHOUT passing its Post block
+;; (this same br is what routes the function to the recover-trampoline). The
+;; try's active-flag must drop on that exit edge: the later throw happens
+;; OUTSIDE the try and must propagate to the caller, not into the stale
+;; handler. Expected: 222 (111 would mean the exited try still caught it).
+(module
+  (tag $a)
+  (func $inner (result i32)
+    block $out
+      try
+        br $out
+      catch_all
+        i32.const 111
+        return
+      end
+    end
+    throw $a)
+  (func (export "run") (result i32)
+    try (result i32)
+      call $inner
+    catch_all
+      i32.const 222
+    end))

--- a/transpile/eh_catch_patterns_test.go
+++ b/transpile/eh_catch_patterns_test.go
@@ -1,0 +1,112 @@
+package transpile_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/transpile"
+)
+
+// runEHFixture translates fixture (which must export "run" () -> i32), builds
+// the generated module with the default backend, executes it, and compares
+// run()'s printed result. Shared by the C++-shaped EH pattern tests below.
+func runEHFixture(t *testing.T, fixture, want string) {
+	t.Helper()
+	bin := testfixture.Wasm(t, fixture)
+	m, err := transpile.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	var buf bytes.Buffer
+	res, err := transpile.Translate(&buf, m, transpile.Options{
+		Package:          "pkg",
+		OutputImportPath: "ehtest/pkg",
+	})
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+
+	dir := t.TempDir()
+	writeFile := func(rel string, data []byte) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile("go.mod", []byte("module ehtest\n\ngo 1.25.0\n"))
+	writeFile("pkg/gen.go", buf.Bytes())
+	for rel, data := range res.Files {
+		writeFile("pkg/"+rel, data)
+	}
+	for name, data := range res.Sidecars {
+		writeFile("pkg/"+name, data)
+	}
+	writeFile("main.go", []byte(`package main
+
+import (
+	"fmt"
+
+	"ehtest/pkg"
+)
+
+func main() {
+	fmt.Println(pkg.New().Run())
+}
+`))
+
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Fatalf("run() printed %q, want %s\n%s", got, want, out)
+	}
+}
+
+// TestTranspileEHMultiCatch: one try with catch $a / catch $b / catch_all —
+// the clause dispatch must select by tag, in clause order, with catch_all as
+// the final default.
+func TestTranspileEHMultiCatch(t *testing.T) {
+	runEHFixture(t, "eh_multi_catch", "132")
+}
+
+// TestTranspileEHMultiCatchTrampoline is the same dispatch through the
+// recover-trampoline path (a return inside the try body forces it).
+func TestTranspileEHMultiCatchTrampoline(t *testing.T) {
+	runEHFixture(t, "eh_multi_catch_tramp", "139")
+}
+
+// TestTranspileEHCatchAllRethrow: catch_all + rethrow 0 — the C++ cleanup-
+// during-unwind shape. The rethrown exception keeps tag and payload.
+func TestTranspileEHCatchAllRethrow(t *testing.T) {
+	runEHFixture(t, "eh_catch_all_rethrow", "42")
+}
+
+// TestTranspileEHDelegateSkip: delegate 1 forwards past the middle try's
+// catch_all straight to the outer catch $a. The middle handler must not run.
+func TestTranspileEHDelegateSkip(t *testing.T) {
+	runEHFixture(t, "eh_delegate_skip", "42")
+}
+
+// TestTranspileEHRethrowOuter: rethrow 1 inside an inner catch_all re-raises
+// the OUTER catch's exception (42), not the inner one (99).
+func TestTranspileEHRethrowOuter(t *testing.T) {
+	runEHFixture(t, "eh_rethrow_outer", "42")
+}
+
+// TestTranspileEHTryExitFlag: a br out of a protected body must deactivate the
+// try — a later throw outside it propagates to the caller instead of being
+// caught by the exited try's handler.
+func TestTranspileEHTryExitFlag(t *testing.T) {
+	runEHFixture(t, "eh_try_exit_flag", "222")
+}


### PR DESCRIPTION
## Summary

Extends the legacy wasm exception-handling support (added for clang SjLj in #22) to the full C++ patterns that clang's `-fwasm-exceptions` emits — measured against a real llama.cpp module built for `wasm32-wasip1`, which uses try ×4044, catch_all ×2857, rethrow ×2444 (97 of them with depth > 0), delegate ×1133 (depths 1–12+), and 862 multi-clause trys.

- **Multi-clause catch dispatch** — `catch $a / catch $b / catch_all` on one try, dispatched by tag in clause order, on both the structured and the recover-trampoline emit paths (the trampoline previously rejected everything but a single non-catch_all handler).
- **`delegate l` target resolution** — the label depth is resolved to its target try region at lowering time; the trampoline dispatch clears the flags of every region between the delegate and its target, so intermediate handlers are skipped (wasm semantics). The structured emitter bails to the trampoline whenever a plain re-panic would land anywhere else. Also fixes `delegate` closing a try inside a dead (unreachable) region, which previously corrupted the control stack.
- **`rethrow l` depth resolution** — a rethrow inside nested handlers can name an OUTER catch's exception; each region now keeps its caught exception in its own variable and the rethrow resolves to the right one.
- **Protected-body delimitation** — the lowering records each region's body block set. The CFG alone cannot delimit a try body: a `br` that exits the try early makes its continuation reachable from inside, and both emitters previously treated that continuation as protected. The structured emitter now bails in that case; the trampoline clears the region's active flag on every edge that leaves the body (previously a later, unrelated throw could misroute into the exited try's handler).
- **Verifier** — dominators are computed over the CFG augmented with virtual entry→handler edges so landing pads (no CFG preds) can use values defined before their try.
- **gcasm** — functions that call their own EH closure now route to the pure fallback (the outer function of a structured try has no panic/recover runtime call of its own; the defer/recover lives inside the closure).

## Verification (this session)

- `go test -race -timeout 20m ./...` — exit 0, all packages ok.
- New fixtures/tests: `eh_multi_catch` (+ trampoline twin), `eh_catch_all_rethrow`, `eh_delegate_skip`, `eh_rethrow_outer`, `eh_try_exit_flag`.
- End-to-end: llama.cpp HEAD compiled to `wasm32-wasip1` with `-fwasm-exceptions` (SIMD disabled), transpiled with this branch, built and run as pure Go: loads a GGUF model, tokenizes, and generates the same text as the reference run of the same wasm under node:wasi; a deliberately bad model path exercises the exception path and fails gracefully.
- NOT run this session: the googlesql/wasmify five-step e2e chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
