### PR TITLE
gcasm: fix amd64 fused-region miscompilation (register clobber + loop carry)

### DIFF
--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -777,6 +777,10 @@ func buildPkg(
 			// on the asm GOARCHs, so nothing may quietly degrade.
 			if _, isSynth := synth[name]; !isSynth &&
 				(errors.Is(terr, errUnsupportedDuff) || errors.Is(terr, errUnsupportedJumpTable) || errors.Is(terr, errSimdPairUnspliced)) {
+				// The failed attempt may already have registered
+				// jump-table sites; their stubs will not exist in the
+				// emitted asm, so the registrations must go with it.
+				jt.Drop(name)
 				fallbackNames[name] = true
 				stats.Fallback++
 				continue

--- a/internal/gcasm/jumppad.go
+++ b/internal/gcasm/jumppad.go
@@ -78,6 +78,22 @@ func (jt *JTTable) fn(sym string) *JTFn {
 	return &jt.Fns[len(jt.Fns)-1]
 }
 
+// Drop discards every registration for sym. A transform can fail
+// AFTER emitJumpPad registered sites (a later call site refuses to
+// splice and the function falls back to its pure Go body); the stubs
+// those sites describe are then absent from the emitted asm, and a
+// stale spec would send the generated init's signature scan past the
+// end of the text segment looking for them.
+func (jt *JTTable) Drop(sym string) {
+	kept := jt.Fns[:0]
+	for _, fn := range jt.Fns {
+		if fn.Sym != sym {
+			kept = append(kept, fn)
+		}
+	}
+	jt.Fns = kept
+}
+
 // jtSig derives the deterministic signature for one dispatch target.
 // bits selects the architecture's signature width.
 func jtSig(fnSym string, siteOff, target, bits int) uint64 {

--- a/internal/gcasm/simdsplice_fuse_loop_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_loop_x64_test.go
@@ -1,0 +1,78 @@
+package gcasm
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/simdfuse"
+)
+
+// carryLoop is a minimal accumulate loop: acc = i32x4_add(acc,
+// load(s0)) over a counted range. The carried pair (node 0, the
+// f32x4/i32x4 accumulator input) seeds from the argument at entry and
+// must thereafter read the running value from its reserved register.
+func carryLoop() *simdfuse.Loop {
+	tree := &simdfuse.Tree{
+		Name:       "simd_p_fxl_carry",
+		NumScalars: 1, // s0 = load address
+		NumPairs:   1, // the carried accumulator
+		NeedsMem:   true,
+		Nodes: []simdfuse.Node{
+			// node 0: the memory operand of the add.
+			{Op: "v128_load", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgScalar, Index: 0},
+				{Kind: simdfuse.ArgConst, Const: 0},
+			}},
+			// node 1: acc(pair 0) + load. Pair 0 is the carry.
+			{Op: "i32x4_add", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgPairIn, Index: 0},
+				{Kind: simdfuse.ArgNode, Index: 0},
+			}},
+		},
+		Roots: []int{1},
+	}
+	return &simdfuse.Loop{
+		Tree:          tree,
+		CarriedPairs:  [][2]int{{0, 1}}, // pair 0 in, node 1 out
+		CounterScalar: 0,
+		Dec:           1,
+		PreTest:       true,
+	}
+}
+
+// The loop body must read the carried accumulator from its reserved
+// register (written back at the tail), NOT rebuild it from the
+// incoming argument registers — those only hold the first iteration's
+// value, so reading them resets the accumulator every iteration.
+func TestX64LoopCarryReadsReservedRegister(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceLoop(&b, carryLoop(), &ConstPool{}, fuseTestOffs, "0", 0)
+	if err != nil || !spliced {
+		t.Fatalf("spliced=%v err=%v", spliced, err)
+	}
+	body := b.String()
+
+	loopStart := strings.Index(body, "gcasmfxl0:")
+	if loopStart < 0 {
+		t.Fatalf("no loop label in body:\n%s", body)
+	}
+	loopBody := body[loopStart:]
+
+	// The carried accumulator is reserved at X14 (poolTop). The add
+	// must consume it via a register copy from X14, not a MOVQ/PINSRQ
+	// rebuild from a GPR pair.
+	if !regexp.MustCompile(`MOVOU X14, X\d`).MatchString(loopBody) {
+		t.Errorf("loop body never reads the carried register X14:\n%s", loopBody)
+	}
+	// The tail writes the running value back to X14.
+	if !strings.Contains(loopBody, "MOVOU X0, X14") && !regexp.MustCompile(`MOVOU X\d+, X14`).MatchString(loopBody) {
+		t.Errorf("loop body never writes back the carried register X14:\n%s", loopBody)
+	}
+	// The prologue (before the loop label) seeds X14 from the argument
+	// registers exactly once; the body must not rebuild it there.
+	prologue := body[:loopStart]
+	if !regexp.MustCompile(`, X14\n`).MatchString(prologue) {
+		t.Errorf("carried register not seeded from arguments before the loop:\n%s", prologue)
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_pool_test.go
+++ b/internal/gcasm/simdsplice_fuse_pool_test.go
@@ -1,0 +1,126 @@
+package gcasm
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/simdfuse"
+)
+
+// fusePoolClobberTree keeps a loaded vector (n0) live across a canned
+// pair-table op (i8x16_shuffle) — the rotate-window shape (RoPE) that
+// exposed the pool/scratch overlap: canned op bodies scratch X0–X7,
+// so a value parked there was silently corrupted and every consumer
+// after the shuffle computed garbage.
+func fusePoolClobberTree() *simdfuse.Tree {
+	return &simdfuse.Tree{
+		Name:       "simd_p_fx2",
+		NumScalars: 2,
+		NumPairs:   1,
+		NeedsMem:   true,
+		Nodes: []simdfuse.Node{
+			{Op: "v128_load", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgScalar, Index: 0},
+				{Kind: simdfuse.ArgConst, Const: 0},
+			}},
+			{Op: "v128_load", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgScalar, Index: 1},
+				{Kind: simdfuse.ArgConst, Const: 0},
+			}},
+			{Op: "v128_load", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgScalar, Index: 1},
+				{Kind: simdfuse.ArgConst, Const: 16},
+			}},
+			{Op: "i8x16_shuffle", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 1},
+				{Kind: simdfuse.ArgNode, Index: 2},
+				{Kind: simdfuse.ArgPairIn, Index: 0},
+			}},
+			{Op: "f32x4_mul", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 0},
+				{Kind: simdfuse.ArgNode, Index: 3},
+			}},
+		},
+		Roots: []int{4},
+	}
+}
+
+// A value parked in X4–X7 that must survive a canned pair-table op
+// (whose pasted body uses X0–X7 as inputs and scratch) is relocated
+// to X8+ before the paste, and every later consumer reads the new
+// home. Without this, the shuffle's scratch writes corrupted the
+// parked load and every consumer after it computed garbage.
+func TestX64FusedCannedOpRelocatesLiveValues(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, fusePoolClobberTree(), &ConstPool{}, fuseTestOffs, 0)
+	if err != nil || !spliced {
+		t.Fatalf("spliced=%v err=%v", spliced, err)
+	}
+	body := b.String()
+	// n0 parks in X4 (first pool register); the shuffle must move it
+	// to X8+ before its canned lines run.
+	if !regexp.MustCompile(`MOVOU X4, X(8|9|1[0-4])\b`).MatchString(body) {
+		t.Fatalf("live value not relocated out of canned scratch:\n%s", body)
+	}
+	// The mul consumes the relocated home, never stale X4.
+	if strings.Contains(body, "MOVOU X4, X0") {
+		t.Fatalf("consumer read the clobbered X4 park:\n%s", body)
+	}
+}
+
+// A tree over the shrunken pool budget must surface errFusedCapacity
+// (the transform then falls the whole function back to pure Go) —
+// never a silent partial splice.
+func TestX64FusedPoolCapacity(t *testing.T) {
+	// Twelve loads all live until a final chain of muls: more parked
+	// values than the X4..X14 pool can hold.
+	tree := &simdfuse.Tree{
+		Name:       "simd_p_fx3",
+		NumScalars: 1,
+		NeedsMem:   true,
+	}
+	const n = 12
+	for i := 0; i < n; i++ {
+		tree.Nodes = append(tree.Nodes, simdfuse.Node{Op: "v128_load", Args: []simdfuse.Arg{
+			{Kind: simdfuse.ArgScalar, Index: 0},
+			{Kind: simdfuse.ArgConst, Const: int32(16 * i)},
+		}})
+	}
+	prev := 0
+	for i := 1; i < n; i++ {
+		tree.Nodes = append(tree.Nodes, simdfuse.Node{Op: "f32x4_mul", Args: []simdfuse.Arg{
+			{Kind: simdfuse.ArgNode, Index: prev},
+			{Kind: simdfuse.ArgNode, Index: i},
+		}})
+		prev = len(tree.Nodes) - 1
+	}
+	tree.Roots = []int{prev}
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, tree, &ConstPool{}, fuseTestOffs, 0)
+	if spliced {
+		t.Fatal("over-budget tree spliced")
+	}
+	if err == nil || !errors.Is(err, errFusedCapacity) {
+		t.Fatalf("want errFusedCapacity, got %v", err)
+	}
+}
+
+// Registrations from a transform attempt that later fell back must
+// leave the jump-table spec set: their stubs are absent from the
+// emitted asm, and a stale spec sends the generated init's signature
+// scan past the end of the text segment.
+func TestJTTableDrop(t *testing.T) {
+	jt := &JTTable{}
+	jt.fn("Fn1").Sites = append(jt.fn("Fn1").Sites, JTSite{TabVar: "Fn1_jt0"})
+	jt.fn("Fn2").Sites = append(jt.fn("Fn2").Sites, JTSite{TabVar: "Fn2_jt0"})
+	jt.Drop("Fn1")
+	if len(jt.Fns) != 1 || jt.Fns[0].Sym != "Fn2" {
+		t.Fatalf("Drop(Fn1) left %+v", jt.Fns)
+	}
+	jt.Drop("Fn2")
+	if got := jt.EmitGo("amd64"); got != "" {
+		t.Fatalf("empty table emitted Go:\n%s", got)
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -2,9 +2,11 @@ package gcasm
 
 // Fused-region splicing, amd64 — the SSE twin of
 // simdsplice_fuse_a64.go. Same synthesis: table bodies verbatim
-// (operands in X0..X2, scratch within X0..X3, result in X0), operand
-// builds and result moves replaced by MOVOU register copies, parked
-// values in X8..X14 (X15 is the ABI zero register). Fused arguments
+// (operands in X0..X2, result in X0; scratch reaches up to X7 in the
+// wider bodies), operand builds and result moves replaced by MOVOU
+// register copies, parked values in X4..X14 (X15 is the ABI zero
+// register) — any park still live when a canned body is pasted is
+// first relocated above that body's measured reach. Fused arguments
 // ride AX,BX,CX,DI,SI,R8,R9 (fusedMaxIntRegs=7 exists exactly so the
 // load scratch R10–R12 stays free); m is saved to R13 because table
 // cores stage scalars through AX.
@@ -12,12 +14,17 @@ package gcasm
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/goccy/wasm2go/internal/simdfuse"
 )
 
 var x64FusedArgRegs = []string{"AX", "BX", "CX", "DI", "SI", "R8", "R9", "R10", "R11"}
+
+// x64XRegRe matches vector-register operands in canned op lines; the
+// fused emitter uses the highest mention to size an op's scratch reach.
+var x64XRegRe = regexp.MustCompile(`\bX(\d+)\b`)
 
 // x64FusedResultRegs is the full ABIInternal integer RESULT sequence:
 // results run past the argument cap because the epilogue is the last
@@ -202,9 +209,26 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 	for _, r := range reserve {
 		reservedX[r] = true
 	}
+	// Canned pair-table op bodies (pasted verbatim by the ClassV128
+	// default arm below) use X0–X7 as inputs and scratch, so a pool
+	// value parked there is silently clobbered by the next canned op
+	// — visible as corrupt vectors whenever a window keeps a value
+	// live across a shuffle. The arm64 twin pools V16–V30 above its
+	// canned v0–v4 scratch; amd64 has no such headroom, so X4–X7 stay
+	// in the pool for capacity and any value still live when a canned
+	// op is pasted is relocated to X8+ first (see relocateForCanned).
 	for x := poolTop; x >= 4; x-- {
 		if !reservedX[x] {
 			freePool = append(freePool, x)
+		}
+	}
+	// Loop-carried accumulators are live across every canned op and
+	// are never relocated; they reserve downward from the pool top, so
+	// reaching the canned-scratch range means the window is over
+	// budget, not silently corrupt.
+	for _, r := range reserve {
+		if r < 8 {
+			return nil, false, fmt.Errorf("fused splice %s: %w: carried value in canned-scratch range", tree.Name, errFusedCapacity)
 		}
 	}
 	needsTrap := false
@@ -414,6 +438,45 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 				} else {
 					fmt.Fprintf(b, "\tMOVQ %s, AX\n", scalarReg(*sArg))
 				}
+			}
+			// Relocate pool values that must survive this op out of
+			// the canned core's reach before it is pasted; every
+			// later consumer reads the updated loc. The reach differs
+			// per op — a plain PADDW touches only its X0/X1 inputs
+			// while the shuffle body scratches up to X5 — so scan the
+			// core for the highest register it mentions and move only
+			// what that range would corrupt. This runs after the
+			// input copies above: registers freed by this op's own
+			// consumption are dead by now and safe to hand out as
+			// relocation homes.
+			maxX := 1
+			for _, l := range core {
+				for _, m := range x64XRegRe.FindAllStringSubmatch(l, -1) {
+					if x, aerr := strconv.Atoi(m[1]); aerr == nil && x > maxX {
+						maxX = x
+					}
+				}
+			}
+			for j := range loc {
+				// pool < 4: not parked (chained through X0, inline
+				// scalar chain, or not yet emitted).
+				if loc[j].chained || loc[j].pool < 4 || loc[j].pool > maxX || uses[j] <= 0 {
+					continue
+				}
+				moved := -1
+				for k := range freePool {
+					if freePool[k] > maxX {
+						moved = freePool[k]
+						freePool = append(freePool[:k], freePool[k+1:]...)
+						break
+					}
+				}
+				if moved < 0 {
+					return nil, false, fmt.Errorf("fused splice %s: %w: no register outside canned scratch", tree.Name, errFusedCapacity)
+				}
+				x64VecCopy(b, moved, loc[j].pool)
+				freePool = append(freePool, loc[j].pool)
+				loc[j].pool = moved
 			}
 			for _, l := range core {
 				fmt.Fprintf(b, "\t%s\n", l)

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -335,10 +335,19 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 					src = loc[a.Index].pool
 				}
 			case simdfuse.ArgPairIn:
-				lo, hi := pairRegs(a)
-				fmt.Fprintf(b, "\tMOVQ %s, X1\n", lo)
-				fmt.Fprintf(b, "\tPINSRQ $1, %s, X1\n", hi)
-				src = 1
+				// A loop-carried pair lives in its reserved register
+				// across iterations (the tail writes it there); the
+				// incoming argument registers only hold the first
+				// iteration's value. Read the reserved register so
+				// later iterations see the accumulated value.
+				if cr, isCarried := carried[a.Index]; isCarried {
+					src = cr
+				} else {
+					lo, hi := pairRegs(a)
+					fmt.Fprintf(b, "\tMOVQ %s, X1\n", lo)
+					fmt.Fprintf(b, "\tPINSRQ $1, %s, X1\n", hi)
+					src = 1
+				}
 			default:
 				return nil, false, fmt.Errorf("fused splice %s: malformed %s args", tree.Name, n.Op)
 			}
@@ -427,9 +436,17 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 					}
 					x64VecCopy(b, dst, src.pool)
 				case simdfuse.ArgPairIn:
-					lo, hi := pairRegs(a)
-					fmt.Fprintf(b, "\tMOVQ %s, X%d\n", lo, dst)
-					fmt.Fprintf(b, "\tPINSRQ $1, %s, X%d\n", hi, dst)
+					// Loop-carried pair: copy from its reserved
+					// register (the tail wrote the running value
+					// there); only the first iteration's value ever
+					// reaches the argument registers.
+					if cr, isCarried := carried[a.Index]; isCarried {
+						x64VecCopy(b, dst, cr)
+					} else {
+						lo, hi := pairRegs(a)
+						fmt.Fprintf(b, "\tMOVQ %s, X%d\n", lo, dst)
+						fmt.Fprintf(b, "\tPINSRQ $1, %s, X%d\n", hi, dst)
+					}
 				}
 			}
 			if sArg != nil {

--- a/internal/gcasm/transform.go
+++ b/internal/gcasm/transform.go
@@ -778,9 +778,11 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 					var fbuf strings.Builder
 					spliced, wantsTrap, perr = x64SpliceLoop(&fbuf, lp, pool, opts.ModOffsets, fmt.Sprintf("%d", in.Off), maxOut)
 					if errors.Is(perr, errFusedCapacity) {
-						// Over-budget signature: keep the helper CALL —
-						// the captured helper body is always correct.
-						spliced, perr = false, nil
+						// Over-budget window: pair-form helpers cannot
+						// be marshalled as calls (their contract has no
+						// ABI0 shape), so the whole function keeps its
+						// pure Go body instead.
+						spliced, perr = false, errSimdPairUnspliced
 					}
 					if spliced {
 						b.WriteString(fbuf.String())
@@ -789,7 +791,7 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 					var fbuf strings.Builder
 					spliced, wantsTrap, perr = x64SpliceFused(&fbuf, tree, pool, opts.ModOffsets, maxOut)
 					if errors.Is(perr, errFusedCapacity) {
-						spliced, perr = false, nil
+						spliced, perr = false, errSimdPairUnspliced
 					}
 					if spliced {
 						b.WriteString(fbuf.String())


### PR DESCRIPTION
## Summary

Makes memory64 (and wasm32) bundles correct on `GOARCH=amd64`. Before this, m64 bundles generated garbage on amd64 (empty text on a tiny f32 model, `!` runs on qwen q8_0) while the identical bundles were fully correct on arm64. Two independent gcasm-amd64 defects, both in the fused-region splicer:

### 1. Fused-window register clobber

The x64 fused-region emitter parked live vector values in X4–X14, but 30 canned pair-table op bodies it pastes verbatim (`i8x16_shuffle`, the `trunc_sat` family, unsigned compares, min/max, …) use registers up to **X7** as scratch. A value parked in X4–X7 and still live when such a body was pasted was silently corrupted. The arm64 twin pools V16–V30 above its canned v0–v4 scratch and never had the problem; amd64 has no headroom above X14, so the emitter now scans each canned body for the highest register it mentions and relocates any live park above that reach before the paste. This was the catastrophic failure (RoPE rotate-windows hit it every decode).

### 2. Fused-loop carried accumulator read from the wrong register

A fused countdown loop keeps its carried accumulator in a reserved vector register (X14) written back at each backedge, but the emitter built the first block's accumulator operand from the pair's incoming **argument** registers — which hold only the first iteration's value. Every later iteration restarted the accumulator from the entry value, dropping the running sum past the first four blocks. The arm64 twin already reads the carried register for `ArgPairIn`; this ports that to both x64 pair-input sites. This is the q8_0 vec_dot numeric defect (NLL rel ~3e-2 on qwen; f32 models, which skip the pairing path, were unaffected).

Two adjacent build-robustness fixes came with #1: an over-budget fused window now takes the whole-function pure fallback instead of a broken call-marshal; and jump-table registrations are dropped when a function falls back, so the generated init's signature scan can't run off the text segment (was a SIGBUS at process start).

## Verification

Full go-llama suite against the llama.cpp wasm32 and memory64 modules (qwen2.5-0.5b q8_0 + stories260K):

| bundle | arch | before | after |
|---|---|---|---|
| memory64 | arm64 | pass | pass, **byte-identical** output |
| memory64 | amd64 (v1 & v2) | garbage / in-guest trap | **all pass** incl. native NLL + embedding parity |
| wasm32 | arm64 | pass | pass |
| wasm32 | amd64 (v2) | 26/30 (3 numeric-parity fails) | **all pass** |

- `go test ./...` all packages pass; `make lint` 0 issues.
- New unit tests pin: the relocation contract, capacity fallback, jump-table drop, and the loop-carry register read (the last fails on the pre-fix generator).
- Each defect was localized by bisecting the transform set to a single function and confirmed with an in-engine differential (transformed asm vs the pure Go body on the exact inputs the engine feeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
