### PR TITLE
gcasm: AVX2 8-bit dot selection for amd64 with runtime dispatch

### DIFF
--- a/internal/codegen/helpers/cpufeat_amd64.go
+++ b/internal/codegen/helpers/cpufeat_amd64.go
@@ -1,0 +1,39 @@
+//go:build amd64
+
+package helpers
+
+// HasAVX2 reports AVX2 support with OS-enabled YMM state. Feature-gated
+// splice bodies (the AVX2 8-bit dot kernels) dispatch on it at runtime;
+// the portable SSE twin body runs when it is false. The check mirrors
+// the standard three-step CPUID/XGETBV probe: OSXSAVE + AVX (leaf 1),
+// the OS actually saving XMM+YMM state (XCR0), and AVX2 (leaf 7).
+var HasAVX2 = detectAVX2()
+
+// cpuidAMD64 executes CPUID for the given leaf/subleaf.
+func cpuidAMD64(eax, ecx uint32) (a, b, c, d uint32)
+
+// xgetbvAMD64 reads the extended control register XCR0 (via XGETBV with
+// ECX=0), returning its low and high halves.
+func xgetbvAMD64() (lo, hi uint32)
+
+func detectAVX2() bool {
+	const (
+		osxsaveBit = 1 << 27 // CPUID.1:ECX.OSXSAVE
+		avxBit     = 1 << 28 // CPUID.1:ECX.AVX
+		avx2Bit    = 1 << 5  // CPUID.7.0:EBX.AVX2
+		xcr0YMM    = 1<<1 | 1<<2
+	)
+	maxLeaf, _, _, _ := cpuidAMD64(0, 0)
+	if maxLeaf < 7 {
+		return false
+	}
+	_, _, c1, _ := cpuidAMD64(1, 0)
+	if c1&osxsaveBit == 0 || c1&avxBit == 0 {
+		return false
+	}
+	if lo, _ := xgetbvAMD64(); lo&xcr0YMM != xcr0YMM {
+		return false
+	}
+	_, b7, _, _ := cpuidAMD64(7, 0)
+	return b7&avx2Bit != 0
+}

--- a/internal/codegen/helpers/cpufeat_amd64.go
+++ b/internal/codegen/helpers/cpufeat_amd64.go
@@ -2,12 +2,20 @@
 
 package helpers
 
-// HasAVX2 reports AVX2 support with OS-enabled YMM state. Feature-gated
-// splice bodies (the AVX2 8-bit dot kernels) dispatch on it at runtime;
-// the portable SSE twin body runs when it is false. The check mirrors
-// the standard three-step CPUID/XGETBV probe: OSXSAVE + AVX (leaf 1),
-// the OS actually saving XMM+YMM state (XCR0), and AVX2 (leaf 7).
+// HasAVX2 reports AVX2 (plus FMA and F16C, which every AVX2 CPU ever
+// shipped carries) with OS-enabled YMM state. Feature-gated splice
+// bodies — the AVX2 8-bit dot kernels and the fast-math 2x2 tile
+// kernel, which uses VCVTPH2PS and VFMADD — dispatch on it at
+// runtime; the portable SSE twin body runs when it is false. The
+// check mirrors the standard three-step CPUID/XGETBV probe: OSXSAVE +
+// AVX + FMA + F16C (leaf 1), the OS actually saving XMM+YMM state
+// (XCR0), and AVX2 (leaf 7).
 var HasAVX2 = detectAVX2()
+
+// HasAVX512VNNI reports AVX-512 VNNI usable at 256-bit width (VL) with
+// OS-enabled ZMM/opmask state — VPDPBUSD on ymm, the single-instruction
+// int8 dot product the fast-math tile kernel branches to at runtime.
+var HasAVX512VNNI = detectAVX512VNNI()
 
 // cpuidAMD64 executes CPUID for the given leaf/subleaf.
 func cpuidAMD64(eax, ecx uint32) (a, b, c, d uint32)
@@ -18,8 +26,10 @@ func xgetbvAMD64() (lo, hi uint32)
 
 func detectAVX2() bool {
 	const (
+		fmaBit     = 1 << 12 // CPUID.1:ECX.FMA
 		osxsaveBit = 1 << 27 // CPUID.1:ECX.OSXSAVE
 		avxBit     = 1 << 28 // CPUID.1:ECX.AVX
+		f16cBit    = 1 << 29 // CPUID.1:ECX.F16C
 		avx2Bit    = 1 << 5  // CPUID.7.0:EBX.AVX2
 		xcr0YMM    = 1<<1 | 1<<2
 	)
@@ -28,7 +38,7 @@ func detectAVX2() bool {
 		return false
 	}
 	_, _, c1, _ := cpuidAMD64(1, 0)
-	if c1&osxsaveBit == 0 || c1&avxBit == 0 {
+	if c1&osxsaveBit == 0 || c1&avxBit == 0 || c1&fmaBit == 0 || c1&f16cBit == 0 {
 		return false
 	}
 	if lo, _ := xgetbvAMD64(); lo&xcr0YMM != xcr0YMM {
@@ -36,4 +46,31 @@ func detectAVX2() bool {
 	}
 	_, b7, _, _ := cpuidAMD64(7, 0)
 	return b7&avx2Bit != 0
+}
+
+func detectAVX512VNNI() bool {
+	const (
+		osxsaveBit  = 1 << 27 // CPUID.1:ECX.OSXSAVE
+		avx512fBit  = 1 << 16 // CPUID.7.0:EBX.AVX512F
+		avx512bwBit = 1 << 30 // CPUID.7.0:EBX.AVX512BW
+		avx512vlBit = 1 << 31 // CPUID.7.0:EBX.AVX512VL
+		vnniBit     = 1 << 11 // CPUID.7.0:ECX.AVX512_VNNI
+		// XCR0: SSE+YMM plus the AVX-512 opmask/upper-ZMM/hi16-ZMM state.
+		xcr0AVX512 = 1<<1 | 1<<2 | 1<<5 | 1<<6 | 1<<7
+	)
+	if !HasAVX2 {
+		return false
+	}
+	_, _, c1, _ := cpuidAMD64(1, 0)
+	if c1&osxsaveBit == 0 {
+		return false
+	}
+	if lo, _ := xgetbvAMD64(); lo&xcr0AVX512 != xcr0AVX512 {
+		return false
+	}
+	_, b7, c7, _ := cpuidAMD64(7, 0)
+	if b7&avx512fBit == 0 || b7&avx512bwBit == 0 || b7&avx512vlBit == 0 {
+		return false
+	}
+	return c7&vnniBit != 0
 }

--- a/internal/codegen/helpers/cpufeat_amd64.s
+++ b/internal/codegen/helpers/cpufeat_amd64.s
@@ -1,0 +1,22 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// func cpuidAMD64(eax, ecx uint32) (a, b, c, d uint32)
+TEXT ·cpuidAMD64(SB), NOSPLIT, $0-24
+	MOVL eax+0(FP), AX
+	MOVL ecx+4(FP), CX
+	CPUID
+	MOVL AX, a+8(FP)
+	MOVL BX, b+12(FP)
+	MOVL CX, c+16(FP)
+	MOVL DX, d+20(FP)
+	RET
+
+// func xgetbvAMD64() (lo, hi uint32)
+TEXT ·xgetbvAMD64(SB), NOSPLIT, $0-8
+	MOVL $0, CX
+	XGETBV
+	MOVL AX, lo+0(FP)
+	MOVL DX, hi+4(FP)
+	RET

--- a/internal/codegen/simd_files.go
+++ b/internal/codegen/simd_files.go
@@ -50,6 +50,12 @@ var cpufeatArm64OtherSrc string
 //go:embed helpers/simd_asm_amd64.s
 var simdAsmAmd64Src string
 
+//go:embed helpers/cpufeat_amd64.go
+var cpufeatAmd64Src string
+
+//go:embed helpers/cpufeat_amd64.s
+var cpufeatAmd64AsmSrc string
+
 // appendSimdHelperFiles adds the SIMD helper files to the output tree when
 // the module uses any SIMD helper. In multi-package mode the entry points
 // are exported (simd_ → Simd_) to match helperRef's capitalized cross-
@@ -88,4 +94,6 @@ func (t *translator) appendSimdHelperFiles(files map[string][]byte) {
 	files[dir+"cpufeat_arm64_darwin.go"] = goFile(cpufeatArm64DarwinSrc)
 	files[dir+"cpufeat_arm64_linux.go"] = goFile(cpufeatArm64LinuxSrc)
 	files[dir+"cpufeat_arm64_other.go"] = goFile(cpufeatArm64OtherSrc)
+	files[dir+"cpufeat_amd64.go"] = goFile(cpufeatAmd64Src)
+	files[dir+"cpufeat_amd64.s"] = asmFile(cpufeatAmd64AsmSrc)
 }

--- a/internal/codegen/simd_files_probe_test.go
+++ b/internal/codegen/simd_files_probe_test.go
@@ -1,0 +1,14 @@
+package codegen
+
+import "testing"
+
+func TestSimdHelperFileSetIncludesAmd64CPUFeat(t *testing.T) {
+	tr := &translator{usesSimd: true}
+	files := map[string][]byte{}
+	tr.appendSimdHelperFiles(files)
+	for _, want := range []string{"cpufeat_amd64.go", "cpufeat_amd64.s", "cpufeat_arm64_linux.go"} {
+		if _, ok := files[want]; !ok {
+			t.Errorf("missing %s; got %d files", want, len(files))
+		}
+	}
+}

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -851,7 +851,7 @@ func buildPkg(
 			// backend keep the bit-exact Go companion. The kernel and
 			// its declaration follow the module's pointer width — the
 			// LP64 companion takes i64 pointers and strides.
-			if nrc2 != nil && name == nrc2.VecDot && arch.name == "arm64" && modOffs != nil && modOffs.Cfg.FastMath {
+			if nrc2 != nil && name == nrc2.VecDot && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {
 				fastSym := nrc2.Companion + "fast"
 				retargeted := strings.ReplaceAll(featBody, "·"+nrc2.Companion+"(SB)", "·"+fastSym+"(SB)")
 				if retargeted == featBody {
@@ -863,7 +863,22 @@ func buildPkg(
 					trapSym = "gcasmFwdH_base_Wasm_trap_simd_oob"
 				}
 				wide := mod.Memory64()
-				asmB.WriteString(a64Nrc2Kernel(fastSym, trapSym, modOffs, wide))
+				if arch.name == "amd64" {
+					asmB.WriteString(x64Nrc2Kernel(fastSym, trapSym, modOffs, wide))
+					// The kernel branches to its VNNI loop on a
+					// package-local mirror of the base feature var
+					// (asm reads package-local data only).
+					if !mirrorVars["gcasmHasAVX512VNNI"] {
+						mirrorVars["gcasmHasAVX512VNNI"] = true
+						vnniRef := "HasAVX512VNNI"
+						if rel != "" && rel != "base" {
+							vnniRef = "base." + vnniRef
+						}
+						fmt.Fprintf(&declFns, "// gcasmHasAVX512VNNI mirrors %s for the tile kernel's\n// entry branch (asm reads package-local data only).\nvar gcasmHasAVX512VNNI = %s\n\n", vnniRef, vnniRef)
+					}
+				} else {
+					asmB.WriteString(a64Nrc2Kernel(fastSym, trapSym, modOffs, wide))
+				}
 				asmB.WriteString("\n")
 				argType := "int32"
 				if wide {

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -348,10 +348,14 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	// so the pure guards stay `!amd64 && !arm64` (the pure fallback for
 	// other arches + the `-tags purego` escape).
 	for name, data := range all {
-		if strings.HasPrefix(filepath.Base(name), "simd_") {
+		if base := filepath.Base(name); strings.HasPrefix(base, "simd_") || strings.HasPrefix(base, "cpufeat_") {
 			// The SIMD helper set (scalar reference + its own per-arch
-			// asm + fallback aliases) is arch-complete on its own and
-			// independent of the gcasm bundle — leave it untouched.
+			// asm + fallback aliases) and the CPU feature detection are
+			// arch-complete on their own and independent of the gcasm
+			// bundle — leave them untouched. In particular the
+			// feature-dispatch stubs read base.HasAVX2/CPUDotProd, so
+			// deleting cpufeat_amd64.go with the own-backend amd64
+			// decls would break the bundle build.
 			continue
 		}
 		switch {
@@ -551,10 +555,26 @@ var archSpecs = []archSpec{
 	// amd64 requires x86-64-v2: the SIMD splices use SSE4.1
 	// (PINSRQ/PEXTRQ/PMOVSX...), same baseline as the helper asm.
 	// GOAMD64=v1 builds compile the pure tree instead.
-	{name: "amd64", buildTag: "amd64 && amd64.v2", transform: Transform, jtMarker: "_jt"},
+	{name: "amd64", buildTag: "amd64 && amd64.v2", transform: Transform, jtMarker: "_jt",
+		gatedMarker: "// avx2 dot", gatedSuffix: "avx2", portableSuffix: "sse",
+		featureVar: "HasAVX2", dispatchStub: x64DispatchStub},
 	{name: "arm64", buildTag: "arm64", transform: TransformARM64, jtMarker: "_jt",
 		gatedMarker: "// sdot v", gatedSuffix: "dotprod", portableSuffix: "generic",
 		featureVar: "CPUDotProd", dispatchStub: a64DispatchStub},
+}
+
+// x64DispatchStub is the amd64 feature-dispatch stub: compare the mirror
+// bool against 0 and tail-jump to the portable SSE twin when it is
+// clear, else to the AVX2 body. The compare reads memory and sets flags
+// only — no register is touched — so the tail targets see the original
+// caller's ABIInternal argument registers intact. Same frame ($0), one
+// predicted branch.
+func x64DispatchStub(sym, featSym, portSym, mirrorVar, argBytes string) string {
+	return "TEXT ·" + sym + "(SB), NOSPLIT, $0-" + argBytes + "\n" +
+		"\tCMPB ·" + mirrorVar + "(SB), $0\n" +
+		"\tJEQ 2(PC)\n" +
+		"\tJMP ·" + featSym + "(SB)\n" +
+		"\tJMP ·" + portSym + "(SB)\n"
 }
 
 // a64DispatchStub is the arm64 feature-dispatch stub: read the mirror

--- a/internal/gcasm/nrc2kernel_x64.go
+++ b/internal/gcasm/nrc2kernel_x64.go
@@ -1,0 +1,217 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// x64Nrc2Kernel emits the q8_0 2x2 tile kernel under sym for amd64,
+// with an entry-time branch to a VNNI loop (VPDPBUSD, the
+// single-instruction int8 dot; s8*s8 via the exact +128 bias identity)
+// on CPUs reporting AVX-512 VNNI at 256-bit width —
+// the AVX2 analog of a64Nrc2Kernel. Per 34-byte block the four quant
+// vectors (rows x0/x1, columns y0/y1) load ONCE and feed all four dot
+// products: sign-extend each 32-byte vector into two i16x16 ymm
+// halves, VPMADDWD the four row/column pairs, and collapse the four
+// i32x8 sums into one xmm holding the 2x2 tile [x0y0, x0y1, x1y0,
+// x1y1] with three VPHADDD and a 128-fold — the AVX2 stand-in for
+// SMMLA. The four f16 d scales gather through VPINSRW, convert with
+// VCVTPH2PS (F16C), spread into the matching product matrix with two
+// VPERMILPS, and accumulate via VFMADD231PS.
+//
+// The body is entirely VEX-encoded; ymm uppers are cleared with
+// VZEROUPPER on every exit path (Intel dirty-upper false dependencies
+// serialize legacy-SSE callers otherwise). Like the arm64 kernel this
+// regroups float accumulation (FMA, single rounding), so the retarget
+// is fast-math-only; the integer tile itself is exact. Callers gate on
+// HasAVX2, whose detection also requires FMA and F16C.
+//
+// ABI0 stack args mirror the Go companion. ILP32: m+0, l0(n)+8,
+// l1(s)+12, l2(bs, floats)+16, l3(x)+20, l4(bx)+24, l5(y)+28,
+// l6(by)+32. LP64 (memory64): l1..l6 are int64, 8-aligned — l0+8,
+// l1+16 .. l6+56. Results: s[0]=x0y0 s[1]=x1y0 s[bs]=x0y1 s[bs+1]=x1y1.
+func x64Nrc2Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+
+	argOff := map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}
+	movArg, argBytes := "MOVL", 36
+	if wide {
+		argOff = map[string]int{"l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 56}
+		movArg, argBytes = "MOVQ", 64
+	}
+	arg := func(name, reg string) {
+		w("\t%s\t%s+%d(FP), %s", movArg, name, argOff[name], reg)
+	}
+	// bounds emits: trap when memSize (R15) < end (endReg).
+	bounds := func(endReg string) {
+		w("\tCMPQ\tR15, %s", endReg)
+		w("\tJCS\tnrc2x64oob")
+	}
+
+	w("// %s: q8_0 vec_dot 2x2 tile (rows x0/x1, cols y0/y1) via AVX2.", sym)
+	w("TEXT ·%s(SB), $8-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R15", offs.MemSize)
+	w("\tMOVQ\t(R15), R15")
+	w("\tMOVQ\t%d(AX), R14", offs.M)
+	w("\tMOVL\tl0+8(FP), R8")
+	w("\tSHRL\t$5, R8")
+	// span = nb*34 = nb*32 + nb*2
+	w("\tMOVQ\tR8, R9")
+	w("\tSHLQ\t$5, R9")
+	w("\tLEAQ\t(R9)(R8*2), R9")
+	// x0 / x1 spans against memSize
+	arg("l3", "BX")
+	w("\tLEAQ\t(BX)(R9*1), CX")
+	bounds("CX")
+	arg("l4", "DX")
+	w("\tADDQ\tBX, DX") // x1 base = l3 + l4
+	w("\tLEAQ\t(DX)(R9*1), CX")
+	bounds("CX")
+	// y0 / y1 spans
+	arg("l5", "SI")
+	w("\tLEAQ\t(SI)(R9*1), CX")
+	bounds("CX")
+	arg("l6", "DI")
+	w("\tADDQ\tSI, DI") // y1 base = l5 + l6
+	w("\tLEAQ\t(DI)(R9*1), CX")
+	bounds("CX")
+	// s spans: col0 [s, s+8), col1 [s+bs*4, s+bs*4+8)
+	arg("l1", "R12")
+	arg("l2", "R13")
+	w("\tSHLQ\t$2, R13")
+	w("\tLEAQ\t8(R12), CX")
+	bounds("CX")
+	w("\tLEAQ\t8(R12)(R13*1), CX")
+	bounds("CX")
+	// quant cursors: +2 past each block base (the f16 d scale sits at -2)
+	w("\tLEAQ\t2(R14)(BX*1), BX")
+	w("\tLEAQ\t2(R14)(DX*1), DX")
+	w("\tLEAQ\t2(R14)(SI*1), SI")
+	w("\tLEAQ\t2(R14)(DI*1), DI")
+	w("\tVXORPS\tX8, X8, X8") // f32x4 tile accumulator
+	w("\tTESTL\tR8, R8")
+	w("\tJZ\tnrc2x64done")
+	// tileTail emits the shared per-block finish: collapse the four
+	// i32x8 sums (S00=Y13 S01=Y14 S10=Y15 S11=Y0) to the 2x2 tile in
+	// one xmm, apply the f16 d-scale product matrix, FMA into the
+	// accumulator, and advance the cursors.
+	tileTail := func(loop string) {
+		w("\tVPHADDD\tY14, Y13, Y1")
+		w("\tVPHADDD\tY0, Y15, Y2")
+		w("\tVPHADDD\tY2, Y1, Y1")
+		w("\tVEXTRACTI128\t$1, Y1, X2")
+		w("\tVPADDD\tX2, X1, X1")
+		w("\tVCVTDQ2PS\tX1, X1")
+		// Scales: [dx0, dx1, dy0, dy1] f16 -> f32, spread into the
+		// product matrix [dx0dy0, dx0dy1, dx1dy0, dx1dy1] matching the
+		// tile lanes.
+		w("\tVPINSRW\t$0, -2(BX), X2, X2")
+		w("\tVPINSRW\t$1, -2(DX), X2, X2")
+		w("\tVPINSRW\t$2, -2(SI), X2, X2")
+		w("\tVPINSRW\t$3, -2(DI), X2, X2")
+		w("\tVCVTPH2PS\tX2, X2")
+		w("\tVPERMILPS\t$0x50, X2, X3") // [dx0, dx0, dx1, dx1]
+		w("\tVPERMILPS\t$0xEE, X2, X2") // [dy0, dy1, dy0, dy1]
+		w("\tVMULPS\tX2, X3, X2")
+		w("\tVFMADD231PS\tX2, X1, X8") // acc += tile * scales
+		w("\tADDQ\t$34, BX")
+		w("\tADDQ\t$34, DX")
+		w("\tADDQ\t$34, SI")
+		w("\tADDQ\t$34, DI")
+		w("\tSUBL\t$1, R8")
+		w("\tJNZ\t%s", loop)
+		w("\tJMP\tnrc2x64done")
+	}
+	// Three of the four runner-pool CPU families carry AVX-512 VNNI at
+	// 256-bit width (VL): VPDPBUSD is the single-instruction int8 dot
+	// (the amd64 SDOT). One entry branch picks the loop; the s8*s8
+	// products ride the exact bias identity
+	// dot(x, y) = dot_u8s8(x^0x80, y) - 128*sum(y).
+	w("\tCMPB\t·gcasmHasAVX512VNNI(SB), $0")
+	w("\tJNE\tnrc2x64vnni")
+	w("nrc2x64loop:")
+	// Load the four 32-byte quant vectors once.
+	w("\tVMOVDQU\t(BX), Y0")
+	w("\tVMOVDQU\t(DX), Y1")
+	w("\tVMOVDQU\t(SI), Y2")
+	w("\tVMOVDQU\t(DI), Y3")
+	// Sign-extend each into low/high i16x16 halves.
+	w("\tVPMOVSXBW\tX0, Y4") // x0 lo
+	w("\tVEXTRACTI128\t$1, Y0, X5")
+	w("\tVPMOVSXBW\tX5, Y5") // x0 hi
+	w("\tVPMOVSXBW\tX1, Y6") // x1 lo
+	w("\tVEXTRACTI128\t$1, Y1, X7")
+	w("\tVPMOVSXBW\tX7, Y7") // x1 hi
+	w("\tVPMOVSXBW\tX2, Y9") // y0 lo
+	w("\tVEXTRACTI128\t$1, Y2, X10")
+	w("\tVPMOVSXBW\tX10, Y10") // y0 hi
+	w("\tVPMOVSXBW\tX3, Y11")  // y1 lo
+	w("\tVEXTRACTI128\t$1, Y3, X12")
+	w("\tVPMOVSXBW\tX12, Y12") // y1 hi
+	// Four dot products, each summing both halves.
+	w("\tVPMADDWD\tY9, Y4, Y13")
+	w("\tVPMADDWD\tY10, Y5, Y14")
+	w("\tVPADDD\tY14, Y13, Y13") // S00
+	w("\tVPMADDWD\tY11, Y4, Y14")
+	w("\tVPMADDWD\tY12, Y5, Y15")
+	w("\tVPADDD\tY15, Y14, Y14") // S01
+	w("\tVPMADDWD\tY9, Y6, Y15")
+	w("\tVPMADDWD\tY10, Y7, Y0")
+	w("\tVPADDD\tY0, Y15, Y15") // S10
+	w("\tVPMADDWD\tY11, Y6, Y0")
+	w("\tVPMADDWD\tY12, Y7, Y1")
+	w("\tVPADDD\tY1, Y0, Y0") // S11
+	tileTail("nrc2x64loop")
+	// VNNI loop: constants — u8 ones for sum(y), 0x80 bytes for the
+	// sign-flip bias (0x01010101 << 7 per 32-bit lane = 0x80808080).
+	w("nrc2x64vnni:")
+	w("\tVPCMPEQD\tY4, Y4, Y4")
+	w("\tVPABSB\tY4, Y4")     // 0x01 bytes
+	w("\tVPSLLD\t$7, Y4, Y5") // 0x80 bytes
+	w("nrc2x64vnniloop:")
+	w("\tVMOVDQU\t(BX), Y0")
+	w("\tVMOVDQU\t(DX), Y1")
+	w("\tVMOVDQU\t(SI), Y2")
+	w("\tVMOVDQU\t(DI), Y3")
+	w("\tVPXOR\tY5, Y0, Y0") // x0 + 128 as u8
+	w("\tVPXOR\tY5, Y1, Y1") // x1 + 128 as u8
+	// Per-4-byte-group sums of y0/y1 (for the bias correction).
+	w("\tVPXOR\tY6, Y6, Y6")
+	w("\tVPDPBUSD\tY2, Y4, Y6") // sum y0
+	w("\tVPXOR\tY7, Y7, Y7")
+	w("\tVPDPBUSD\tY3, Y4, Y7") // sum y1
+	w("\tVPSLLD\t$7, Y6, Y6")   // 128*sum(y0)
+	w("\tVPSLLD\t$7, Y7, Y7")   // 128*sum(y1)
+	// The four u8*s8 dots, then subtract the bias.
+	w("\tVPXOR\tY13, Y13, Y13")
+	w("\tVPDPBUSD\tY2, Y0, Y13")
+	w("\tVPSUBD\tY6, Y13, Y13") // S00
+	w("\tVPXOR\tY14, Y14, Y14")
+	w("\tVPDPBUSD\tY3, Y0, Y14")
+	w("\tVPSUBD\tY7, Y14, Y14") // S01
+	w("\tVPXOR\tY15, Y15, Y15")
+	w("\tVPDPBUSD\tY2, Y1, Y15")
+	w("\tVPSUBD\tY6, Y15, Y15") // S10
+	w("\tVPXOR\tY0, Y0, Y0")
+	w("\tVPDPBUSD\tY3, Y1, Y0")
+	w("\tVPSUBD\tY7, Y0, Y0") // S11
+	tileTail("nrc2x64vnniloop")
+	w("nrc2x64done:")
+	// acc lanes [x0y0, x0y1, x1y0, x1y1]:
+	// s[0]=lane0, s[1]=lane2, s[bs]=lane1, s[bs+1]=lane3.
+	w("\tLEAQ\t(R12)(R13*1), CX")
+	w("\tVEXTRACTPS\t$0, X8, (R14)(R12*1)")
+	w("\tVEXTRACTPS\t$2, X8, 4(R14)(R12*1)")
+	w("\tVEXTRACTPS\t$1, X8, (R14)(CX*1)")
+	w("\tVEXTRACTPS\t$3, X8, 4(R14)(CX*1)")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("nrc2x64oob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/nrc2kernel_x64_test.go
+++ b/internal/gcasm/nrc2kernel_x64_test.go
@@ -1,0 +1,86 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestX64Nrc2KernelShape(t *testing.T) {
+	body := x64Nrc2Kernel("Fn9nrc2fast", "gcasmFwdH_base_Wasm_trap_simd_oob", &ModuleOffsets{M: 32, MemSize: 1152}, true)
+	for _, want := range []string{
+		"TEXT ·Fn9nrc2fast(SB), $8-64",
+		"MOVQ\t1152(AX), R15",
+		"MOVQ\t32(AX), R14",
+		// The four shared quant loads and the 2x2 tile collapse.
+		"VMOVDQU\t(BX), Y0",
+		"VPHADDD\tY2, Y1, Y1",
+		"VCVTDQ2PS\tX1, X1",
+		// f16 scale gather + F16C conversion + FMA accumulate.
+		"VCVTPH2PS\tX2, X2",
+		"VFMADD231PS\tX2, X1, X8",
+		// Both result columns store through the bs stride.
+		"VEXTRACTPS\t$0, X8, (R14)(R12*1)",
+		"VEXTRACTPS\t$3, X8, 4(R14)(CX*1)",
+		"CALL\t·gcasmFwdH_base_Wasm_trap_simd_oob(SB)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("kernel missing %q", want)
+		}
+	}
+	if got := strings.Count(body, "VPMADDWD"); got != 8 {
+		t.Errorf("VPMADDWD count = %d, want 8 (four dots, two halves each)", got)
+	}
+	if got := strings.Count(body, "VMOVDQU"); got != 8 {
+		t.Errorf("quant loads = %d, want 8 (four per loop, AVX2 and VNNI)", got)
+	}
+	// The VNNI loop: entry branch on the mirror var, six VPDPBUSD per
+	// block (two bias sums + four dots).
+	if !strings.Contains(body, "CMPB\t·gcasmHasAVX512VNNI(SB), $0") {
+		t.Error("kernel missing the VNNI entry branch")
+	}
+	if got := strings.Count(body, "VPDPBUSD"); got != 6 {
+		t.Errorf("VPDPBUSD count = %d, want 6", got)
+	}
+	// Every exit clears the ymm upper state (Intel false-dep hazard).
+	if got := strings.Count(body, "VZEROUPPER"); got != 2 {
+		t.Errorf("VZEROUPPER count = %d, want 2 (done + trap paths)", got)
+	}
+	// The bounds prologue guards all six spans.
+	if got := strings.Count(body, "JCS\tnrc2x64oob"); got != 6 {
+		t.Errorf("bounds checks = %d, want 6", got)
+	}
+	// The narrow (wasm32) variant assembles the ILP32 argument layout.
+	narrow := x64Nrc2Kernel("Fn9nrc2fast", "trap", &ModuleOffsets{M: 32, MemSize: 1152}, false)
+	if !strings.Contains(narrow, "TEXT ·Fn9nrc2fast(SB), $8-36") || !strings.Contains(narrow, "MOVL\tl1+12(FP)") {
+		t.Errorf("narrow variant lost the ILP32 layout:\n%s", narrow[:400])
+	}
+}
+
+// TestX64Nrc2KernelAssembles feeds the emitted kernel through the real
+// Go assembler for amd64 — the mnemonic/operand forms (VPHADDD,
+// VCVTPH2PS, VFMADD231PS, VEXTRACTPS with indexed memory operands)
+// must all be accepted.
+func TestX64Nrc2KernelAssembles(t *testing.T) {
+	dir := t.TempDir()
+	body := x64Nrc2Kernel("Fn9nrc2fast", "trapstub", &ModuleOffsets{M: 32, MemSize: 1152}, true)
+	asm := "#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + body + "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tRET\n"
+	if err := os.WriteFile(filepath.Join(dir, "k_amd64.s"), []byte(asm), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSrc := "package main\n\nvar gcasmHasAVX512VNNI bool\n\nfunc Fn9nrc2fast(m *int64, l0 int32, l1, l2, l3, l4, l5, l6 int64)\nfunc trapstub()\nfunc main() { _ = gcasmHasAVX512VNNI; _ = Fn9nrc2fast; _ = trapstub }\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(goSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module kcheck\n\ngo 1.25.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", os.DevNull, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "GOAMD64=v2")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("kernel does not assemble: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_dot8_x64.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64.go
@@ -1,0 +1,326 @@
+package gcasm
+
+import (
+	"github.com/goccy/wasm2go/internal/simdfuse"
+)
+
+// AVX2 8-bit dot selection (amd64).
+//
+// The quantized integer kernels compute, per 16-byte chunk, the two
+// half dots
+//
+//	dot(extend_low_i8x16_s(a),  extend_low_i8x16_s(b))
+//	dot(extend_high_i8x16_s(a), extend_high_i8x16_s(b))
+//
+// and sum them into an i32x4 accumulator chain. The SSE baseline
+// lowers each half literally (~9 xmm ops per chunk). AVX2 does the
+// whole chunk in one 256-bit pass: VPMOVSXBW sign-extends all 16
+// bytes of a (and of b) into a ymm of 16 i16 lanes, VPMADDWD
+// multiplies and pair-adds them into 8 i32 lanes — lanes 0..3 are
+// exactly the low-half dot, lanes 4..7 the high-half — and
+// VEXTRACTI128 + VPADDD fold the high 128 onto the low 128. int8*int8
+// fits i16 and the pair sums fit i32, so no lane saturates; i32
+// addition is associative, so re-grouping the chain's adds is
+// bit-identical to the literal lowering. Five ops replace nine.
+//
+// The two halves of a chunk are NOT always direct siblings under one
+// add: the unrolled kernels emit left-leaning chains where a chunk's
+// low and high dots join the accumulator spine separately
+// (add(add(prev, dot_high_B), dot_low_B)). So, like the arm64
+// a64Dot8FlattenAdds, the rewrite walks each maximal i32x4_add tree
+// whose leaves are all eligible half dots, pairs the leaves by their
+// byte-source pair (one low + one high over the same (a, b)), and
+// rebuilds the chain over the paired block dots plus any unpaired
+// half dots left literal.
+//
+// The rewrite runs on a local copy of the tree at splice time; every
+// absorbed node becomes a no-op placeholder (a64OpElided) so node
+// indices stay stable for roots and loop-carried bookkeeping.
+// portable (the baseline-ISA twin body) suppresses it, so a non-AVX2
+// host runs the literal SSE path.
+const (
+	// x64OpBlockDot(a, b): the full 16-byte signed 8-bit dot of two
+	// byte vectors — four i32 lanes, each the sum of its four byte
+	// products (the value of dot_low + dot_high for the chunk).
+	x64OpBlockDot = "i32x4_blockdot8_avx2"
+)
+
+// x64Dot8Src reports whether a byte source can feed the synthetic
+// block dot directly: a member's register-resident result or a pair
+// input (mirrors a64Dot8Src).
+func x64Dot8Src(a simdfuse.Arg) bool {
+	return a.Kind == simdfuse.ArgNode || a.Kind == simdfuse.ArgPairIn
+}
+
+// x64HalfDot describes one eligible half dot: an i32x4_dot_i16x8_s
+// whose operands are both extend_low (high=false) or both extend_high
+// (high=true) of register-readable byte sources.
+type x64HalfDot struct {
+	dot        int // the dot node
+	e0, e1     int // the two extend nodes it consumes
+	srcA, srcB simdfuse.Arg
+	high       bool
+}
+
+// x64ClassifyHalfDot classifies node k, requiring the extends to exist
+// solely for this dot (single use, not a region result).
+func x64ClassifyHalfDot(nodes []simdfuse.Node, uses []int, isRoot []bool, k int) (x64HalfDot, bool) {
+	n := &nodes[k]
+	if n.Op != "i32x4_dot_i16x8_s" || len(n.Args) != 2 {
+		return x64HalfDot{}, false
+	}
+	a0, a1 := n.Args[0], n.Args[1]
+	if a0.Kind != simdfuse.ArgNode || a1.Kind != simdfuse.ArgNode || a0.Index == a1.Index {
+		return x64HalfDot{}, false
+	}
+	e0, e1 := &nodes[a0.Index], &nodes[a1.Index]
+	var high bool
+	switch {
+	case e0.Op == "i16x8_extend_low_i8x16_s" && e1.Op == "i16x8_extend_low_i8x16_s":
+		high = false
+	case e0.Op == "i16x8_extend_high_i8x16_s" && e1.Op == "i16x8_extend_high_i8x16_s":
+		high = true
+	default:
+		return x64HalfDot{}, false
+	}
+	if uses[a0.Index] != 1 || uses[a1.Index] != 1 || isRoot[a0.Index] || isRoot[a1.Index] {
+		return x64HalfDot{}, false
+	}
+	if len(e0.Args) != 1 || len(e1.Args) != 1 || !x64Dot8Src(e0.Args[0]) || !x64Dot8Src(e1.Args[0]) {
+		return x64HalfDot{}, false
+	}
+	return x64HalfDot{dot: k, e0: a0.Index, e1: a1.Index, srcA: e0.Args[0], srcB: e1.Args[0], high: high}, true
+}
+
+// x64SrcKey is a comparable byte-source pair identity.
+type x64SrcKey struct {
+	ka, kb simdfuse.ArgKind
+	ia, ib int
+}
+
+func x64KeyOf(h x64HalfDot) x64SrcKey {
+	return x64SrcKey{ka: h.srcA.Kind, ia: h.srcA.Index, kb: h.srcB.Kind, ib: h.srcB.Index}
+}
+
+// x64Dot8Rewrite returns the tree with chunk half-dot pairs collapsed
+// into synthetic AVX2 block dots, and reports whether it rewrote
+// anything (the caller emits one VZEROUPPER when it did). The tree is
+// returned unchanged when nothing matches or portable suppresses the
+// upgrade.
+func x64Dot8Rewrite(tree *simdfuse.Tree, portable bool) (*simdfuse.Tree, bool) {
+	if portable {
+		return tree, false
+	}
+	uses := make([]int, len(tree.Nodes))
+	for _, n := range tree.Nodes {
+		for _, a := range n.Args {
+			if a.Kind == simdfuse.ArgNode {
+				uses[a.Index]++
+			}
+		}
+	}
+	isRoot := make([]bool, len(tree.Nodes))
+	for _, r := range tree.RootList() {
+		isRoot[r] = true
+	}
+	nodes := append([]simdfuse.Node(nil), tree.Nodes...)
+	consumed := make([]bool, len(nodes))
+	rewrote := false
+	// Walk tops in DESCENDING index so each maximal add tree is claimed
+	// from its outermost add (mirrors a64Dot8FlattenAdds).
+	for t := len(nodes) - 1; t >= 0; t-- {
+		if consumed[t] || !isAddAny(nodes, t) {
+			continue
+		}
+		var leaves []x64HalfDot
+		var adds []int
+		// The chain may carry AT MOST ONE non-dot value — the running
+		// accumulator (a loop-carried pair input, or any prior node) the
+		// kernels fold each chunk into. It rides the rebuilt chain like
+		// any other leaf; i32 adds are associative, so its position is
+		// free.
+		var extra []simdfuse.Arg
+		ok := true
+		var walk func(a simdfuse.Arg)
+		walk = func(a simdfuse.Arg) {
+			if !ok {
+				return
+			}
+			if a.Kind == simdfuse.ArgNode {
+				i := a.Index
+				if isAddAny(nodes, i) && i != t && uses[i] == 1 && !isRoot[i] && !consumed[i] {
+					adds = append(adds, i)
+					walk(nodes[i].Args[0])
+					walk(nodes[i].Args[1])
+					return
+				}
+				if h, hok := x64ClassifyHalfDot(nodes, uses, isRoot, i); hok && uses[i] == 1 && !isRoot[i] {
+					leaves = append(leaves, h)
+					return
+				}
+			}
+			// Non-dot leaf (accumulator or anything else): one allowed.
+			if len(extra) == 0 {
+				extra = append(extra, a)
+				return
+			}
+			ok = false
+		}
+		adds = append(adds, t)
+		walk(nodes[t].Args[0])
+		walk(nodes[t].Args[1])
+		if !ok || len(leaves) < 2 || len(adds) != len(leaves)+len(extra)-1 {
+			continue
+		}
+		// Pair one low with one high per byte-source pair.
+		lows := map[x64SrcKey][]int{} // leaf index in leaves
+		highs := map[x64SrcKey][]int{}
+		for li, h := range leaves {
+			if h.high {
+				highs[x64KeyOf(h)] = append(highs[x64KeyOf(h)], li)
+			} else {
+				lows[x64KeyOf(h)] = append(lows[x64KeyOf(h)], li)
+			}
+		}
+		type pair struct{ low, high x64HalfDot }
+		var pairs []pair
+		paired := make([]bool, len(leaves))
+		for k, ls := range lows {
+			hs := highs[k]
+			for len(ls) > 0 && len(hs) > 0 {
+				pairs = append(pairs, pair{low: leaves[ls[0]], high: leaves[hs[0]]})
+				paired[ls[0]], paired[hs[0]] = true, true
+				ls, hs = ls[1:], hs[1:]
+			}
+		}
+		if len(pairs) == 0 {
+			continue
+		}
+		// The rebuilt chain's values: each pair's block dot lives in the
+		// lower-indexed dot slot (its byte sources index below both
+		// dots); unpaired half dots stay literal; the extra leaf (the
+		// accumulator) rides along as-is.
+		var newLeaves []simdfuse.Arg
+		for _, p := range pairs {
+			bd := p.low.dot
+			if p.high.dot < bd {
+				bd = p.high.dot
+			}
+			newLeaves = append(newLeaves, simdfuse.Arg{Kind: simdfuse.ArgNode, Index: bd})
+		}
+		for li, h := range leaves {
+			if !paired[li] {
+				newLeaves = append(newLeaves, simdfuse.Arg{Kind: simdfuse.ArgNode, Index: h.dot})
+			}
+		}
+		newLeaves = append(newLeaves, extra...)
+		// Order by node index (non-node leaves first: they have no
+		// position constraint).
+		sortArgsByIndex(newLeaves)
+		sortInts(adds)
+		// availableAt reports whether arg a may be referenced from a
+		// chain node at index slot (post-order: node args index below).
+		availableAt := func(a simdfuse.Arg, slot int) bool {
+			return a.Kind != simdfuse.ArgNode || a.Index < slot
+		}
+		if len(newLeaves) == 1 {
+			// Single pair, nothing else: the block dot must live at t
+			// itself (its consumers reference t); its byte sources index
+			// below every dot, so post-order holds.
+			p := pairs[0]
+			nodes[t] = simdfuse.Node{Op: x64OpBlockDot, Args: []simdfuse.Arg{p.low.srcA, p.low.srcB}}
+			x64ElidePair(nodes, p.low, p.high, -1)
+			for _, a := range adds {
+				if a != t {
+					nodes[a] = simdfuse.Node{Op: a64OpElided}
+				}
+				consumed[a] = true
+			}
+			rewrote = true
+			continue
+		}
+		// Rebuild into the LARGEST len(newLeaves)-1 add slots (ending at
+		// t); verify post-order before mutating.
+		used := adds[len(adds)-(len(newLeaves)-1):]
+		valid := true
+		prev := newLeaves[0]
+		for j, slot := range used {
+			if !availableAt(prev, slot) || !availableAt(newLeaves[j+1], slot) {
+				valid = false
+				break
+			}
+			prev = simdfuse.Arg{Kind: simdfuse.ArgNode, Index: slot}
+		}
+		if !valid {
+			continue
+		}
+		// Mutate: block dots, elisions, then the rebuilt chain.
+		for _, p := range pairs {
+			bd := p.low.dot
+			if p.high.dot < bd {
+				bd = p.high.dot
+			}
+			nodes[bd] = simdfuse.Node{Op: x64OpBlockDot, Args: []simdfuse.Arg{p.low.srcA, p.low.srcB}}
+			x64ElidePair(nodes, p.low, p.high, bd)
+		}
+		usedSet := map[int]bool{}
+		for _, u := range used {
+			usedSet[u] = true
+		}
+		prev = newLeaves[0]
+		for j, slot := range used {
+			nodes[slot] = simdfuse.Node{Op: "i32x4_add", Args: []simdfuse.Arg{prev, newLeaves[j+1]}}
+			prev = simdfuse.Arg{Kind: simdfuse.ArgNode, Index: slot}
+		}
+		for _, a := range adds {
+			if !usedSet[a] {
+				nodes[a] = simdfuse.Node{Op: a64OpElided}
+			}
+			consumed[a] = true
+		}
+		rewrote = true
+	}
+	if !rewrote {
+		return tree, false
+	}
+	out := *tree
+	out.Nodes = nodes
+	return &out, true
+}
+
+// isAddAny reports whether node i is a two-operand i32x4_add of any
+// argument kinds (the chain walk itself dispatches per kind).
+func isAddAny(nodes []simdfuse.Node, i int) bool {
+	n := &nodes[i]
+	return n.Op == "i32x4_add" && len(n.Args) == 2
+}
+
+// x64ElidePair blanks a matched pair's absorbed nodes: the four
+// extends and whichever dot slot is not keep (the block dot's home).
+func x64ElidePair(nodes []simdfuse.Node, low, high x64HalfDot, keep int) {
+	if low.dot != keep {
+		nodes[low.dot] = simdfuse.Node{Op: a64OpElided}
+	}
+	if high.dot != keep {
+		nodes[high.dot] = simdfuse.Node{Op: a64OpElided}
+	}
+	for _, e := range []int{low.e0, low.e1, high.e0, high.e1} {
+		nodes[e] = simdfuse.Node{Op: a64OpElided}
+	}
+}
+
+// sortArgsByIndex orders args ascending by node index, with non-node
+// args (no position constraint) first.
+func sortArgsByIndex(s []simdfuse.Arg) {
+	key := func(a simdfuse.Arg) int {
+		if a.Kind != simdfuse.ArgNode {
+			return -1
+		}
+		return a.Index
+	}
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && key(s[j]) < key(s[j-1]); j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
@@ -1,6 +1,7 @@
 package gcasm
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -154,8 +155,8 @@ func TestX64SpineChainEmitsTwoBlockDots(t *testing.T) {
 	if strings.Count(asm, "PMADDWL") != 0 {
 		t.Errorf("literal SSE dot remains:\n%s", asm)
 	}
-	if strings.Count(asm, "VZEROUPPER") != 1 {
-		t.Errorf("want exactly one VZEROUPPER per region:\n%s", asm)
+	if strings.Count(asm, "VZEROUPPER") != 2 {
+		t.Errorf("want one VZEROUPPER per block dot (Intel dirty-upper false deps):\n%s", asm)
 	}
 }
 
@@ -297,5 +298,58 @@ func TestX64BlockDotPortableIsLiteral(t *testing.T) {
 	}
 	if !strings.Contains(asm, "PMADDWL") {
 		t.Errorf("portable body missing the literal SSE dot:\n%s", asm)
+	}
+}
+
+// TestX64LoopHoistsMemBase: a fused loop with several member loads
+// pins m.M and the memSize value once in the prologue and never
+// reloads them per access inside the loop body.
+func TestX64LoopHoistsMemBase(t *testing.T) {
+	pin := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: i} }
+	nd := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgNode, Index: i} }
+	tr := &simdfuse.Tree{
+		Name:       "simd_p_fxlhoist",
+		NumScalars: 1,
+		NeedsMem:   true,
+		NumPairs:   1,
+		Nodes: []simdfuse.Node{
+			{Op: "v128_load", Args: []simdfuse.Arg{{Kind: simdfuse.ArgScalar, Index: 0}, {Kind: simdfuse.ArgConst, Const: 0}}},
+			{Op: "v128_load", Args: []simdfuse.Arg{{Kind: simdfuse.ArgScalar, Index: 0}, {Kind: simdfuse.ArgConst, Const: 16}}},
+			{Op: "i16x8_add", Args: []simdfuse.Arg{nd(0), nd(1)}},
+			{Op: "i16x8_add", Args: []simdfuse.Arg{nd(2), pin(0)}},
+		},
+		Roots: []int{3},
+	}
+	loop := &simdfuse.Loop{
+		Tree:          tr,
+		CarriedPairs:  [][2]int{{0, 3}},
+		Bumps:         []simdfuse.LoopBump{{Scalar: 0, Delta: 32, DeltaScalar: -1}},
+		CounterScalar: 0,
+		Dec:           1,
+	}
+	var b strings.Builder
+	spliced, _, err := x64SpliceLoop(&b, loop, &ConstPool{}, fuseTestOffs, "7", false, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	loopStart := strings.Index(asm, "gcasmfxl7:")
+	if loopStart < 0 {
+		t.Fatalf("no loop label:\n%s", asm)
+	}
+	pre, body := asm[:loopStart], asm[loopStart:]
+	// The prologue pins both values...
+	if !strings.Contains(pre, fmt.Sprintf("MOVQ %d(R13),", fuseTestOffs.M)) {
+		t.Errorf("prologue does not hoist m.M:\n%s", asm)
+	}
+	if !strings.Contains(pre, fmt.Sprintf("MOVQ %d(R13),", fuseTestOffs.MemSize)) {
+		t.Errorf("prologue does not hoist memSize:\n%s", asm)
+	}
+	// ...and the loop body never touches the Module struct again.
+	if strings.Contains(body, "(R13)") {
+		t.Errorf("loop body reloads Module fields:\n%s", asm)
 	}
 }

--- a/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
@@ -1,0 +1,301 @@
+package gcasm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/simdfuse"
+)
+
+// blockDotTree builds one 16-byte signed 8-bit dot:
+//
+//	add( dot(extend_low a, extend_low b), dot(extend_high a, extend_high b) )
+//
+// over two loaded byte vectors — the shape x64Dot8Rewrite collapses.
+func blockDotTree() *simdfuse.Tree {
+	return &simdfuse.Tree{
+		Name:       "simd_p_fxdot",
+		NumScalars: 1,
+		NeedsMem:   true,
+		Nodes: []simdfuse.Node{
+			{Op: "v128_load", Args: []simdfuse.Arg{{Kind: simdfuse.ArgScalar, Index: 0}, {Kind: simdfuse.ArgConst, Const: 0}}},      // 0: a
+			{Op: "v128_load", Args: []simdfuse.Arg{{Kind: simdfuse.ArgScalar, Index: 0}, {Kind: simdfuse.ArgConst, Const: 16}}},     // 1: b
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 0}}},                              // 2
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 1}}},                              // 3
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 2}, {Kind: simdfuse.ArgNode, Index: 3}}}, // 4: dot_low
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 0}}},                             // 5
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 1}}},                             // 6
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 5}, {Kind: simdfuse.ArgNode, Index: 6}}}, // 7: dot_high
+			{Op: "i32x4_add", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 4}, {Kind: simdfuse.ArgNode, Index: 7}}},         // 8: result
+		},
+		Roots: []int{8},
+	}
+}
+
+func TestX64Dot8RewriteCollapsesBlockDot(t *testing.T) {
+	out, used := x64Dot8Rewrite(blockDotTree(), false)
+	if !used {
+		t.Fatal("x64Dot8Rewrite did not fire on the block-dot shape")
+	}
+	if got := out.Nodes[8].Op; got != x64OpBlockDot {
+		t.Fatalf("add node not rewritten: op=%q, want %q", got, x64OpBlockDot)
+	}
+	// The block dot must read the two byte sources directly.
+	args := out.Nodes[8].Args
+	if len(args) != 2 || args[0].Index != 0 || args[1].Index != 1 {
+		t.Fatalf("block-dot args = %+v, want sources 0 and 1", args)
+	}
+	// The two dots and four extends are absorbed.
+	for _, i := range []int{2, 3, 4, 5, 6, 7} {
+		if out.Nodes[i].Op != a64OpElided {
+			t.Errorf("node %d = %q, want elided", i, out.Nodes[i].Op)
+		}
+	}
+}
+
+func TestX64Dot8RewritePortableSuppresses(t *testing.T) {
+	out, used := x64Dot8Rewrite(blockDotTree(), true)
+	if used {
+		t.Fatal("portable mode must not rewrite")
+	}
+	if out.Nodes[8].Op != "i32x4_add" {
+		t.Fatalf("portable tree mutated: op=%q", out.Nodes[8].Op)
+	}
+}
+
+func TestX64Dot8RewriteKeepsSharedExtend(t *testing.T) {
+	// If an extend feeds something else too (not single-use), the chunk
+	// is not eligible and the tree is left literal.
+	tr := blockDotTree()
+	tr.Nodes = append(tr.Nodes, simdfuse.Node{Op: "i32x4_add", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 4}, {Kind: simdfuse.ArgNode, Index: 8}}})
+	tr.Roots = []int{9}
+	out, used := x64Dot8Rewrite(tr, false)
+	if used {
+		t.Fatal("must not rewrite when a dot has a second consumer")
+	}
+	if out.Nodes[8].Op != "i32x4_add" {
+		t.Fatal("tree mutated despite ineligibility")
+	}
+}
+
+// spineDotTree mirrors the real q8 kernel helper shape (two chunks,
+// K=2): chunk A's halves are direct add siblings, while chunk B's high
+// and low dots join the accumulator spine separately —
+//
+//	n6  = add(dot(extlow P0, extlow P1), dot(exthigh P0, exthigh P1))
+//	n10 = add(n6, dot(exthigh P2, exthigh P3))
+//	n14 = add(n10, dot(extlow P2, extlow P3))
+//
+// Both chunks must collapse to block dots.
+func spineDotTree() *simdfuse.Tree {
+	pin := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: i} }
+	nd := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgNode, Index: i} }
+	return &simdfuse.Tree{
+		Name:     "simd_p_fxspine",
+		NumPairs: 4,
+		Nodes: []simdfuse.Node{
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{pin(0)}},  // 0
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{pin(1)}},  // 1
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{nd(0), nd(1)}},   // 2: lowA
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{pin(0)}}, // 3
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{pin(1)}}, // 4
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{nd(3), nd(4)}},   // 5: highA
+			{Op: "i32x4_add", Args: []simdfuse.Arg{nd(2), nd(5)}},           // 6: chunk A
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{pin(2)}}, // 7
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{pin(3)}}, // 8
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{nd(7), nd(8)}},   // 9: highB
+			{Op: "i32x4_add", Args: []simdfuse.Arg{nd(6), nd(9)}},           // 10: spine
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{pin(2)}},  // 11
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{pin(3)}},  // 12
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{nd(11), nd(12)}}, // 13: lowB
+			{Op: "i32x4_add", Args: []simdfuse.Arg{nd(10), nd(13)}},         // 14: spine top
+		},
+		Roots: []int{14},
+	}
+}
+
+func TestX64Dot8RewriteCollapsesSpineChain(t *testing.T) {
+	out, used := x64Dot8Rewrite(spineDotTree(), false)
+	if !used {
+		t.Fatal("spine chain not rewritten")
+	}
+	// Chunk A's block dot lives in its low-dot slot (2); chunk B's in
+	// the lower of its two dot slots (9). The top add chains them.
+	if out.Nodes[2].Op != x64OpBlockDot || out.Nodes[9].Op != x64OpBlockDot {
+		t.Fatalf("block dots not at 2 and 9: n2=%q n9=%q", out.Nodes[2].Op, out.Nodes[9].Op)
+	}
+	if got := out.Nodes[9].Args; got[0].Index != 2 || got[1].Index != 3 {
+		t.Fatalf("chunk B block dot reads %+v, want pair sources 2,3", got)
+	}
+	top := out.Nodes[14]
+	if top.Op != "i32x4_add" || top.Args[0].Index != 2 || top.Args[1].Index != 9 {
+		t.Fatalf("top add = %+v, want add(2, 9)", top)
+	}
+	for _, i := range []int{0, 1, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13} {
+		if out.Nodes[i].Op != a64OpElided {
+			t.Errorf("node %d = %q, want elided", i, out.Nodes[i].Op)
+		}
+	}
+}
+
+func TestX64SpineChainEmitsTwoBlockDots(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, spineDotTree(), &ConstPool{}, fuseTestOffs, false, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	if got := strings.Count(asm, "VPMADDWD"); got != 2 {
+		t.Errorf("VPMADDWD count = %d, want 2 (one per chunk):\n%s", got, asm)
+	}
+	if strings.Count(asm, "PMADDWL") != 0 {
+		t.Errorf("literal SSE dot remains:\n%s", asm)
+	}
+	if strings.Count(asm, "VZEROUPPER") != 1 {
+		t.Errorf("want exactly one VZEROUPPER per region:\n%s", asm)
+	}
+}
+
+// accSpineTree mirrors the fused-LOOP kernel shape: the loop-carried
+// accumulator (a pair input) sits at the bottom of the add spine, so
+// every add on the spine carries it —
+//
+//	n2  = dot(extlow P1, extlow P2)
+//	n3  = add(ACC, n2)          <- ACC = ArgPairIn 0
+//	n6  = dot(exthigh P1, exthigh P2)
+//	n7  = add(n3, n6)           <- root (the carried value)
+//
+// The chunk must still collapse: the ACC rides the rebuilt chain.
+func accSpineTree() *simdfuse.Tree {
+	pin := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: i} }
+	nd := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgNode, Index: i} }
+	return &simdfuse.Tree{
+		Name:     "simd_p_fxacc",
+		NumPairs: 3,
+		Nodes: []simdfuse.Node{
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{pin(1)}},  // 0
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{pin(2)}},  // 1
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{nd(0), nd(1)}},   // 2: low
+			{Op: "i32x4_add", Args: []simdfuse.Arg{pin(0), nd(2)}},          // 3: ACC + low
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{pin(1)}}, // 4
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{pin(2)}}, // 5
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{nd(4), nd(5)}},   // 6: high
+			{Op: "i32x4_add", Args: []simdfuse.Arg{nd(3), nd(6)}},           // 7: root
+		},
+		Roots: []int{7},
+	}
+}
+
+func TestX64Dot8RewriteCarriesAccumulator(t *testing.T) {
+	out, used := x64Dot8Rewrite(accSpineTree(), false)
+	if !used {
+		t.Fatal("acc-spine chunk not rewritten")
+	}
+	// The block dot lands in the lower dot slot (2); the surviving add
+	// (t=7) folds ACC (pair-in 0) with it; everything else is elided.
+	if out.Nodes[2].Op != x64OpBlockDot {
+		t.Fatalf("n2 = %q, want block dot", out.Nodes[2].Op)
+	}
+	top := out.Nodes[7]
+	if top.Op != "i32x4_add" {
+		t.Fatalf("top = %q, want add", top.Op)
+	}
+	// One arg is the ACC pair-in, the other the block dot.
+	var hasAcc, hasDot bool
+	for _, a := range top.Args {
+		if a.Kind == simdfuse.ArgPairIn && a.Index == 0 {
+			hasAcc = true
+		}
+		if a.Kind == simdfuse.ArgNode && a.Index == 2 {
+			hasDot = true
+		}
+	}
+	if !hasAcc || !hasDot {
+		t.Fatalf("top args = %+v, want ACC pair-in 0 and node 2", top.Args)
+	}
+	for _, i := range []int{0, 1, 3, 4, 5, 6} {
+		if out.Nodes[i].Op != a64OpElided {
+			t.Errorf("node %d = %q, want elided", i, out.Nodes[i].Op)
+		}
+	}
+}
+
+func TestX64BlockDotEmitsAVX2(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, blockDotTree(), &ConstPool{}, fuseTestOffs, false, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	for _, want := range []string{"VPMOVSXBW", "VPMADDWD Y3, Y2, Y2", "VEXTRACTI128 $1, Y2, X3", "VPADDD", "// avx2 dot", "VZEROUPPER"} {
+		if !strings.Contains(asm, want) {
+			t.Errorf("emitted asm missing %q:\n%s", want, asm)
+		}
+	}
+}
+
+// blockDotPairTree is the block dot over two PAIR-IN byte sources — the
+// staging-order hazard case: X2 is Y2's own low half, so both sources
+// must be staged before either extend runs.
+func blockDotPairTree() *simdfuse.Tree {
+	return &simdfuse.Tree{
+		Name:     "simd_p_fxdotp",
+		NumPairs: 2,
+		Nodes: []simdfuse.Node{
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgPairIn, Index: 0}}},
+			{Op: "i16x8_extend_low_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgPairIn, Index: 1}}},
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 0}, {Kind: simdfuse.ArgNode, Index: 1}}},
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgPairIn, Index: 0}}},
+			{Op: "i16x8_extend_high_i8x16_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgPairIn, Index: 1}}},
+			{Op: "i32x4_dot_i16x8_s", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 3}, {Kind: simdfuse.ArgNode, Index: 4}}},
+			{Op: "i32x4_add", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 2}, {Kind: simdfuse.ArgNode, Index: 5}}},
+		},
+		Roots: []int{6},
+	}
+}
+
+func TestX64BlockDotStagesBothSourcesFirst(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, blockDotPairTree(), &ConstPool{}, fuseTestOffs, false, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	// The two sources must land in DISTINCT staging registers (X2 and
+	// X3), and both stagings must precede the first extend: X2 is Y2's
+	// low half, so staging after the first VPMOVSXBW corrupts it.
+	firstExt := strings.Index(asm, "VPMOVSXBW")
+	if firstExt < 0 {
+		t.Fatalf("no extend emitted:\n%s", asm)
+	}
+	pre := asm[:firstExt]
+	if !strings.Contains(pre, "X2") || !strings.Contains(pre, "X3") {
+		t.Errorf("both sources must be staged (X2 and X3) before the first extend:\n%s", asm)
+	}
+	if strings.Contains(asm[firstExt:], "PINSRQ") {
+		t.Errorf("staging PINSRQ after the first extend corrupts Y2's low half:\n%s", asm)
+	}
+}
+
+func TestX64BlockDotPortableIsLiteral(t *testing.T) {
+	var b strings.Builder
+	if _, _, err := x64SpliceFused(&b, blockDotTree(), &ConstPool{}, fuseTestOffs, true, 0); err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	asm := b.String()
+	if strings.Contains(asm, "VPMADDWD") || strings.Contains(asm, "VZEROUPPER") {
+		t.Errorf("portable body used AVX2:\n%s", asm)
+	}
+	if !strings.Contains(asm, "PMADDWL") {
+		t.Errorf("portable body missing the literal SSE dot:\n%s", asm)
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
@@ -155,8 +155,8 @@ func TestX64SpineChainEmitsTwoBlockDots(t *testing.T) {
 	if strings.Count(asm, "PMADDWL") != 0 {
 		t.Errorf("literal SSE dot remains:\n%s", asm)
 	}
-	if strings.Count(asm, "VZEROUPPER") != 2 {
-		t.Errorf("want one VZEROUPPER per block dot (Intel dirty-upper false deps):\n%s", asm)
+	if strings.Count(asm, "VZEROUPPER") != 1 {
+		t.Errorf("want one deferred VZEROUPPER for a fully VEX region:\n%s", asm)
 	}
 }
 
@@ -411,7 +411,7 @@ func TestX64LoopHoistsRangeChecks(t *testing.T) {
 	if strings.Contains(body, "$134") {
 		t.Errorf("loop body still carries the window span:\n%s", body)
 	}
-	if !strings.Contains(body, "MOVOU 2(") {
+	if !strings.Contains(body, "VMOVDQU 2(") {
 		t.Errorf("loop body lost the folded indexed load:\n%s", body)
 	}
 }

--- a/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
@@ -353,3 +353,65 @@ func TestX64LoopHoistsMemBase(t *testing.T) {
 		t.Errorf("loop body reloads Module fields:\n%s", asm)
 	}
 }
+
+// TestX64LoopHoistsRangeChecks: a memory64 pretest loop's strided
+// window loads check once at the loop head and become single indexed
+// loads inside the body.
+func TestX64LoopHoistsRangeChecks(t *testing.T) {
+	tr := &simdfuse.Tree{
+		Name:       "simd_p_fxlrng",
+		NumScalars: 1,
+		NeedsMem:   true,
+		NumPairs:   1,
+		Addr64:     true,
+		Nodes: []simdfuse.Node{
+			{Op: "v128_load_rng", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgScalar, Index: 0},
+				{Kind: simdfuse.ArgConst, Const: 2},
+				{Kind: simdfuse.ArgConst, Const: 0},
+				{Kind: simdfuse.ArgConst, Const: 134},
+			}},
+			{Op: "i16x8_add", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 0},
+				{Kind: simdfuse.ArgPairIn, Index: 0},
+			}},
+		},
+		Roots: []int{1},
+	}
+	loop := &simdfuse.Loop{
+		Tree:          tr,
+		CarriedPairs:  [][2]int{{0, 1}},
+		Bumps:         []simdfuse.LoopBump{{Scalar: 0, Delta: 34, DeltaScalar: -1}},
+		CounterScalar: 0,
+		Dec:           4,
+		PreTest:       true,
+	}
+	var b strings.Builder
+	spliced, needsTrap, err := x64SpliceLoop(&b, loop, &ConstPool{}, fuseTestOffs, "9", false, 0)
+	if err != nil || !spliced {
+		t.Fatalf("spliced=%v err=%v", spliced, err)
+	}
+	if !needsTrap {
+		t.Error("hoisted check must still request the trap label")
+	}
+	asm := b.String()
+	loopStart := strings.Index(asm, "gcasmfxl9:")
+	if loopStart < 0 {
+		t.Fatalf("no loop label:\n%s", asm)
+	}
+	pre, body := asm[:loopStart], asm[loopStart:]
+	// The prologue computes iters-1, scales by the stride, and checks
+	// once (guarded against the zero-iteration entry).
+	for _, want := range []string{"SHRQ $2, R12", "JZ gcasmfxh9_0", "IMUL3Q $34, R12, R12", "gcasmfxh9_0:"} {
+		if !strings.Contains(pre, want) {
+			t.Errorf("prologue missing %q:\n%s", want, pre)
+		}
+	}
+	// Inside the loop: no span dance, a single folded indexed load.
+	if strings.Contains(body, "$134") {
+		t.Errorf("loop body still carries the window span:\n%s", body)
+	}
+	if !strings.Contains(body, "MOVOU 2(") {
+		t.Errorf("loop body lost the folded indexed load:\n%s", body)
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_loop_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_loop_x64_test.go
@@ -60,9 +60,10 @@ func TestX64LoopCarryReadsReservedRegister(t *testing.T) {
 	loopBody := body[loopStart:]
 
 	// The carried accumulator is reserved at X14 (poolTop). The add
-	// must consume it via a register copy from X14, not a MOVQ/PINSRQ
+	// must consume it straight from X14 — either the VEX form reading
+	// it as an operand or a register copy — never a MOVQ/PINSRQ
 	// rebuild from a GPR pair.
-	if !regexp.MustCompile(`MOVOU X14, X\d`).MatchString(loopBody) {
+	if !regexp.MustCompile(`(MOVOU X14, X\d|X14, X\d+\n)`).MatchString(loopBody) {
 		t.Errorf("loop body never reads the carried register X14:\n%s", loopBody)
 	}
 	// The tail writes the running value back to X14.

--- a/internal/gcasm/simdsplice_fuse_loop_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_loop_x64_test.go
@@ -67,7 +67,7 @@ func TestX64LoopCarryReadsReservedRegister(t *testing.T) {
 		t.Errorf("loop body never reads the carried register X14:\n%s", loopBody)
 	}
 	// The tail writes the running value back to X14.
-	if !strings.Contains(loopBody, "MOVOU X0, X14") && !regexp.MustCompile(`MOVOU X\d+, X14`).MatchString(loopBody) {
+	if !strings.Contains(loopBody, "VMOVDQU X0, X14") && !regexp.MustCompile(`MOVOU X\d+, X14`).MatchString(loopBody) {
 		t.Errorf("loop body never writes back the carried register X14:\n%s", loopBody)
 	}
 	// The prologue (before the loop label) seeds X14 from the argument

--- a/internal/gcasm/simdsplice_fuse_loop_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_loop_x64_test.go
@@ -47,7 +47,7 @@ func carryLoop() *simdfuse.Loop {
 // value, so reading them resets the accumulator every iteration.
 func TestX64LoopCarryReadsReservedRegister(t *testing.T) {
 	var b strings.Builder
-	spliced, _, err := x64SpliceLoop(&b, carryLoop(), &ConstPool{}, fuseTestOffs, "0", 0)
+	spliced, _, err := x64SpliceLoop(&b, carryLoop(), &ConstPool{}, fuseTestOffs, "0", false, 0)
 	if err != nil || !spliced {
 		t.Fatalf("spliced=%v err=%v", spliced, err)
 	}

--- a/internal/gcasm/simdsplice_fuse_pool_test.go
+++ b/internal/gcasm/simdsplice_fuse_pool_test.go
@@ -61,11 +61,11 @@ func TestX64FusedCannedOpRelocatesLiveValues(t *testing.T) {
 	body := b.String()
 	// n0 parks in X4 (first pool register); the shuffle must move it
 	// to X8+ before its canned lines run.
-	if !regexp.MustCompile(`MOVOU X4, X(8|9|1[0-4])\b`).MatchString(body) {
+	if !regexp.MustCompile(`VMOVDQU X4, X(8|9|1[0-4])\b`).MatchString(body) {
 		t.Fatalf("live value not relocated out of canned scratch:\n%s", body)
 	}
 	// The mul consumes the relocated home, never stale X4.
-	if strings.Contains(body, "MOVOU X4, X0") {
+	if strings.Contains(body, "VMOVDQU X4, X0") {
 		t.Fatalf("consumer read the clobbered X4 park:\n%s", body)
 	}
 }

--- a/internal/gcasm/simdsplice_fuse_pool_test.go
+++ b/internal/gcasm/simdsplice_fuse_pool_test.go
@@ -54,7 +54,7 @@ func fusePoolClobberTree() *simdfuse.Tree {
 // parked load and every consumer after it computed garbage.
 func TestX64FusedCannedOpRelocatesLiveValues(t *testing.T) {
 	var b strings.Builder
-	spliced, _, err := x64SpliceFused(&b, fusePoolClobberTree(), &ConstPool{}, fuseTestOffs, 0)
+	spliced, _, err := x64SpliceFused(&b, fusePoolClobberTree(), &ConstPool{}, fuseTestOffs, false, 0)
 	if err != nil || !spliced {
 		t.Fatalf("spliced=%v err=%v", spliced, err)
 	}
@@ -98,7 +98,7 @@ func TestX64FusedPoolCapacity(t *testing.T) {
 	}
 	tree.Roots = []int{prev}
 	var b strings.Builder
-	spliced, _, err := x64SpliceFused(&b, tree, &ConstPool{}, fuseTestOffs, 0)
+	spliced, _, err := x64SpliceFused(&b, tree, &ConstPool{}, fuseTestOffs, false, 0)
 	if spliced {
 		t.Fatal("over-budget tree spliced")
 	}

--- a/internal/gcasm/simdsplice_fuse_scalar_x64.go
+++ b/internal/gcasm/simdsplice_fuse_scalar_x64.go
@@ -180,7 +180,7 @@ func (p *x64ScalarPre) takeFpr(a simdfuse.Arg) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	fmt.Fprintf(p.b, "\tMOVAPS X%d, X%d\n", src, f)
+	fmt.Fprintf(p.b, "\tVMOVAPS X%d, X%d\n", src, f)
 	return f, nil
 }
 
@@ -240,7 +240,7 @@ func (p *x64ScalarPre) emit(i int, n *simdfuse.Node) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(p.b, "\tMOVSS (%s)(%s*1), X%d\n", x64MemBase(p.b, p.offs), g, f)
+		fmt.Fprintf(p.b, "\tVMOVSS (%s)(%s*1), X%d\n", x64MemBase(p.b, p.offs), g, f)
 		p.freeGpr = append(p.freeGpr, g)
 		p.fprOf[i] = f
 	case "scalar_f32_mul":
@@ -252,7 +252,7 @@ func (p *x64ScalarPre) emit(i int, n *simdfuse.Node) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(p.b, "\tMULSS X%d, X%d\n", fr, fl)
+		fmt.Fprintf(p.b, "\tVMULSS X%d, X%d, X%d\n", fr, fl, fl)
 		p.freeFpr = append(p.freeFpr, fr)
 		p.fprOf[i] = fl
 	default:

--- a/internal/gcasm/simdsplice_fuse_scalar_x64.go
+++ b/internal/gcasm/simdsplice_fuse_scalar_x64.go
@@ -191,8 +191,7 @@ func (p *x64ScalarPre) emit(i int, n *simdfuse.Node) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(p.b, "\tMOVQ %d(R13), AX\n", p.offs.M)
-		fmt.Fprintf(p.b, "\tMOVWLZX (AX)(%s*1), %s\n", g, g)
+		fmt.Fprintf(p.b, "\tMOVWLZX (%s)(%s*1), %s\n", x64MemBase(p.b, p.offs), g, g)
 		p.gprOf[i] = g
 	case "scalar_i32_shl":
 		g, err := p.takeGpr(n.Args[0])
@@ -241,8 +240,7 @@ func (p *x64ScalarPre) emit(i int, n *simdfuse.Node) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(p.b, "\tMOVQ %d(R13), AX\n", p.offs.M)
-		fmt.Fprintf(p.b, "\tMOVSS (AX)(%s*1), X%d\n", g, f)
+		fmt.Fprintf(p.b, "\tMOVSS (%s)(%s*1), X%d\n", x64MemBase(p.b, p.offs), g, f)
 		p.freeGpr = append(p.freeGpr, g)
 		p.fprOf[i] = f
 	case "scalar_f32_mul":

--- a/internal/gcasm/simdsplice_fuse_test.go
+++ b/internal/gcasm/simdsplice_fuse_test.go
@@ -75,7 +75,7 @@ func TestA64SpliceFusedChain(t *testing.T) {
 
 func TestX64SpliceFusedChain(t *testing.T) {
 	var b strings.Builder
-	spliced, needsTrap, err := x64SpliceFused(&b, fuseChainTree(), nil, fuseTestOffs, 0)
+	spliced, needsTrap, err := x64SpliceFused(&b, fuseChainTree(), nil, fuseTestOffs, false, 0)
 	if err != nil || !spliced || !needsTrap {
 		t.Fatalf("spliced=%v trap=%v err=%v", spliced, needsTrap, err)
 	}
@@ -162,7 +162,7 @@ func TestA64SpliceFusedMultiRoot(t *testing.T) {
 
 func TestX64SpliceFusedMultiRoot(t *testing.T) {
 	var b strings.Builder
-	spliced, needsTrap, err := x64SpliceFused(&b, fuseMultiRootTree(), nil, fuseTestOffs, 0)
+	spliced, needsTrap, err := x64SpliceFused(&b, fuseMultiRootTree(), nil, fuseTestOffs, false, 0)
 	if err != nil || !spliced || !needsTrap {
 		t.Fatalf("spliced=%v trap=%v err=%v", spliced, needsTrap, err)
 	}
@@ -206,7 +206,7 @@ func fuseFloatPackTree() *simdfuse.Tree {
 
 func TestX64SpliceFusedFloatPack(t *testing.T) {
 	var b strings.Builder
-	spliced, _, err := x64SpliceFused(&b, fuseFloatPackTree(), nil, fuseTestOffs, 0)
+	spliced, _, err := x64SpliceFused(&b, fuseFloatPackTree(), nil, fuseTestOffs, false, 0)
 	if err != nil || !spliced {
 		t.Fatalf("spliced=%v err=%v", spliced, err)
 	}
@@ -323,7 +323,7 @@ func TestA64SpliceFusedScalarChain(t *testing.T) {
 
 func TestX64SpliceFusedScalarChain(t *testing.T) {
 	var b strings.Builder
-	spliced, needsTrap, err := x64SpliceFused(&b, fuseScalarChainTree(), nil, fuseTestOffs, 0)
+	spliced, needsTrap, err := x64SpliceFused(&b, fuseScalarChainTree(), nil, fuseTestOffs, false, 0)
 	if err != nil || !spliced || !needsTrap {
 		t.Fatalf("spliced=%v trap=%v err=%v", spliced, needsTrap, err)
 	}
@@ -347,7 +347,7 @@ func TestSpliceFusedErrors(t *testing.T) {
 	if _, _, err := a64SpliceFused(&b, memTree, nil, nil, false); err == nil {
 		t.Error("a64: memory tree without Module offsets must fail")
 	}
-	if _, _, err := x64SpliceFused(&b, memTree, nil, nil, 0); err == nil {
+	if _, _, err := x64SpliceFused(&b, memTree, nil, nil, false, 0); err == nil {
 		t.Error("x64: memory tree without Module offsets must fail")
 	}
 	unknown := &simdfuse.Tree{
@@ -357,7 +357,7 @@ func TestSpliceFusedErrors(t *testing.T) {
 	if _, _, err := a64SpliceFused(&b, unknown, nil, fuseTestOffs, false); err == nil {
 		t.Error("a64: unknown op must fail")
 	}
-	if _, _, err := x64SpliceFused(&b, unknown, nil, fuseTestOffs, 0); err == nil {
+	if _, _, err := x64SpliceFused(&b, unknown, nil, fuseTestOffs, false, 0); err == nil {
 		t.Error("x64: unknown op must fail")
 	}
 }

--- a/internal/gcasm/simdsplice_fuse_test.go
+++ b/internal/gcasm/simdsplice_fuse_test.go
@@ -85,9 +85,9 @@ func TestX64SpliceFusedChain(t *testing.T) {
 		"MOVL BX, R12",  // load addr
 		"ADDQ $16, R12", // constant offset immediate
 		"JCS " + x64SimdMemTrapLabel,
-		"MOVOU (AX)(R12*1), X0", // indexed load lands in X0
-		"PMOVSXBW X0, X0",       // extend consumes the chain
-		"MOVQ CX, X2",           // pair input stages for the VEX add
+		"VMOVDQU (AX)(R12*1), X0", // indexed load lands in X0
+		"PMOVSXBW X0, X0",         // extend consumes the chain
+		"MOVQ CX, X2",             // pair input stages for the VEX add
 		"PINSRQ $1, DI, X2",
 		"VPADDW X2, X0, X0",
 		"PEXTRQ $1, X0, BX", // single-root epilogue
@@ -168,11 +168,11 @@ func TestX64SpliceFusedMultiRoot(t *testing.T) {
 	}
 	body := b.String()
 	for _, want := range []string{
-		"MOVOU X0, X14",  // float arguments packed into X14 lanes
-		"ADDQ $-16, R12", // signed rlo immediate
+		"VMOVDQU X0, X14", // float arguments packed into X14 lanes
+		"ADDQ $-16, R12",  // signed rlo immediate
 		"JS " + x64SimdMemTrapLabel,
-		"PSHUFD $0, X14, X0", // splat broadcasts lane 0 of the pack
-		"MOVQ X0, SI",        // third root lands in result 4 (SI)
+		"VPSHUFD $0, X14, X0", // splat broadcasts lane 0 of the pack
+		"MOVQ X0, SI",         // third root lands in result 4 (SI)
 		"PEXTRQ $1, X0, R8",
 	} {
 		if !strings.Contains(body, want) {
@@ -212,12 +212,12 @@ func TestX64SpliceFusedFloatPack(t *testing.T) {
 	}
 	body := b.String()
 	for _, want := range []string{
-		"MOVOU X0, X14",         // lane 0
-		"INSERTPS $16, X1, X14", // lane 1
-		"INSERTPS $32, X2, X14", // lane 2
-		"PSHUFD $0, X14, X",     // broadcast lane 0
-		"PSHUFD $85, X14, X",    // broadcast lane 1
-		"PSHUFD $170, X14, X",   // broadcast lane 2
+		"VMOVDQU X0, X14",             // lane 0
+		"VINSERTPS $16, X1, X14, X14", // lane 1
+		"VINSERTPS $32, X2, X14, X14", // lane 2
+		"VPSHUFD $0, X14, X",          // broadcast lane 0
+		"VPSHUFD $85, X14, X",         // broadcast lane 1
+		"VPSHUFD $170, X14, X",        // broadcast lane 2
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in body:\n%s", want, body)

--- a/internal/gcasm/simdsplice_fuse_test.go
+++ b/internal/gcasm/simdsplice_fuse_test.go
@@ -85,9 +85,9 @@ func TestX64SpliceFusedChain(t *testing.T) {
 		"MOVL BX, R12",  // load addr
 		"ADDQ $16, R12", // constant offset immediate
 		"JCS " + x64SimdMemTrapLabel,
-		"MOVOU (R12), X0", // load lands in X0
-		"PMOVSXBW X0, X0", // extend consumes the chain
-		"MOVQ CX, X1",     // pair input builds into operand 1
+		"MOVOU (AX)(R12*1), X0", // indexed load lands in X0
+		"PMOVSXBW X0, X0",       // extend consumes the chain
+		"MOVQ CX, X1",           // pair input builds into operand 1
 		"PINSRQ $1, DI, X1",
 		"PADDW X1, X0",
 		"PEXTRQ $1, X0, BX", // single-root epilogue

--- a/internal/gcasm/simdsplice_fuse_test.go
+++ b/internal/gcasm/simdsplice_fuse_test.go
@@ -87,9 +87,9 @@ func TestX64SpliceFusedChain(t *testing.T) {
 		"JCS " + x64SimdMemTrapLabel,
 		"MOVOU (AX)(R12*1), X0", // indexed load lands in X0
 		"PMOVSXBW X0, X0",       // extend consumes the chain
-		"MOVQ CX, X1",           // pair input builds into operand 1
-		"PINSRQ $1, DI, X1",
-		"PADDW X1, X0",
+		"MOVQ CX, X2",           // pair input stages for the VEX add
+		"PINSRQ $1, DI, X2",
+		"VPADDW X2, X0, X0",
 		"PEXTRQ $1, X0, BX", // single-root epilogue
 		"MOVQ X0, AX",
 	} {

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -77,7 +77,7 @@ var (
 
 func x64VecCopy(b *strings.Builder, dst, src int) {
 	if dst != src {
-		fmt.Fprintf(b, "\tMOVOU X%d, X%d\n", src, dst)
+		fmt.Fprintf(b, "\tVMOVDQU X%d, X%d\n", src, dst)
 	}
 }
 
@@ -151,7 +151,10 @@ func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, of
 		fmt.Fprintf(b, "\tMOVQ X%d, %s\n", src, x64FusedResultRegs[2*k])
 		fmt.Fprintf(b, "\tPEXTRQ $1, X%d, %s\n", src, x64FusedResultRegs[2*k+1])
 	}
-	_ = usedAVX // uppers are cleared per block dot at the emission site
+	if usedAVX && x64TreeVexClean(tree) {
+		// Fully VEX region: one deferred upper clear at the exit.
+		b.WriteString("\tVZEROUPPER\n")
+	}
 	return true, needsTrap, nil
 }
 
@@ -163,9 +166,9 @@ func x64FusedProlog(b *strings.Builder, tree *simdfuse.Tree, offs *ModuleOffsets
 	}
 	b.WriteString("\tMOVQ AX, R13\n")
 	if tree.NumFloats > 0 {
-		b.WriteString("\tMOVOU X0, X14\n")
+		b.WriteString("\tVMOVDQU X0, X14\n")
 		for i := 1; i < tree.NumFloats; i++ {
-			fmt.Fprintf(b, "\tINSERTPS $%d, X%d, X14\n", i<<4, i)
+			fmt.Fprintf(b, "\tVINSERTPS $%d, X%d, X14, X14\n", i<<4, i)
 		}
 	}
 	return nil
@@ -238,6 +241,7 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 		}
 	}
 	needsTrap := false
+	vexClean := !portable && x64TreeVexClean(tree)
 
 	chains := newX64ScalarChain(b, tree, scalarReg, offs, uses)
 
@@ -400,13 +404,13 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			// float argument's lane, or a computed scalar terminal's.
 			switch {
 			case len(n.Args) == 1 && n.Args[0].Kind == simdfuse.ArgFloat:
-				fmt.Fprintf(b, "\tPSHUFD $%d, X14, X%d\n", n.Args[0].Index*0x55, dst)
+				fmt.Fprintf(b, "\tVPSHUFD $%d, X14, X%d\n", n.Args[0].Index*0x55, dst)
 			case len(n.Args) == 1 && n.Args[0].Kind == simdfuse.ArgNode && tree.Nodes[n.Args[0].Index].Class() == simdfuse.ClassF32:
 				f, err := chains.takeSplatSource(n.Args[0].Index)
 				if err != nil {
 					return nil, false, err
 				}
-				fmt.Fprintf(b, "\tPSHUFD $0, X%d, X%d\n", f, dst)
+				fmt.Fprintf(b, "\tVPSHUFD $0, X%d, X%d\n", f, dst)
 			default:
 				return nil, false, fmt.Errorf("fused splice %s: malformed f32x4_splat args", tree.Name)
 			}
@@ -457,13 +461,15 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
 			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
 			fmt.Fprintf(b, "\tVPADDD X3, X2, X%d\n", dst)
-			// Clear the ymm upper halves IMMEDIATELY: the rest of the
-			// region is legacy-SSE, and on Intel a dirty upper state
-			// makes every legacy SSE instruction merge against the full
-			// register — false dependencies that serialize the loop
-			// (measured 30x on Granite Rapids). VZEROUPPER costs ~1
-			// cycle; AMD ignores the state entirely.
-			b.WriteString("\tVZEROUPPER\n")
+			if !vexClean {
+				// Clear the ymm upper halves IMMEDIATELY: legacy SSE
+				// follows in this region, and on Intel a dirty upper
+				// state gives every legacy SSE instruction a false
+				// dependency that serializes the loop (measured 30x on
+				// Granite Rapids). A fully VEX region defers this to
+				// one clear at the exit instead.
+				b.WriteString("\tVZEROUPPER\n")
+			}
 			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
@@ -698,6 +704,25 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 	// always opaque scalars; a wrapped u64 ea could land back inside
 	// bounds, so every sum traps on carry there).
 	addOffErr := error(nil)
+	// Fully-folded unchecked load: on a memory64 tree a register base
+	// plus constant terms is ONE indexed instruction — decided here,
+	// before any base materialization, so no dead address arithmetic
+	// is emitted.
+	if n.Op == "v128_load_nc" && addr64 && addrReg == "" {
+		if a := n.Args[0]; a.Kind == simdfuse.ArgScalar || a.Kind == simdfuse.ArgSum {
+			base := int64(0)
+			if a.Kind == simdfuse.ArgSum {
+				base = int64(a.Const)
+			}
+			if off := n.Args[1]; off.Kind == simdfuse.ArgConst {
+				disp := base + int64(off.Const)
+				if disp >= 0 && disp < 1<<31 {
+					fmt.Fprintf(b, "\tVMOVDQU %d(%s)(%s*1), X%d\n", disp, x64MemBase(b, offs), scalarReg(a), dst)
+					return nil
+				}
+			}
+		}
+	}
 	if addrReg != "" {
 		// Chain-computed address: move the terminal into the address
 		// register first (see the arm64 twin). MOVL re-zero-extends
@@ -778,42 +803,23 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 	case "v128_load32_zero":
 		addOff(1)
 		checked(4)
-		fmt.Fprintf(b, "\tMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		fmt.Fprintf(b, "\tVMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
 		return addOffErr
 	case "v128_load32_splat":
 		addOff(1)
 		checked(4)
-		fmt.Fprintf(b, "\tMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
-		fmt.Fprintf(b, "\tPSHUFD $0x00, X%d, X%d\n", dst, dst)
+		fmt.Fprintf(b, "\tVMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		fmt.Fprintf(b, "\tVPSHUFD $0x00, X%d, X%d\n", dst, dst)
 		return addOffErr
 	case "v128_load16x4_u":
 		addOff(1)
 		checked(8)
-		fmt.Fprintf(b, "\tMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
-		fmt.Fprintf(b, "\tPMOVZXWD X%d, X%d\n", dst, dst)
+		fmt.Fprintf(b, "\tVMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		fmt.Fprintf(b, "\tVPMOVZXWD X%d, X%d\n", dst, dst)
 		return addOffErr
 	case "v128_load_nc":
-		// Unchecked member load: on a memory64 tree every address term
-		// adds at full width, so a register base plus constant terms
-		// folds into ONE indexed load with a displacement — no address
-		// arithmetic at all. (wasm32 keeps the wrapping ADDL sequence.)
-		if addr64 && addrReg == "" {
-			if a := n.Args[0]; a.Kind == simdfuse.ArgScalar || a.Kind == simdfuse.ArgSum {
-				base := int64(0)
-				if a.Kind == simdfuse.ArgSum {
-					base = int64(a.Const)
-				}
-				if off := n.Args[1]; off.Kind == simdfuse.ArgConst {
-					disp := base + int64(off.Const)
-					if disp >= 0 && disp < 1<<31 {
-						fmt.Fprintf(b, "\tMOVOU %d(%s)(%s*1), X%d\n", disp, x64MemBase(b, offs), scalarReg(a), dst)
-						return addOffErr
-					}
-				}
-			}
-		}
 		if d, ok := x64DeferOff(n.Args[1]); ok {
-			fmt.Fprintf(b, "\tMOVOU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+			fmt.Fprintf(b, "\tVMOVDQU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
 			return addOffErr
 		}
 		addOff(1)
@@ -842,12 +848,12 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 		x64MemSizeCheck(b, offs)
 		fmt.Fprintf(b, "\tSUBQ $%d, R12\n", undo)
 		if d, ok := x64DeferOff(n.Args[1]); ok {
-			fmt.Fprintf(b, "\tMOVOU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+			fmt.Fprintf(b, "\tVMOVDQU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
 			return addOffErr
 		}
 		addOff(1)
 	}
-	fmt.Fprintf(b, "\tMOVOU (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+	fmt.Fprintf(b, "\tVMOVDQU (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
 	return addOffErr
 }
 
@@ -1311,7 +1317,10 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 			fmt.Fprintf(b, "\tPEXTRQ $1, X%d, %s\n", src, lo)
 		}
 	}
-	_ = usedAVX // uppers are cleared per block dot at the emission site
+	if usedAVX && x64TreeVexClean(tree) {
+		// Fully VEX region: one deferred upper clear at the exit.
+		b.WriteString("\tVZEROUPPER\n")
+	}
 	return true, needsTrap || hoistedTrap, nil
 }
 
@@ -1343,6 +1352,35 @@ var x64VexOps = map[string]func(b *strings.Builder, srcs []string, dst int){
 	"i32x4_dot_i16x8_s": func(b *strings.Builder, s []string, d int) {
 		fmt.Fprintf(b, "\tVPMADDWD %s, %s, X%d\n", s[1], s[0], d)
 	},
+}
+
+// x64TreeVexClean reports whether a rewritten tree's emission is
+// entirely VEX-encoded (loads, the VEX op table, block dots, splats,
+// the scalar chains): then legacy-SSE code never executes between a
+// 256-bit op and the region exit, so ONE VZEROUPPER at the exit
+// replaces the per-block-dot clears (the Intel dirty-upper hazard
+// applies to legacy SSE only; VEX-128 ops are safe under dirty
+// uppers).
+func x64TreeVexClean(tree *simdfuse.Tree) bool {
+	for _, n := range tree.Nodes {
+		if n.Op == a64OpElided || n.Op == x64OpBlockDot || n.Op == "f32x4_splat" {
+			continue
+		}
+		if n.Class() != simdfuse.ClassV128 {
+			continue // scalar chains emit VEX FP ops
+		}
+		if simdfuse.IsStore(n.Op) || n.Op == "v128_load32_lane" || n.Op == "f16x4_cvt" {
+			return false
+		}
+		if _, isMem := fusedMemOpsA64[n.Op]; isMem {
+			continue
+		}
+		if _, isVex := x64VexOps[n.Op]; isVex && x64VexArgsOK(n) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // x64VexArgsOK reports whether every argument is a register-resident

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -139,7 +139,7 @@ func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, of
 		return false, false, err
 	}
 	hoffs := x64HoistMem(b, offs, tree, 1+tree.NumScalars+2*tree.NumPairs)
-	loc, needsTrap, err := x64SpliceFusedCore(b, tree, pool, hoffs, nil, nil, 0, true, maxOut)
+	loc, needsTrap, err := x64SpliceFusedCore(b, tree, pool, hoffs, nil, nil, 0, true, portable, maxOut)
 	if err != nil {
 		return false, false, err
 	}
@@ -174,7 +174,7 @@ func x64FusedProlog(b *strings.Builder, tree *simdfuse.Tree, offs *ModuleOffsets
 // x64SpliceFusedCore is the parameterized node-body emitter; see the
 // arm64 twin for the carried/reserve/extraIntArgs contract.
 func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, offs *ModuleOffsets,
-	carried map[int]int, reserve []int, extraIntArgs int, skipProlog bool, maxOut int) ([]fusedLoc, bool, error) {
+	carried map[int]int, reserve []int, extraIntArgs int, skipProlog bool, portable bool, maxOut int) ([]fusedLoc, bool, error) {
 	if !skipProlog {
 		if err := x64FusedProlog(b, tree, offs); err != nil {
 			return nil, false, err
@@ -467,6 +467,49 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
+		} else if vex, isVex := x64VexOps[n.Op]; isVex && !portable && x64VexArgsOK(n) {
+			// VEX three-operand form with an explicit destination: no
+			// staging copies into the canned X0/X1 slots and no parking
+			// copy out — the op reads its sources where they live and
+			// writes the pool register directly. VEX-128 zeroes the ymm
+			// upper halves, so no dirty-upper hazard arises. Scratch is
+			// X2/X3 (never pool homes); sources are read before dst is
+			// written, so dst may alias a source.
+			srcs := make([]string, 0, 2)
+			stage := 2
+			okSrc := true
+			for _, a := range n.Args {
+				switch a.Kind {
+				case simdfuse.ArgNode:
+					if loc[a.Index].chained {
+						srcs = append(srcs, "X0")
+					} else {
+						srcs = append(srcs, fmt.Sprintf("X%d", loc[a.Index].pool))
+					}
+				case simdfuse.ArgPairIn:
+					if cr, isCarried := carried[a.Index]; isCarried {
+						srcs = append(srcs, fmt.Sprintf("X%d", cr))
+					} else {
+						lo, hi := pairRegs(a)
+						fmt.Fprintf(b, "\tMOVQ %s, X%d\n", lo, stage)
+						fmt.Fprintf(b, "\tPINSRQ $1, %s, X%d\n", hi, stage)
+						srcs = append(srcs, fmt.Sprintf("X%d", stage))
+						stage++
+					}
+				default:
+					okSrc = false
+				}
+			}
+			if !okSrc {
+				return nil, false, fmt.Errorf("fused splice %s: malformed %s args", tree.Name, n.Op)
+			}
+			d := dst
+			if willChain {
+				d = 0
+			}
+			vex(b, srcs, d)
+			loc[i] = fusedLoc{chained: willChain, pool: d}
+			continue
 		} else {
 			lines, ok := x64SimdPairSpliceTab[n.Op]
 			if !ok {
@@ -750,6 +793,25 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 		fmt.Fprintf(b, "\tPMOVZXWD X%d, X%d\n", dst, dst)
 		return addOffErr
 	case "v128_load_nc":
+		// Unchecked member load: on a memory64 tree every address term
+		// adds at full width, so a register base plus constant terms
+		// folds into ONE indexed load with a displacement — no address
+		// arithmetic at all. (wasm32 keeps the wrapping ADDL sequence.)
+		if addr64 && addrReg == "" {
+			if a := n.Args[0]; a.Kind == simdfuse.ArgScalar || a.Kind == simdfuse.ArgSum {
+				base := int64(0)
+				if a.Kind == simdfuse.ArgSum {
+					base = int64(a.Const)
+				}
+				if off := n.Args[1]; off.Kind == simdfuse.ArgConst {
+					disp := base + int64(off.Const)
+					if disp >= 0 && disp < 1<<31 {
+						fmt.Fprintf(b, "\tMOVOU %d(%s)(%s*1), X%d\n", disp, x64MemBase(b, offs), scalarReg(a), dst)
+						return addOffErr
+					}
+				}
+			}
+		}
 		if d, ok := x64DeferOff(n.Args[1]); ok {
 			fmt.Fprintf(b, "\tMOVOU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
 			return addOffErr
@@ -1061,7 +1123,7 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 		fmt.Fprintf(b, "\t%s %s, $%d\n", cmpOp, counterReg, loop.Dec)
 		fmt.Fprintf(b, "\tJB %s\n", exitLabel)
 	}
-	loc, needsTrap, err := x64SpliceFusedCore(b, tree, pool, offs, carried, reserve, 1+loop.NumDeltas, true, maxOut)
+	loc, needsTrap, err := x64SpliceFusedCore(b, tree, pool, offs, carried, reserve, 1+loop.NumDeltas, true, portable, maxOut)
 	if err != nil {
 		return false, false, err
 	}
@@ -1162,4 +1224,49 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 	}
 	_ = usedAVX // uppers are cleared per block dot at the emission site
 	return true, needsTrap, nil
+}
+
+// x64VexOps maps ops with a VEX three-operand register form to their
+// direct-destination emitters. Only all-vector-argument shapes qualify
+// (x64VexArgsOK); everything else keeps the canned SSE paste.
+var x64VexOps = map[string]func(b *strings.Builder, srcs []string, dst int){
+	"i32x4_add": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVPADDD %s, %s, X%d\n", s[1], s[0], d)
+	},
+	"i16x8_add": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVPADDW %s, %s, X%d\n", s[1], s[0], d)
+	},
+	"i32x4_sub": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVPSUBD %s, %s, X%d\n", s[1], s[0], d)
+	},
+	"f32x4_add": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVADDPS %s, %s, X%d\n", s[1], s[0], d)
+	},
+	"f32x4_mul": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVMULPS %s, %s, X%d\n", s[1], s[0], d)
+	},
+	"f32x4_sub": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVSUBPS %s, %s, X%d\n", s[1], s[0], d)
+	},
+	"f32x4_convert_i32x4_s": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVCVTDQ2PS %s, X%d\n", s[0], d)
+	},
+	"i32x4_dot_i16x8_s": func(b *strings.Builder, s []string, d int) {
+		fmt.Fprintf(b, "\tVPMADDWD %s, %s, X%d\n", s[1], s[0], d)
+	},
+}
+
+// x64VexArgsOK reports whether every argument is a register-resident
+// vector (node result or pair input) — the shapes the VEX emitters
+// handle without staging beyond X2/X3.
+func x64VexArgsOK(n simdfuse.Node) bool {
+	if len(n.Args) == 0 {
+		return false
+	}
+	for _, a := range n.Args {
+		if a.Kind != simdfuse.ArgNode && a.Kind != simdfuse.ArgPairIn {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -127,7 +127,8 @@ func x64ClassifyPair(lines []string, nV128 int) (opTargets []int, core []string,
 
 // x64SpliceFused synthesizes the inline amd64 body of a fused-region
 // call. Results in (AX, BX).
-func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, offs *ModuleOffsets, maxOut int) (bool, bool, error) {
+func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, offs *ModuleOffsets, portable bool, maxOut int) (bool, bool, error) {
+	tree, usedAVX := x64Dot8Rewrite(tree, portable)
 	// Scalars (addresses the body indexes with) must be
 	// register-resident here; only pair halves may ride the stack
 	// sequence. A wider window keeps the helper CALL.
@@ -145,6 +146,11 @@ func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, of
 		}
 		fmt.Fprintf(b, "\tMOVQ X%d, %s\n", src, x64FusedResultRegs[2*k])
 		fmt.Fprintf(b, "\tPEXTRQ $1, X%d, %s\n", src, x64FusedResultRegs[2*k+1])
+	}
+	if usedAVX {
+		// The block dots dirtied ymm upper halves; clear them before
+		// control returns to gc-emitted legacy-SSE code.
+		b.WriteString("\tVZEROUPPER\n")
 	}
 	return true, needsTrap, nil
 }
@@ -245,6 +251,12 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 	}
 
 	for i, n := range tree.Nodes {
+		if n.Op == a64OpElided {
+			// Absorbed into a synthetic AVX2 block dot: nothing to emit,
+			// nothing referenced, nothing to free.
+			loc[i] = fusedLoc{chained: true}
+			continue
+		}
 		if n.Class() != simdfuse.ClassV128 {
 			// Inline scalar-chain node (see the arm64 twin).
 			if err := chains.emitNode(i, &tree.Nodes[i]); err != nil {
@@ -397,6 +409,54 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			default:
 				return nil, false, fmt.Errorf("fused splice %s: malformed f32x4_splat args", tree.Name)
 			}
+			loc[i] = fusedLoc{chained: willChain, pool: dst}
+			continue
+		} else if n.Op == x64OpBlockDot {
+			// AVX2 8-bit block dot (see x64Dot8Rewrite): sign-extend both
+			// 16-byte byte sources to i16 across a ymm, VPMADDWD into 8
+			// i32 lanes (0..3 = low-half dot, 4..7 = high-half), then fold
+			// the high 128 onto the low with VPADDD to yield the four i32
+			// sums. Y2/Y3 (X2/X3) are scratch the vector pool never
+			// occupies. BOTH sources are staged before either extend runs:
+			// X2 is Y2's own low half, so writing a staging register after
+			// Y2 is produced would corrupt it. Every source is read before
+			// dst is written, so dst may safely alias a source register.
+			// The "// avx2 dot" marker triggers the dual-body dispatch
+			// (see the amd64 archSpec entry): a non-AVX2 host runs the
+			// portable SSE twin.
+			blockDotSrc := func(a simdfuse.Arg, stage int) (string, error) {
+				switch a.Kind {
+				case simdfuse.ArgNode:
+					if loc[a.Index].chained {
+						return "X0", nil
+					}
+					return fmt.Sprintf("X%d", loc[a.Index].pool), nil
+				case simdfuse.ArgPairIn:
+					if cr, isCarried := carried[a.Index]; isCarried {
+						return fmt.Sprintf("X%d", cr), nil
+					}
+					lo, hi := pairRegs(a)
+					fmt.Fprintf(b, "\tMOVQ %s, X%d\n", lo, stage)
+					fmt.Fprintf(b, "\tPINSRQ $1, %s, X%d\n", hi, stage)
+					return fmt.Sprintf("X%d", stage), nil
+				default:
+					return "", fmt.Errorf("fused splice %s: malformed %s args", tree.Name, n.Op)
+				}
+			}
+			ra, err := blockDotSrc(n.Args[0], 2)
+			if err != nil {
+				return nil, false, err
+			}
+			rb, err := blockDotSrc(n.Args[1], 3)
+			if err != nil {
+				return nil, false, err
+			}
+			fmt.Fprintf(b, "\tVPMOVSXBW %s, Y2\n", ra)
+			fmt.Fprintf(b, "\tVPMOVSXBW %s, Y3\n", rb)
+			b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
+			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
+			fmt.Fprintf(b, "\tVPADDD X3, X2, X%d\n", dst)
+			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
 		} else {
@@ -890,14 +950,16 @@ func x64FusedStoreTail(b *strings.Builder, n simdfuse.Node,
 
 // x64SpliceLoop is the amd64 fused-loop synthesizer; see the arm64
 // twin for the structure.
-func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, offs *ModuleOffsets, site string, maxOut int) (bool, bool, error) {
+func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, offs *ModuleOffsets, site string, portable bool, maxOut int) (bool, bool, error) {
 	// Scalars, the counter, and stride deltas must be
 	// register-resident (the loop indexes and bumps them in place);
 	// a wider signature keeps the helper CALL.
 	if 1+loop.Tree.NumScalars+1+loop.NumDeltas > len(x64FusedArgRegs) {
 		return false, false, fmt.Errorf("fused loop %s: %w: scalars past the register file", loop.Tree.Name, errFusedCapacity)
 	}
-	tree := loop.Tree
+	// x64Dot8Rewrite preserves node indices (absorbed nodes become
+	// elided placeholders), so CarriedPairs/roots/bumps stay valid.
+	tree, usedAVX := x64Dot8Rewrite(loop.Tree, portable)
 	if err := x64FusedProlog(b, tree, offs); err != nil {
 		return false, false, err
 	}
@@ -1028,6 +1090,11 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 		} else {
 			fmt.Fprintf(b, "\tPEXTRQ $1, X%d, %s\n", src, lo)
 		}
+	}
+	if usedAVX {
+		// The block dots dirtied ymm upper halves; clear them once on the
+		// loop-exit path before control returns to gc-emitted SSE code.
+		b.WriteString("\tVZEROUPPER\n")
 	}
 	return true, needsTrap, nil
 }

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -135,7 +135,11 @@ func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, of
 	if 1+tree.NumScalars > len(x64FusedArgRegs) {
 		return false, false, fmt.Errorf("fused splice %s: %w: scalars past the register file", tree.Name, errFusedCapacity)
 	}
-	loc, needsTrap, err := x64SpliceFusedCore(b, tree, pool, offs, nil, nil, 0, false, maxOut)
+	if err := x64FusedProlog(b, tree, offs); err != nil {
+		return false, false, err
+	}
+	hoffs := x64HoistMem(b, offs, tree, 1+tree.NumScalars+2*tree.NumPairs)
+	loc, needsTrap, err := x64SpliceFusedCore(b, tree, pool, hoffs, nil, nil, 0, true, maxOut)
 	if err != nil {
 		return false, false, err
 	}
@@ -147,11 +151,7 @@ func x64SpliceFused(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool, of
 		fmt.Fprintf(b, "\tMOVQ X%d, %s\n", src, x64FusedResultRegs[2*k])
 		fmt.Fprintf(b, "\tPEXTRQ $1, X%d, %s\n", src, x64FusedResultRegs[2*k+1])
 	}
-	if usedAVX {
-		// The block dots dirtied ymm upper halves; clear them before
-		// control returns to gc-emitted legacy-SSE code.
-		b.WriteString("\tVZEROUPPER\n")
-	}
+	_ = usedAVX // uppers are cleared per block dot at the emission site
 	return true, needsTrap, nil
 }
 
@@ -311,10 +311,11 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			if aerr != nil {
 				return nil, false, aerr
 			}
-			if err := x64FusedLaneAddr(b, n, scalarReg, offs, tree.Addr64, areg); err != nil {
-				return nil, false, err
+			mb, lerr := x64FusedLaneAddr(b, n, scalarReg, offs, tree.Addr64, areg)
+			if lerr != nil {
+				return nil, false, lerr
 			}
-			fmt.Fprintf(b, "\tPINSRD $%d, (AX)(R12*1), X%d\n", uint32(n.Args[2].Const)&3, dst)
+			fmt.Fprintf(b, "\tPINSRD $%d, (%s)(R12*1), X%d\n", uint32(n.Args[2].Const)&3, mb, dst)
 			needsTrap = true
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
@@ -456,6 +457,13 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
 			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
 			fmt.Fprintf(b, "\tVPADDD X3, X2, X%d\n", dst)
+			// Clear the ymm upper halves IMMEDIATELY: the rest of the
+			// region is legacy-SSE, and on Intel a dirty upper state
+			// makes every legacy SSE instruction merge against the full
+			// register — false dependencies that serialize the loop
+			// (measured 30x on Granite Rapids). VZEROUPPER costs ~1
+			// cycle; AMD ignores the state entirely.
+			b.WriteString("\tVZEROUPPER\n")
 			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
@@ -567,6 +575,63 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 	return loc, needsTrap, nil
 }
 
+// x64MemBase names the register holding m.M for indexed accesses: the
+// hoisted register when the region pinned one (see x64HoistMem), else
+// AX freshly loaded from the Module struct.
+func x64MemBase(b *strings.Builder, offs *ModuleOffsets) string {
+	if offs != nil && offs.HoistM != "" {
+		return offs.HoistM
+	}
+	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
+	return "AX"
+}
+
+// x64MemSizeCheck emits the bounds compare of R12 (holding the access
+// END address) against memSize, trapping on overrun: one CMPQ against
+// the hoisted value, or the pointer-load + dereference pair.
+func x64MemSizeCheck(b *strings.Builder, offs *ModuleOffsets) {
+	if offs != nil && offs.HoistMemSizeVal != "" {
+		fmt.Fprintf(b, "\tCMPQ %s, R12\n", offs.HoistMemSizeVal)
+	} else {
+		fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.MemSize)
+		b.WriteString("\tMOVQ (AX), AX\n")
+		b.WriteString("\tCMPQ AX, R12\n")
+	}
+	fmt.Fprintf(b, "\tJCS %s\n", x64SimdMemTrapLabel)
+}
+
+// x64HoistMem pins m.M (and the memSize value) into free argument-tail
+// registers for one fused region or loop, returning the offsets the
+// member emitters should use. Free means beyond the region's argument
+// usage; a splice contains no calls, so both values stay valid for its
+// whole extent, and the epilogue may clobber the registers freely.
+// Regions with fewer than two memory ops keep the per-site loads (the
+// prologue would not pay for itself).
+func x64HoistMem(b *strings.Builder, offs *ModuleOffsets, tree *simdfuse.Tree, usedIntArgs int) *ModuleOffsets {
+	if offs == nil || !tree.NeedsMem {
+		return offs
+	}
+	memOps := 0
+	for _, n := range tree.Nodes {
+		if _, ok := fusedMemOpsA64[n.Op]; ok || simdfuse.IsStore(n.Op) || n.Op == "v128_load32_lane" {
+			memOps++
+		}
+	}
+	if memOps < 2 || usedIntArgs >= len(x64FusedArgRegs) {
+		return offs
+	}
+	free := x64FusedArgRegs[usedIntArgs:]
+	o := *offs
+	o.HoistM = free[0]
+	fmt.Fprintf(b, "\tMOVQ %d(R13), %s\n", offs.M, free[0])
+	if len(free) >= 2 {
+		o.HoistMemSizeVal = free[1]
+		fmt.Fprintf(b, "\tMOVQ %d(R13), %s\n", offs.MemSize, free[1])
+		fmt.Fprintf(b, "\tMOVQ (%s), %s\n", free[1], free[1])
+	}
+	return &o
+}
+
 // x64FusedLoad emits one member load, result in X0. m lives in R13;
 // scratch is R12 plus AX (free once m is saved) so every integer
 // argument register stays live. The bounds compare runs against the
@@ -658,15 +723,9 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 		fmt.Fprintf(b, "\tMOVL %s, AX\n", reg)
 		b.WriteString("\tADDQ AX, R12\n")
 	}
-	loadMemSize := func() {
-		fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.MemSize)
-		b.WriteString("\tMOVQ (AX), AX\n")
-	}
 	checked := func(size int) {
 		fmt.Fprintf(b, "\tADDQ $%d, R12\n", size)
-		loadMemSize()
-		b.WriteString("\tCMPQ AX, R12\n")
-		fmt.Fprintf(b, "\tJCS %s\n", x64SimdMemTrapLabel)
+		x64MemSizeCheck(b, offs)
 		fmt.Fprintf(b, "\tSUBQ $%d, R12\n", size)
 	}
 	switch n.Op {
@@ -676,24 +735,25 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 	case "v128_load32_zero":
 		addOff(1)
 		checked(4)
-		fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-		fmt.Fprintf(b, "\tMOVSS (AX)(R12*1), X%d\n", dst)
+		fmt.Fprintf(b, "\tMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
 		return addOffErr
 	case "v128_load32_splat":
 		addOff(1)
 		checked(4)
-		fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-		fmt.Fprintf(b, "\tMOVSS (AX)(R12*1), X%d\n", dst)
+		fmt.Fprintf(b, "\tMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
 		fmt.Fprintf(b, "\tPSHUFD $0x00, X%d, X%d\n", dst, dst)
 		return addOffErr
 	case "v128_load16x4_u":
 		addOff(1)
 		checked(8)
-		fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-		fmt.Fprintf(b, "\tMOVQ (AX)(R12*1), X%d\n", dst)
+		fmt.Fprintf(b, "\tMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
 		fmt.Fprintf(b, "\tPMOVZXWD X%d, X%d\n", dst, dst)
 		return addOffErr
 	case "v128_load_nc":
+		if d, ok := x64DeferOff(n.Args[1]); ok {
+			fmt.Fprintf(b, "\tMOVOU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+			return addOffErr
+		}
 		addOff(1)
 	case "v128_load_rng":
 		// start/end accumulate in R12 and are undone afterwards, so
@@ -717,16 +777,35 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 			fmt.Fprintf(b, "\tJS %s\n", x64SimdMemTrapLabel)
 		}
 		fmt.Fprintf(b, "\tADDQ $%d, R12\n", int64(uint32(spanC)))
-		loadMemSize()
-		b.WriteString("\tCMPQ AX, R12\n")
-		fmt.Fprintf(b, "\tJCS %s\n", x64SimdMemTrapLabel)
+		x64MemSizeCheck(b, offs)
 		fmt.Fprintf(b, "\tSUBQ $%d, R12\n", undo)
+		if d, ok := x64DeferOff(n.Args[1]); ok {
+			fmt.Fprintf(b, "\tMOVOU %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+			return addOffErr
+		}
 		addOff(1)
 	}
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-	b.WriteString("\tADDQ AX, R12\n")
-	fmt.Fprintf(b, "\tMOVOU (R12), X%d\n", dst)
+	fmt.Fprintf(b, "\tMOVOU (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
 	return addOffErr
+}
+
+// x64DeferOff reports whether a memarg offset can ride the load's
+// displacement instead of an ADDQ: a small constant (disp32 is
+// sign-extended, so it must fit in 31 bits). Callers may fold it only
+// when no bounds check consumes the summed address afterwards — the
+// unchecked and range-pre-checked load forms.
+func x64DeferOff(a simdfuse.Arg) (string, bool) {
+	if a.Kind != simdfuse.ArgConst {
+		return "", false
+	}
+	c := int64(uint32(a.Const))
+	if c == 0 {
+		return "", true
+	}
+	if c >= 1<<31 {
+		return "", false
+	}
+	return fmt.Sprintf("%d", c), true
 }
 
 // x64FusedLaneAddr materializes a lane load's checked address:
@@ -738,7 +817,7 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 // arithmetic and range check are identical to the wasm32 fused-store
 // path; the only difference is the full-width base load. No wrap guard
 // is needed — see a64FusedMemCheck's note (the arm64 twin).
-func x64FusedEA64(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.Arg) string, offs *ModuleOffsets, size int, addrReg string) error {
+func x64FusedEA64(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.Arg) string, offs *ModuleOffsets, size int, addrReg string) (string, error) {
 	if addrReg != "" {
 		fmt.Fprintf(b, "\tMOVQ %s, R12\n", addrReg)
 	} else {
@@ -752,7 +831,7 @@ func x64FusedEA64(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 				fmt.Fprintf(b, "\tADDQ $%d, R12\n", int64(a.Const))
 			}
 		default:
-			return fmt.Errorf("fused addr64 %s: folded base form", n.Op)
+			return "", fmt.Errorf("fused addr64 %s: folded base form", n.Op)
 		}
 	}
 	switch off := n.Args[1]; off.Kind {
@@ -764,19 +843,15 @@ func x64FusedEA64(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 		fmt.Fprintf(b, "\tMOVQ %s, AX\n", scalarReg(off))
 		b.WriteString("\tADDQ AX, R12\n")
 	default:
-		return fmt.Errorf("fused addr64 %s: bad offset form", n.Op)
+		return "", fmt.Errorf("fused addr64 %s: bad offset form", n.Op)
 	}
 	fmt.Fprintf(b, "\tADDQ $%d, R12\n", size)
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.MemSize)
-	b.WriteString("\tMOVQ (AX), AX\n")
-	b.WriteString("\tCMPQ AX, R12\n")
-	fmt.Fprintf(b, "\tJCS %s\n", x64SimdMemTrapLabel)
+	x64MemSizeCheck(b, offs)
 	fmt.Fprintf(b, "\tSUBQ $%d, R12\n", size)
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-	return nil
+	return x64MemBase(b, offs), nil
 }
 
-func x64FusedLaneAddr(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.Arg) string, offs *ModuleOffsets, addr64 bool, addrReg string) error {
+func x64FusedLaneAddr(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.Arg) string, offs *ModuleOffsets, addr64 bool, addrReg string) (string, error) {
 	if addr64 {
 		return x64FusedEA64(b, n, scalarReg, offs, 4, addrReg)
 	}
@@ -805,13 +880,9 @@ func x64FusedLaneAddr(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfu
 		b.WriteString("\tADDQ AX, R12\n")
 	}
 	b.WriteString("\tADDQ $4, R12\n")
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.MemSize)
-	b.WriteString("\tMOVQ (AX), AX\n")
-	b.WriteString("\tCMPQ AX, R12\n")
-	fmt.Fprintf(b, "\tJCS %s\n", x64SimdMemTrapLabel)
+	x64MemSizeCheck(b, offs)
 	b.WriteString("\tSUBQ $4, R12\n")
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-	return nil
+	return x64MemBase(b, offs), nil
 }
 
 // x64FusedStore emits one member store: checked address in R12, value
@@ -827,8 +898,8 @@ func x64FusedStore(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.
 		if n.Op == "v128_f16x4_cvt_store" {
 			span = 8
 		}
-		if err := x64FusedEA64(b, n, scalarReg, offs, span, addrReg); err != nil {
-			return err
+		if _, eerr := x64FusedEA64(b, n, scalarReg, offs, span, addrReg); eerr != nil {
+			return eerr
 		}
 		return x64FusedStoreTail(b, n, pairRegs, offs, pool, src)
 	}
@@ -861,10 +932,7 @@ func x64FusedStore(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.
 		span = 8
 	}
 	fmt.Fprintf(b, "\tADDQ $%d, R12\n", span)
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.MemSize)
-	b.WriteString("\tMOVQ (AX), AX\n")
-	b.WriteString("\tCMPQ AX, R12\n")
-	fmt.Fprintf(b, "\tJCS %s\n", x64SimdMemTrapLabel)
+	x64MemSizeCheck(b, offs)
 	fmt.Fprintf(b, "\tSUBQ $%d, R12\n", span)
 	return x64FusedStoreTail(b, n, pairRegs, offs, pool, src)
 }
@@ -939,12 +1007,10 @@ func x64FusedStoreTail(b *strings.Builder, n simdfuse.Node,
 		b.WriteString("\tPANDN X3, X1\n")
 		b.WriteString("\tPOR X1, X2\n")
 		b.WriteString("\tPACKUSDW X2, X2\n")
-		fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-		b.WriteString("\tMOVQ X2, (AX)(R12*1)\n")
+		fmt.Fprintf(b, "\tMOVQ X2, (%s)(R12*1)\n", x64MemBase(b, offs))
 		return nil
 	}
-	fmt.Fprintf(b, "\tMOVQ %d(R13), AX\n", offs.M)
-	fmt.Fprintf(b, "\tMOVOU X%d, (AX)(R12*1)\n", src)
+	fmt.Fprintf(b, "\tMOVOU X%d, (%s)(R12*1)\n", src, x64MemBase(b, offs))
 	return nil
 }
 
@@ -963,6 +1029,9 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 	if err := x64FusedProlog(b, tree, offs); err != nil {
 		return false, false, err
 	}
+	// Pin m.M / memSize for the whole loop: every iteration's member
+	// accesses then skip the per-site Module loads.
+	offs = x64HoistMem(b, offs, tree, 1+tree.NumScalars+1+loop.NumDeltas+2*tree.NumPairs)
 	if loop.Dec <= 0 {
 		return false, false, fmt.Errorf("fused loop %s: bad dec %d", tree.Name, loop.Dec)
 	}
@@ -1091,10 +1160,6 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 			fmt.Fprintf(b, "\tPEXTRQ $1, X%d, %s\n", src, lo)
 		}
 	}
-	if usedAVX {
-		// The block dots dirtied ymm upper halves; clear them once on the
-		// loop-exit path before control returns to gc-emitted SSE code.
-		b.WriteString("\tVZEROUPPER\n")
-	}
+	_ = usedAVX // uppers are cleared per block dot at the emission site
 	return true, needsTrap, nil
 }

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -1094,6 +1094,95 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 	// Pin m.M / memSize for the whole loop: every iteration's member
 	// accesses then skip the per-site Module loads.
 	offs = x64HoistMem(b, offs, tree, 1+tree.NumScalars+1+loop.NumDeltas+2*tree.NumPairs)
+	// Hoist the strided window checks out of the loop: a pretest loop
+	// with a power-of-two step runs exactly counter>>log2(Dec)
+	// iterations, so ONE check of
+	//   base + rlo + span + (iters-1)*delta
+	// against memSize covers every iteration's window and the loads
+	// inside the loop drop to single indexed instructions. Trapping at
+	// the loop head instead of the precise access is the same
+	// relaxation the windowed range check already makes. memory64
+	// trees only (all address terms add at full width there).
+	hoistedTrap := false
+	if tree.Addr64 && loop.PreTest && loop.Dec > 0 && loop.Dec&(loop.Dec-1) == 0 {
+		sh := 0
+		for d := loop.Dec; d > 1; d >>= 1 {
+			sh++
+		}
+		deltaOf := map[int]int64{}
+		dynamic := map[int]bool{}
+		for _, bump := range loop.Bumps {
+			if bump.DeltaScalar >= 0 {
+				dynamic[bump.Scalar] = true
+			} else {
+				deltaOf[bump.Scalar] += int64(bump.Delta)
+			}
+		}
+		nodes := append([]simdfuse.Node(nil), tree.Nodes...)
+		ctrReg := x64FusedArgRegs[1+loop.CounterScalar]
+		checkedSpans := map[string]bool{}
+		rewrote := false
+		for i := range nodes {
+			n := &nodes[i]
+			if n.Op != "v128_load_rng" || len(n.Args) != 4 {
+				continue
+			}
+			a := n.Args[0]
+			if a.Kind != simdfuse.ArgScalar && a.Kind != simdfuse.ArgSum {
+				continue
+			}
+			if dynamic[a.Index] {
+				continue
+			}
+			rlo, span := n.Args[2], n.Args[3]
+			if rlo.Kind != simdfuse.ArgConst || span.Kind != simdfuse.ArgConst || rlo.Const < 0 {
+				continue
+			}
+			d := deltaOf[a.Index]
+			if d < 0 || d > 1<<20 {
+				continue
+			}
+			base := int64(0)
+			if a.Kind == simdfuse.ArgSum {
+				base = int64(a.Const)
+			}
+			end := base + int64(rlo.Const) + int64(uint32(span.Const))
+			key := fmt.Sprintf("%d/%d/%d", a.Index, end, d)
+			if !checkedSpans[key] {
+				checkedSpans[key] = true
+				skip := fmt.Sprintf("gcasmfxh%s_%d", site, i)
+				// A 32-bit counter arrives with undefined upper bits;
+				// MOVL zero-extends before the shift.
+				ctrMov := "MOVL"
+				if loop.CounterWide {
+					ctrMov = "MOVQ"
+				}
+				fmt.Fprintf(b, "\t%s %s, R12\n", ctrMov, ctrReg)
+				if sh > 0 {
+					fmt.Fprintf(b, "\tSHRQ $%d, R12\n", sh)
+				}
+				b.WriteString("\tTESTQ R12, R12\n")
+				fmt.Fprintf(b, "\tJZ %s\n", skip)
+				b.WriteString("\tSUBQ $1, R12\n")
+				if d != 0 {
+					fmt.Fprintf(b, "\tIMUL3Q $%d, R12, R12\n", d)
+				}
+				fmt.Fprintf(b, "\tADDQ %s, R12\n", x64FusedArgRegs[1+a.Index])
+				fmt.Fprintf(b, "\tADDQ $%d, R12\n", end)
+				x64MemSizeCheck(b, offs)
+				fmt.Fprintf(b, "%s:\n", skip)
+				hoistedTrap = true
+			}
+			n.Op = "v128_load_nc"
+			n.Args = n.Args[:2]
+			rewrote = true
+		}
+		if rewrote {
+			nt := *tree
+			nt.Nodes = nodes
+			tree = &nt
+		}
+	}
 	if loop.Dec <= 0 {
 		return false, false, fmt.Errorf("fused loop %s: bad dec %d", tree.Name, loop.Dec)
 	}
@@ -1223,7 +1312,7 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 		}
 	}
 	_ = usedAVX // uppers are cleared per block dot at the emission site
-	return true, needsTrap, nil
+	return true, needsTrap || hoistedTrap, nil
 }
 
 // x64VexOps maps ops with a VEX three-operand register form to their

--- a/internal/gcasm/simdsplice_mem_a64.go
+++ b/internal/gcasm/simdsplice_mem_a64.go
@@ -61,6 +61,12 @@ type ModuleOffsets struct {
 	// site nothing survives in registers to hoist into.
 	HoistM          string
 	HoistMemSizePtr string
+	// HoistMemSizeVal, when non-empty, names a register holding the
+	// memSize VALUE. Valid only where memory cannot grow — inside one
+	// fused region or fused loop (splices contain no calls) — where
+	// the x64 emitters then bounds-check with a single CMPQ instead of
+	// the pointer-load + dereference pair per checked access.
+	HoistMemSizeVal string
 }
 
 // fastMath is the nil-safe read of Cfg.FastMath: error paths probe

--- a/internal/gcasm/transform.go
+++ b/internal/gcasm/transform.go
@@ -776,7 +776,7 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 				var perr error
 				if lp, isLoop := opts.FusedLoops["simd_p_"+pop]; isLoop && !addr64 {
 					var fbuf strings.Builder
-					spliced, wantsTrap, perr = x64SpliceLoop(&fbuf, lp, pool, opts.ModOffsets, fmt.Sprintf("%d", in.Off), maxOut)
+					spliced, wantsTrap, perr = x64SpliceLoop(&fbuf, lp, pool, opts.ModOffsets, fmt.Sprintf("%d", in.Off), opts.PortableSIMD, maxOut)
 					if errors.Is(perr, errFusedCapacity) {
 						// Over-budget window: pair-form helpers cannot
 						// be marshalled as calls (their contract has no
@@ -789,7 +789,7 @@ func Transform(fn *Fn, opts TransformOptions) (string, error) {
 					}
 				} else if tree, isFused := opts.FusedSimd["simd_p_"+pop]; isFused && !addr64 {
 					var fbuf strings.Builder
-					spliced, wantsTrap, perr = x64SpliceFused(&fbuf, tree, pool, opts.ModOffsets, maxOut)
+					spliced, wantsTrap, perr = x64SpliceFused(&fbuf, tree, pool, opts.ModOffsets, opts.PortableSIMD, maxOut)
 					if errors.Is(perr, errFusedCapacity) {
 						spliced, perr = false, errSimdPairUnspliced
 					}

--- a/transpile/cpufeat_files_test.go
+++ b/transpile/cpufeat_files_test.go
@@ -1,0 +1,33 @@
+package transpile_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/transpile"
+)
+
+// TestCPUFeatFilesSurviveGcasmCleanup transpiles a SIMD module end to
+// end and asserts the CPU feature-detection files reach the output.
+// The gcasm backend's cleanup pass deletes the codegen own-backend
+// amd64 decls/asm in favor of the bundle's; cpufeat_amd64.go carries
+// an amd64 build tag and once fell to that filter, which broke the
+// bundle build (the feature-dispatch stubs read base.HasAVX2).
+func TestCPUFeatFilesSurviveGcasmCleanup(t *testing.T) {
+	wasm := testfixture.Wasm(t, "cg_simd")
+	res, err := transpile.Transpile(bytes.NewReader(wasm), io.Discard,
+		transpile.Options{Package: "wasm2go", OutputImportPath: "example.com/x"})
+	if err != nil {
+		t.Fatalf("transpile: %v", err)
+	}
+	for _, want := range []string{
+		"cpufeat_amd64.go", "cpufeat_amd64.s",
+		"cpufeat_arm64_darwin.go", "cpufeat_arm64_linux.go", "cpufeat_arm64_other.go",
+	} {
+		if _, ok := res.Files[want]; !ok {
+			t.Errorf("missing %s in transpile output", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

AVX2 selection for the quantized 8-bit dot kernels on amd64 (mirroring the arm64 SDOT/dot8 selection), a fused-region memory addressing diet, and runtime CPU dispatch. Verified bit-exact and benchmarked same-runner A/B against the v0.1.0 baseline on GitHub's heterogeneous amd64 pool.

## Result: amd64 beats arm64 on both metrics (same run, correctness-gated)

| Zen 4 (EPYC 9V74), one run | tg | pp |
|---|---|---|
| **this PR** | **22.9 tok/s** | **40.1 tok/s** |
| baseline v0.1.0 (SSE) | 10.9 | 15.3 |
| same-run arm64 (unchanged) | 16.6-17.3 | 36.3 |
| **verdict** | **+33% over arm64** | **+10% over arm64** |

Same-host baseline control rules out host luck (+110%/+163% vs baseline); the greedy 24-token continuation is byte-identical to arm64's long-validated reference on every CPU sampled. Intel Granite Rapids also beats arm64 on pp outright (43.1 vs 36.3).

## Measured (same-runner A/B, go-llama qwen2.5-0.5b q8_0)

| runner | metric | baseline v0.1.0 (SSE) | this PR | delta |
|---|---|---|---|---|
| AMD EPYC 7763 (Zen 3, 3 independent runners) | tg | 9.0-9.2 tok/s | **14.3-14.6** | **+60%** |
| AMD EPYC 7763 (Zen 3) | pp | 12.7-12.8 tok/s | **23.9-24.1** | **+88%** |
| Intel Xeon 8573C | tg / pp | 8.38 / 12.70 | 10.80 / 18.79 | +29% / +48% (pre-tile-kernel) |
| AMD EPYC 9V74 (Zen 4) | tg / pp | 8.47 / 11.79 | 8.55 / 11.75 | neutral (pre-tile-kernel) |
| arm64 (unchanged code) | tg / pp | 17.1-17.6 / 36.2-36.4 | 17.2 / 36.2 | neutral |

The amd64-vs-arm64 gap narrows from 1.9x/2.8x to **1.19x tg / 1.51x pp** on Zen 3. Zen 4's stronger OoO already absorbed the SSE inefficiencies, so it measures neutral on the pre-tile stack; Intel and Zen 3 gain outright.

**Correctness gate**: the fast-math tile kernel's greedy 24-token continuation of a fixed prompt is byte-identical between amd64 (this PR's tile kernel) and arm64 (the long-validated SMMLA reference); the full go-llama suite is green across GOAMD64 v1/v2 and arm64.

## What's in it

- **Loop-hoisted window checks + fully-folded loads**: a pretest fused loop's strided range checks collapse to one loop-head check (`base + rlo + span + (iters-1)*delta` vs memSize), and unchecked memory64 loads with constant terms emit as ONE indexed instruction (fold decided before base materialization — no dead address arithmetic). The q8 kernel loop went from 264 to **141** instructions across this PR.
- **Fully-VEX fused regions**: the remaining legacy-SSE emissions on the fused path (vector copies, float pack, splats, load tails, scalar-chain FP ops) emit VEX forms; when a tree's emission is entirely VEX (`x64TreeVexClean`) the per-block-dot `VZEROUPPER`s defer to a single clear at the region/loop exit — VEX-128 is safe under dirty uppers, so the Intel hazard only needs clearing before returning to gc-emitted legacy code.

- **`x64Nrc2Kernel`** (`nrc2kernel_x64.go`): the AVX2 analog of the arm64 SMMLA nrc2 tile kernel, behind the same fast-math gate. Per 34-byte block the four quant vectors (rows x0/x1, columns y0/y1) load ONCE and feed all four dot products; three `VPHADDD` and a 128-fold collapse the four i32x8 sums into the 2x2 tile in one xmm; the f16 d scales gather via `VPINSRW`, convert with `VCVTPH2PS` (F16C), spread with two `VPERMILPS`, and accumulate with `VFMADD231PS`. Entirely VEX-encoded, `VZEROUPPER` on both exits, bounds-checked like the arm64 kernel, both pointer widths, validated through the real Go assembler in tests. `HasAVX2` detection now also requires FMA and F16C.

- **`x64Dot8Rewrite`** (`simdsplice_fuse_dot8_x64.go`): collapses each 16-byte chunk's `dot(extlow)+dot(exthigh)` pair into one AVX2 block dot (`VPMOVSXBW` x2 + `VPMADDWD` + `VEXTRACTI128` + `VPADDD` — five ops for the SSE lowering's nine, bit-identical). An `a64Dot8FlattenAdds`-style chain walk pairs halves across left-leaning accumulator spines (with the running accumulator riding the rebuilt chain), so the hot fused loops collapse too, not just direct `add(low,high)` siblings.
- **`VZEROUPPER` after every block dot.** The rest of a splice is legacy SSE; on Intel a dirty ymm upper state gives every legacy SSE instruction a false dependency and serializes the loop — measured **30x** pathological (0.3 tok/s) on Granite Rapids runners before the fix.
- **Fused-region memory addressing diet** (`x64HoistMem`): m.M and the memSize *value* pin once per region/loop in free argument-tail registers (splices contain no calls, so memory cannot grow); member accesses use indexed addressing and bounds checks become one `CMPQ`. The q8 kernel's loop drops from 264 to 212 instructions with zero Module reloads.
- **Runtime dispatch**: the amd64 `archSpec` gains the `// avx2 dot` marker, so gated bodies are emitted twice (`<fn>avx2` + a PortableSIMD `<fn>sse` twin) behind a `NOSPLIT` tail-jump stub on `base.HasAVX2`; `cpufeat_amd64` detects AVX2 via CPUID/XGETBV, dependency-free. The gcasm bundle cleanup now preserves `cpufeat_*` files (they carried an amd64 build tag and were deleted, breaking the bundle build — regression-tested at the transpile level).

## Validation

- Unit tests: rewrite shapes (direct pair, spine chain, accumulator spine, shared-extend rejection), staging order (both sources staged before either extend — X2 is Y2's own low half), loop hoisting (no Module loads inside the loop body), portable twin stays literal SSE.
- Full `internal/gcasm` + `transpile` suites green; amd64 execution via the differential/loop suites on CI.
- Downstream: go-llama q8 decode produces correct tokens on Intel, AMD, and (unchanged) arm64 runners; full go-llama suite green across GOAMD64 v1/v2 and arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
