### PR TITLE
Compose wasi-threads with memory64: addr64 atomics and shared-mem64 modules

### DIFF
--- a/internal/codegen/cg_threads_m64_test.go
+++ b/internal/codegen/cg_threads_m64_test.go
@@ -1,0 +1,190 @@
+package codegen_test
+
+// Memory64 counterparts of the wasi-threads and single-agent atomics tests:
+// the same guests with i64 addressing on a shared memory64, so every atomic
+// routes through the _m64 helper family and the i64 start_arg spawn path.
+// Like the wasm32 originals, the generated programs run under the race
+// detector — a wasm thread is a goroutine, so unsynchronised access to the
+// shared linear memory (above all a grow that relocated it) surfaces as a
+// race, not a flake.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+func TestThreadsM64(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_threads_m64.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+
+	main := `package main
+
+import (
+	"fmt"
+	"gentest/pkg"
+)
+
+func main() {
+	// The only wasi import (thread-spawn) is goroutine-backed and internal,
+	// so the generated constructor takes no host parameters at all.
+	m := pkg.New()
+	// 8 agents, each +1 on the counter, joined through atomic wait/notify.
+	fmt.Printf("joined -> %d\n", m.SpawnAndJoin(8))
+	// Growing a shared memory must preserve both contents and pointers:
+	// 2 pages * 65536 + 0xbeef = 131072 + 48879.
+	fmt.Printf("grown -> %d\n", m.GrowShared())
+}
+`
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	want := "joined -> 8\ngrown -> 179951\n"
+	if got != want {
+		t.Errorf("output mismatch\n--want--\n%s\n--got--\n%s", want, got)
+	}
+	if strings.Contains(got, "DATA RACE") {
+		t.Errorf("race detected:\n%s", got)
+	}
+}
+
+func TestThreadsVisibilityM64(t *testing.T) {
+	// A plain store published by an atomic store must be visible to a
+	// goroutine-agent that acquires via an atomic load — on i64 addresses.
+	bin := testfixture.Wasm(t, "cg_threads_visibility_m64.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	main := "package main\n\nimport (\n\t\"fmt\"\n\t\"gentest/pkg\"\n)\n\nfunc main() {\n\tm := pkg.New()\n\tfmt.Println(m.Run())\n}\n"
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	if strings.TrimSpace(got) != "4242" {
+		t.Errorf("cross-thread plain-store visibility (memory64): got %q, want 4242", got)
+	}
+}
+
+// TestAtomicsM64 drives the single-agent atomics matrix on a shared memory64.
+// The wasm32 twin (cg_atomics.wat) is diffed against wazero by the fixtures
+// matrix; this mirror asserts the same deterministic values, which pins the
+// _m64 helper routing without needing a memory64+threads reference engine.
+func TestAtomicsM64(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_atomics_m64.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	main := `package main
+
+import (
+	"fmt"
+	"gentest/pkg"
+)
+
+func main() {
+	m := pkg.New()
+	fmt.Println("rmw32", m.Rmw32())
+	fmt.Println("rmw64", m.Rmw64())
+	fmt.Println("xchg", m.Xchg())
+	fmt.Println("cmpxchg", m.Cmpxchg())
+	fmt.Println("subword", m.Subword())
+	fmt.Println("subword_cmpxchg", m.SubwordCmpxchg())
+	fmt.Println("wait_notify", m.WaitNotify())
+	fmt.Println("fenced_load", m.FencedLoad())
+	fmt.Println("store_neg", m.StoreNeg())
+}
+`
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	want := `rmw32 361
+rmw64 8000000000
+xchg 16
+cmpxchg 6
+subword 305441536
+subword_cmpxchg 9
+wait_notify 1
+fenced_load 42
+store_neg -1
+`
+	if got != want {
+		t.Errorf("output mismatch\n--want--\n%s\n--got--\n%s", want, got)
+	}
+}
+
+// TestMem64UnsharedAtomics locks the regression where every 0xFE opcode on a
+// memory64 module was rejected — atomics on a plain (unshared) memory64 are
+// legal wasm and must both transpile and run.
+func TestMem64UnsharedAtomics(t *testing.T) {
+	bin := testfixture.Wasm(t, "cg_mem64_atomics_unshared.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate (unshared memory64 with atomics): %v", err)
+	}
+	main := `package main
+
+import (
+	"fmt"
+	"gentest/pkg"
+)
+
+func main() {
+	m := pkg.New()
+	fmt.Println(m.Bump())
+	// A wait on an unshared memory never parks: not-equal result.
+	fmt.Println(m.WaitUnshared())
+}
+`
+	got := runGoSnippetRaceDetector(t, buf.String(), main, res.Sidecars, res.Files)
+	if want := "42\n1\n"; got != want {
+		t.Errorf("unshared memory64 atomics: got %q, want %q", got, want)
+	}
+}
+
+// TestSharedMem64RequiresMax: a shared memory64 with no declared maximum has
+// no reservable growth ceiling (the fallback would be the mem64 hard cap),
+// so translation must fail with a clear error. The spec requires shared
+// memories to declare a maximum, but the parser tolerates its absence, so
+// the binary is hand-assembled (wat2wasm refuses to emit it).
+func TestSharedMem64RequiresMax(t *testing.T) {
+	bin := []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // header
+		0x05, 0x03, // memory section, 3 bytes
+		0x01,       // one memory
+		0x06, 0x01, // limits: shared|mem64 flags, min 1, NO max
+	}
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	_, err = codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err == nil {
+		t.Fatal("shared memory64 without a maximum translated; want an error")
+	}
+	if !strings.Contains(err.Error(), "shared memory64 requires a declared maximum") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/codegen/emit_memops.go
+++ b/internal/codegen/emit_memops.go
@@ -483,12 +483,19 @@ type atomicInlineSpec struct {
 
 // atomicInlineSpecs maps OpAtomicCall helper names (lower.go feAtomics)
 // to their inline form. Only the four full-width aligned accesses
-// appear here; absence means "keep the helper call".
+// appear here — in both address widths, since the op itself is
+// identical and only the effective-address arithmetic differs (see
+// memOffsetExpr / memOffsetExpr64); absence means "keep the helper
+// call".
 var atomicInlineSpecs = map[string]atomicInlineSpec{
-	"atomicLoad32":  {elemType: "uint32", fn: "LoadUint32", loadCast: "int32"},
-	"atomicLoad64":  {elemType: "uint64", fn: "LoadUint64", loadCast: "int64"},
-	"atomicStore32": {elemType: "uint32", fn: "StoreUint32", isStore: true},
-	"atomicStore64": {elemType: "uint64", fn: "StoreUint64", isStore: true},
+	"atomicLoad32":      {elemType: "uint32", fn: "LoadUint32", loadCast: "int32"},
+	"atomicLoad64":      {elemType: "uint64", fn: "LoadUint64", loadCast: "int64"},
+	"atomicStore32":     {elemType: "uint32", fn: "StoreUint32", isStore: true},
+	"atomicStore64":     {elemType: "uint64", fn: "StoreUint64", isStore: true},
+	"atomicLoad32_m64":  {elemType: "uint32", fn: "LoadUint32", loadCast: "int32"},
+	"atomicLoad64_m64":  {elemType: "uint64", fn: "LoadUint64", loadCast: "int64"},
+	"atomicStore32_m64": {elemType: "uint32", fn: "StoreUint32", isStore: true},
+	"atomicStore64_m64": {elemType: "uint64", fn: "StoreUint64", isStore: true},
 }
 
 // emitAtomicInline renders an OpAtomicCall as an inline sync/atomic
@@ -503,9 +510,22 @@ func (em *ssaEmitter) emitAtomicInline(v *ssa.Value, name string, emitExpr func(
 	if !ok {
 		return nil, false, nil
 	}
-	off := ssaConstBase(v.Args[1])
-	if off == nil {
-		return nil, false, nil
+	// The static offset is the OpConst32 (wasm32) or OpConst64 (memory64)
+	// the lowering built; its width decides the truncation-free extraction.
+	// memOffsetExpr itself dispatches on em.mem64 for the address math.
+	var offU uint64
+	if em.mem64 {
+		off := ssaConstBase64(v.Args[1])
+		if off == nil {
+			return nil, false, nil
+		}
+		offU = uint64(off.AuxInt)
+	} else {
+		off := ssaConstBase(v.Args[1])
+		if off == nil {
+			return nil, false, nil
+		}
+		offU = uint64(uint32(off.AuxInt))
 	}
 	baseExpr, err := emitExpr(v.Args[0])
 	if err != nil {
@@ -517,7 +537,7 @@ func (em *ssaEmitter) emitAtomicInline(v *ssa.Value, name string, emitExpr func(
 		Fun: &ast.SelectorExpr{X: newID("unsafe"), Sel: newID("Add")},
 		Args: []ast.Expr{
 			em.memBasePtrExpr(),
-			em.memOffsetExpr(baseExpr, uint64(uint32(off.AuxInt)), v.Args[0]),
+			em.memOffsetExpr(baseExpr, offU, v.Args[0]),
 		},
 	}
 	ptr := &ast.CallExpr{

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -1339,7 +1339,14 @@ func (em *ssaEmitter) emitCallImport(v *ssa.Value, emit func(*ssa.Value) (ast.Ex
 	// interface means an embedder gets threads without implementing anything.
 	if imp.Module == "wasi" && imp.Name == "thread-spawn" ||
 		imp.Module == "wasi_snapshot_preview1" && imp.Name == "thread_spawn" {
-		em.useHelper("threadSpawn")
+		// On a memory64 module the start_arg is an i64 linear-memory
+		// pointer, so the spawn routes to the i64-arg helper twin (which
+		// reads the threadStart64 field the mem64 Module struct declares).
+		helper := "threadSpawn"
+		if em.mem64 {
+			helper = "threadSpawn_m64"
+		}
+		em.useHelper(helper)
 		args := []ast.Expr{newID("m")}
 		for _, a := range v.Args {
 			ae, err := emit(a)
@@ -1348,7 +1355,7 @@ func (em *ssaEmitter) emitCallImport(v *ssa.Value, emit func(*ssa.Value) (ast.Ex
 			}
 			args = append(args, ae)
 		}
-		return &ast.CallExpr{Fun: em.helperRef("threadSpawn"), Args: args}, nil
+		return &ast.CallExpr{Fun: em.helperRef(helper), Args: args}, nil
 	}
 	args := []ast.Expr{newID("m")}
 	for _, a := range v.Args {

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -63,6 +63,12 @@ type Module struct {
 	// base cannot import the main package to call it directly. It takes the
 	// Module explicitly so threadSpawn can hand the AGENT'S clone to it.
 	threadStart func(m *Module, tid int32, arg int32)
+	// threadStart64 is threadStart for a memory64 module: the start_arg the
+	// guest hands wasi_thread_spawn is a linear-memory pointer, so it is an
+	// i64 there. Generated output declares exactly ONE of the two fields —
+	// whichever matches the module's memory width; this placeholder carries
+	// both so the helpers package compiles standalone.
+	threadStart64 func(m *Module, tid int32, arg int64)
 	// threads tracks agents spawned through wasi_thread_spawn.
 	threads *threadPool
 }
@@ -1269,20 +1275,40 @@ func atomicEA(m *Module, addr int32, offset int32, size uint64) uint64 {
 	return ea
 }
 
+// atomicEA64 is atomicEA for a memory64 memory: i64 address and offset with
+// overflow-safe u64 effective-address arithmetic (mirroring simdEA64 — a
+// negative addr or offset becomes a huge u64 that either wraps the addition,
+// caught by the wrap checks, or fails the bounds check), then the same
+// natural-alignment check the proposal requires.
+//
 //go:noinline
-func atomicPtr32(m *Module, addr int32, offset int32) *uint32 {
-	ea := atomicEA(m, addr, offset, 4)
-	// atomicEA already bounds-checked ea against memSize, so index off the
-	// raw base pointer to skip Go's redundant slice bounds check — the same
-	// deal the plain load/store path gets. m.M tracks m.memory's data
-	// pointer (New sets it; a shared memory never relocates, and the
-	// non-shared reallocate path refreshes it).
+func atomicEA64(m *Module, addr int64, offset int64, size uint64) uint64 {
+	ea := uint64(addr) + uint64(offset)
+	end := ea + size
+	if ea < uint64(addr) || end < ea || end > m.memSize.Load() {
+		wasm_trap_atomic_oob()
+	}
+	if ea&(size-1) != 0 {
+		wasm_trap_atomic_unaligned()
+	}
+	return ea
+}
+
+// atomicPtr32At / atomicPtr64At turn a CHECKED effective address into a
+// pointer into linear memory. The caller went through atomicEA/atomicEA64,
+// which already bounds-checked ea against memSize, so index off the raw
+// base pointer to skip Go's redundant slice bounds check — the same deal
+// the plain load/store path gets. m.M tracks m.memory's data pointer (New
+// sets it; a shared memory never relocates, and the non-shared reallocate
+// path refreshes it).
+//
+//go:noinline
+func atomicPtr32At(m *Module, ea uint64) *uint32 {
 	return (*uint32)(unsafe.Add(m.M, uintptr(ea)))
 }
 
 //go:noinline
-func atomicPtr64(m *Module, addr int32, offset int32) *uint64 {
-	ea := atomicEA(m, addr, offset, 8)
+func atomicPtr64At(m *Module, ea uint64) *uint64 {
 	return (*uint64)(unsafe.Add(m.M, uintptr(ea)))
 }
 
@@ -1322,48 +1348,27 @@ func atomicSubword32(m *Module, ea uint64, bits uint, op func(old uint32) uint32
 	}
 }
 
+// ----- Effective-address-based atomic cores --------------------------------
+//
+// Every atomic op body lives in an ...At core keyed on a CHECKED effective
+// address; the wasm32 helpers the lowering names (atomicLoad32, ...) and
+// their memory64 twins (atomicLoad32_m64, ...) are one-line wrappers that
+// differ only in how the effective address is computed (atomicEA vs
+// atomicEA64). The //go:noinline rationale above applies to the cores too.
+
 //go:noinline
-func atomicLoad32(m *Module, addr int32, offset int32) int32 {
-	return int32(atomic.LoadUint32(atomicPtr32(m, addr, offset)))
+func atomicLoad32At(m *Module, ea uint64) int32 {
+	return int32(atomic.LoadUint32(atomicPtr32At(m, ea)))
 }
 
 //go:noinline
-func atomicLoad64(m *Module, addr int32, offset int32) int64 {
-	return int64(atomic.LoadUint64(atomicPtr64(m, addr, offset)))
+func atomicLoad64At(m *Module, ea uint64) int64 {
+	return int64(atomic.LoadUint64(atomicPtr64At(m, ea)))
 }
 
 //go:noinline
-func atomicLoad32_8u(m *Module, addr int32, offset int32) int32 {
-	ea := atomicEA(m, addr, offset, 1)
-	return int32(atomicSubword32(m, ea, 8, func(old uint32) uint32 { return old }))
-}
-
-//go:noinline
-func atomicLoad32_16u(m *Module, addr int32, offset int32) int32 {
-	ea := atomicEA(m, addr, offset, 2)
-	return int32(atomicSubword32(m, ea, 16, func(old uint32) uint32 { return old }))
-}
-
-//go:noinline
-func atomicLoad64_8u(m *Module, addr int32, offset int32) int64 {
-	ea := atomicEA(m, addr, offset, 1)
-	return int64(atomicSubword32(m, ea, 8, func(old uint32) uint32 { return old }))
-}
-
-//go:noinline
-func atomicLoad64_16u(m *Module, addr int32, offset int32) int64 {
-	ea := atomicEA(m, addr, offset, 2)
-	return int64(atomicSubword32(m, ea, 16, func(old uint32) uint32 { return old }))
-}
-
-//go:noinline
-func atomicLoad64_32u(m *Module, addr int32, offset int32) int64 {
-	return int64(atomic.LoadUint32(atomicPtr32(m, addr, offset)))
-}
-
-//go:noinline
-func atomicStore32(m *Module, addr int32, offset int32, v int32) int32 {
-	p := atomicPtr32(m, addr, offset)
+func atomicStore32At(m *Module, ea uint64, v int32) int32 {
+	p := atomicPtr32At(m, ea)
 	if atomicsContended(m) {
 		atomic.StoreUint32(p, uint32(v))
 	} else {
@@ -1373,8 +1378,8 @@ func atomicStore32(m *Module, addr int32, offset int32, v int32) int32 {
 }
 
 //go:noinline
-func atomicStore64(m *Module, addr int32, offset int32, v int64) int32 {
-	p := atomicPtr64(m, addr, offset)
+func atomicStore64At(m *Module, ea uint64, v int64) int32 {
+	p := atomicPtr64At(m, ea)
 	if atomicsContended(m) {
 		atomic.StoreUint64(p, uint64(v))
 	} else {
@@ -1384,47 +1389,8 @@ func atomicStore64(m *Module, addr int32, offset int32, v int64) int32 {
 }
 
 //go:noinline
-func atomicStore32_8(m *Module, addr int32, offset int32, v int32) int32 {
-	ea := atomicEA(m, addr, offset, 1)
-	atomicSubword32(m, ea, 8, func(uint32) uint32 { return uint32(v) })
-	return 0
-}
-
-//go:noinline
-func atomicStore32_16(m *Module, addr int32, offset int32, v int32) int32 {
-	ea := atomicEA(m, addr, offset, 2)
-	atomicSubword32(m, ea, 16, func(uint32) uint32 { return uint32(v) })
-	return 0
-}
-
-//go:noinline
-func atomicStore64_8(m *Module, addr int32, offset int32, v int64) int32 {
-	ea := atomicEA(m, addr, offset, 1)
-	atomicSubword32(m, ea, 8, func(uint32) uint32 { return uint32(v) })
-	return 0
-}
-
-//go:noinline
-func atomicStore64_16(m *Module, addr int32, offset int32, v int64) int32 {
-	ea := atomicEA(m, addr, offset, 2)
-	atomicSubword32(m, ea, 16, func(uint32) uint32 { return uint32(v) })
-	return 0
-}
-
-//go:noinline
-func atomicStore64_32(m *Module, addr int32, offset int32, v int64) int32 {
-	p := atomicPtr32(m, addr, offset)
-	if atomicsContended(m) {
-		atomic.StoreUint32(p, uint32(v))
-	} else {
-		*p = uint32(v)
-	}
-	return 0
-}
-
-//go:noinline
-func atomicRmw32(m *Module, addr int32, offset int32, op func(old uint32) uint32) int32 {
-	p := atomicPtr32(m, addr, offset)
+func atomicRmw32At(m *Module, ea uint64, op func(old uint32) uint32) int32 {
+	p := atomicPtr32At(m, ea)
 	if !atomicsContended(m) {
 		cur := *p
 		*p = op(cur)
@@ -1439,8 +1405,8 @@ func atomicRmw32(m *Module, addr int32, offset int32, op func(old uint32) uint32
 }
 
 //go:noinline
-func atomicRmw64(m *Module, addr int32, offset int32, op func(old uint64) uint64) int64 {
-	p := atomicPtr64(m, addr, offset)
+func atomicRmw64At(m *Module, ea uint64, op func(old uint64) uint64) int64 {
+	p := atomicPtr64At(m, ea)
 	if !atomicsContended(m) {
 		cur := *p
 		*p = op(cur)
@@ -1455,8 +1421,8 @@ func atomicRmw64(m *Module, addr int32, offset int32, op func(old uint64) uint64
 }
 
 //go:noinline
-func atomicRmwAdd32(m *Module, addr, offset, v int32) int32 {
-	p := atomicPtr32(m, addr, offset)
+func atomicRmwAdd32At(m *Module, ea uint64, v int32) int32 {
+	p := atomicPtr32At(m, ea)
 	if !atomicsContended(m) {
 		old := *p
 		*p = old + uint32(v)
@@ -1466,8 +1432,8 @@ func atomicRmwAdd32(m *Module, addr, offset, v int32) int32 {
 }
 
 //go:noinline
-func atomicRmwSub32(m *Module, addr, offset, v int32) int32 {
-	p := atomicPtr32(m, addr, offset)
+func atomicRmwSub32At(m *Module, ea uint64, v int32) int32 {
+	p := atomicPtr32At(m, ea)
 	if !atomicsContended(m) {
 		old := *p
 		*p = old - uint32(v)
@@ -1477,23 +1443,8 @@ func atomicRmwSub32(m *Module, addr, offset, v int32) int32 {
 }
 
 //go:noinline
-func atomicRmwAnd32(m *Module, addr, offset, v int32) int32 {
-	return atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o & uint32(v) })
-}
-
-//go:noinline
-func atomicRmwOr32(m *Module, addr, offset, v int32) int32 {
-	return atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o | uint32(v) })
-}
-
-//go:noinline
-func atomicRmwXor32(m *Module, addr, offset, v int32) int32 {
-	return atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o ^ uint32(v) })
-}
-
-//go:noinline
-func atomicRmwXchg32(m *Module, addr, offset, v int32) int32 {
-	p := atomicPtr32(m, addr, offset)
+func atomicRmwXchg32At(m *Module, ea uint64, v int32) int32 {
+	p := atomicPtr32At(m, ea)
 	if !atomicsContended(m) {
 		old := *p
 		*p = uint32(v)
@@ -1503,8 +1454,8 @@ func atomicRmwXchg32(m *Module, addr, offset, v int32) int32 {
 }
 
 //go:noinline
-func atomicRmwCmpxchg32(m *Module, addr, offset, expected, replacement int32) int32 {
-	p := atomicPtr32(m, addr, offset)
+func atomicRmwCmpxchg32At(m *Module, ea uint64, expected, replacement int32) int32 {
+	p := atomicPtr32At(m, ea)
 	if !atomicsContended(m) {
 		cur := *p
 		if cur == uint32(expected) {
@@ -1524,8 +1475,8 @@ func atomicRmwCmpxchg32(m *Module, addr, offset, expected, replacement int32) in
 }
 
 //go:noinline
-func atomicRmwAdd64(m *Module, addr, offset int32, v int64) int64 {
-	p := atomicPtr64(m, addr, offset)
+func atomicRmwAdd64At(m *Module, ea uint64, v int64) int64 {
+	p := atomicPtr64At(m, ea)
 	if !atomicsContended(m) {
 		old := *p
 		*p = old + uint64(v)
@@ -1535,8 +1486,8 @@ func atomicRmwAdd64(m *Module, addr, offset int32, v int64) int64 {
 }
 
 //go:noinline
-func atomicRmwSub64(m *Module, addr, offset int32, v int64) int64 {
-	p := atomicPtr64(m, addr, offset)
+func atomicRmwSub64At(m *Module, ea uint64, v int64) int64 {
+	p := atomicPtr64At(m, ea)
 	if !atomicsContended(m) {
 		old := *p
 		*p = old - uint64(v)
@@ -1546,23 +1497,8 @@ func atomicRmwSub64(m *Module, addr, offset int32, v int64) int64 {
 }
 
 //go:noinline
-func atomicRmwAnd64(m *Module, addr, offset int32, v int64) int64 {
-	return atomicRmw64(m, addr, offset, func(o uint64) uint64 { return o & uint64(v) })
-}
-
-//go:noinline
-func atomicRmwOr64(m *Module, addr, offset int32, v int64) int64 {
-	return atomicRmw64(m, addr, offset, func(o uint64) uint64 { return o | uint64(v) })
-}
-
-//go:noinline
-func atomicRmwXor64(m *Module, addr, offset int32, v int64) int64 {
-	return atomicRmw64(m, addr, offset, func(o uint64) uint64 { return o ^ uint64(v) })
-}
-
-//go:noinline
-func atomicRmwXchg64(m *Module, addr, offset int32, v int64) int64 {
-	p := atomicPtr64(m, addr, offset)
+func atomicRmwXchg64At(m *Module, ea uint64, v int64) int64 {
+	p := atomicPtr64At(m, ea)
 	if !atomicsContended(m) {
 		old := *p
 		*p = uint64(v)
@@ -1572,8 +1508,8 @@ func atomicRmwXchg64(m *Module, addr, offset int32, v int64) int64 {
 }
 
 //go:noinline
-func atomicRmwCmpxchg64(m *Module, addr, offset int32, expected, replacement int64) int64 {
-	p := atomicPtr64(m, addr, offset)
+func atomicRmwCmpxchg64At(m *Module, ea uint64, expected, replacement int64) int64 {
+	p := atomicPtr64At(m, ea)
 	if !atomicsContended(m) {
 		cur := *p
 		if cur == uint64(expected) {
@@ -1592,75 +1528,253 @@ func atomicRmwCmpxchg64(m *Module, addr, offset int32, expected, replacement int
 	}
 }
 
+// The i64 RMW ops over a 32-bit lane (rmw32_u): always LOCKed accesses,
+// matching the pre-refactor helpers (they never had the uncontended fast
+// path the full-width forms have).
+
 //go:noinline
-func atomicRmwSubword(m *Module, addr, offset int32, size uint64, bits uint, op func(old uint32) uint32) uint32 {
-	ea := atomicEA(m, addr, offset, size)
-	return atomicSubword32(m, ea, bits, op)
+func atomicRmwAdd64_32uAt(m *Module, ea uint64, v int64) int64 {
+	return int64(atomic.AddUint32(atomicPtr32At(m, ea), uint32(v)) - uint32(v))
+}
+
+//go:noinline
+func atomicRmwSub64_32uAt(m *Module, ea uint64, v int64) int64 {
+	return int64(atomic.AddUint32(atomicPtr32At(m, ea), -uint32(v)) + uint32(v))
+}
+
+//go:noinline
+func atomicRmwXchg64_32uAt(m *Module, ea uint64, v int64) int64 {
+	return int64(atomic.SwapUint32(atomicPtr32At(m, ea), uint32(v)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64) int64 {
+	p := atomicPtr32At(m, ea)
+	for {
+		cur := atomic.LoadUint32(p)
+		if cur != uint32(expected) {
+			return int64(cur)
+		}
+		if atomic.CompareAndSwapUint32(p, cur, uint32(replacement)) {
+			return int64(cur)
+		}
+	}
+}
+
+// ----- wasm32 atomic helpers (named by the lowering) -----------------------
+
+//go:noinline
+func atomicLoad32(m *Module, addr int32, offset int32) int32 {
+	return atomicLoad32At(m, atomicEA(m, addr, offset, 4))
+}
+
+//go:noinline
+func atomicLoad64(m *Module, addr int32, offset int32) int64 {
+	return atomicLoad64At(m, atomicEA(m, addr, offset, 8))
+}
+
+//go:noinline
+func atomicLoad32_8u(m *Module, addr int32, offset int32) int32 {
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad32_16u(m *Module, addr int32, offset int32) int32 {
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_8u(m *Module, addr int32, offset int32) int64 {
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_16u(m *Module, addr int32, offset int32) int64 {
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_32u(m *Module, addr int32, offset int32) int64 {
+	return int64(atomic.LoadUint32(atomicPtr32At(m, atomicEA(m, addr, offset, 4))))
+}
+
+//go:noinline
+func atomicStore32(m *Module, addr int32, offset int32, v int32) int32 {
+	return atomicStore32At(m, atomicEA(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicStore64(m *Module, addr int32, offset int32, v int64) int32 {
+	return atomicStore64At(m, atomicEA(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicStore32_8(m *Module, addr int32, offset int32, v int32) int32 {
+	atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore32_16(m *Module, addr int32, offset int32, v int32) int32 {
+	atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_8(m *Module, addr int32, offset int32, v int64) int32 {
+	atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_16(m *Module, addr int32, offset int32, v int64) int32 {
+	atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_32(m *Module, addr int32, offset int32, v int64) int32 {
+	// uint32(int32(v)) == uint32(v): the truncation to the 32-bit lane is
+	// the same through the int32 cast, so the full-width store core serves.
+	return atomicStore32At(m, atomicEA(m, addr, offset, 4), int32(v))
+}
+
+//go:noinline
+func atomicRmwAdd32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmwAdd32At(m, atomicEA(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwSub32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmwSub32At(m, atomicEA(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwAnd32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmw32At(m, atomicEA(m, addr, offset, 4), func(o uint32) uint32 { return o & uint32(v) })
+}
+
+//go:noinline
+func atomicRmwOr32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmw32At(m, atomicEA(m, addr, offset, 4), func(o uint32) uint32 { return o | uint32(v) })
+}
+
+//go:noinline
+func atomicRmwXor32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmw32At(m, atomicEA(m, addr, offset, 4), func(o uint32) uint32 { return o ^ uint32(v) })
+}
+
+//go:noinline
+func atomicRmwXchg32(m *Module, addr, offset, v int32) int32 {
+	return atomicRmwXchg32At(m, atomicEA(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwCmpxchg32(m *Module, addr, offset, expected, replacement int32) int32 {
+	return atomicRmwCmpxchg32At(m, atomicEA(m, addr, offset, 4), expected, replacement)
+}
+
+//go:noinline
+func atomicRmwAdd64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmwAdd64At(m, atomicEA(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicRmwSub64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmwSub64At(m, atomicEA(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicRmwAnd64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmw64At(m, atomicEA(m, addr, offset, 8), func(o uint64) uint64 { return o & uint64(v) })
+}
+
+//go:noinline
+func atomicRmwOr64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmw64At(m, atomicEA(m, addr, offset, 8), func(o uint64) uint64 { return o | uint64(v) })
+}
+
+//go:noinline
+func atomicRmwXor64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmw64At(m, atomicEA(m, addr, offset, 8), func(o uint64) uint64 { return o ^ uint64(v) })
+}
+
+//go:noinline
+func atomicRmwXchg64(m *Module, addr, offset int32, v int64) int64 {
+	return atomicRmwXchg64At(m, atomicEA(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicRmwCmpxchg64(m *Module, addr, offset int32, expected, replacement int64) int64 {
+	return atomicRmwCmpxchg64At(m, atomicEA(m, addr, offset, 8), expected, replacement)
 }
 
 //go:noinline
 func atomicRmwAdd32_8u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o + uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o + uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAdd32_16u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o + uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o + uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwSub32_8u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o - uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o - uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwSub32_16u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o - uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o - uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAnd32_8u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o & uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o & uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAnd32_16u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o & uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o & uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwOr32_8u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o | uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o | uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwOr32_16u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o | uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o | uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXor32_8u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o ^ uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o ^ uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXor32_16u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o ^ uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o ^ uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXchg32_8u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 1, 8, func(uint32) uint32 { return uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXchg32_16u(m *Module, addr, offset, v int32) int32 {
-	return int32(atomicRmwSubword(m, addr, offset, 2, 16, func(uint32) uint32 { return uint32(v) }))
+	return int32(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) }))
 }
 
+// atomicCmpxchgSubword is the compare-exchange counterpart of
+// atomicSubword32: CAS on the byte lanes [shift, shift+bits) of the aligned
+// 32-bit word containing the checked effective address ea.
+//
 //go:noinline
-func atomicCmpxchgSubword(m *Module, addr, offset int32, size uint64, bits uint, expected, replacement uint32) uint32 {
-	ea := atomicEA(m, addr, offset, size)
+func atomicCmpxchgSubword(m *Module, ea uint64, bits uint, expected, replacement uint32) uint32 {
 	word := (*uint32)(unsafe.Pointer(&m.memory[ea&^3]))
 	shift := uint(ea&3) * 8
 	mask := uint32(1)<<bits - 1
@@ -1679,126 +1793,117 @@ func atomicCmpxchgSubword(m *Module, addr, offset int32, size uint64, bits uint,
 
 //go:noinline
 func atomicRmwCmpxchg32_8u(m *Module, addr, offset, expected, replacement int32) int32 {
-	return int32(atomicCmpxchgSubword(m, addr, offset, 1, 8, uint32(expected), uint32(replacement)))
+	return int32(atomicCmpxchgSubword(m, atomicEA(m, addr, offset, 1), 8, uint32(expected), uint32(replacement)))
 }
 
 //go:noinline
 func atomicRmwCmpxchg32_16u(m *Module, addr, offset, expected, replacement int32) int32 {
-	return int32(atomicCmpxchgSubword(m, addr, offset, 2, 16, uint32(expected), uint32(replacement)))
+	return int32(atomicCmpxchgSubword(m, atomicEA(m, addr, offset, 2), 16, uint32(expected), uint32(replacement)))
 }
 
 //go:noinline
 func atomicRmwAdd64_8u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o + uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o + uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAdd64_16u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o + uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o + uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAdd64_32u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomic.AddUint32(atomicPtr32(m, addr, offset), uint32(v)) - uint32(v))
+	return atomicRmwAdd64_32uAt(m, atomicEA(m, addr, offset, 4), v)
 }
 
 //go:noinline
 func atomicRmwSub64_8u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o - uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o - uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwSub64_16u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o - uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o - uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwSub64_32u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomic.AddUint32(atomicPtr32(m, addr, offset), -uint32(v)) + uint32(v))
+	return atomicRmwSub64_32uAt(m, atomicEA(m, addr, offset, 4), v)
 }
 
 //go:noinline
 func atomicRmwAnd64_8u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o & uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o & uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAnd64_16u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o & uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o & uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwAnd64_32u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o & uint32(v) })) & 0xffffffff
+	return int64(atomicRmw32At(m, atomicEA(m, addr, offset, 4), func(o uint32) uint32 { return o & uint32(v) })) & 0xffffffff
 }
 
 //go:noinline
 func atomicRmwOr64_8u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o | uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o | uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwOr64_16u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o | uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o | uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwOr64_32u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o | uint32(v) })) & 0xffffffff
+	return int64(atomicRmw32At(m, atomicEA(m, addr, offset, 4), func(o uint32) uint32 { return o | uint32(v) })) & 0xffffffff
 }
 
 //go:noinline
 func atomicRmwXor64_8u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(o uint32) uint32 { return o ^ uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(o uint32) uint32 { return o ^ uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXor64_16u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(o uint32) uint32 { return o ^ uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(o uint32) uint32 { return o ^ uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXor64_32u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmw32(m, addr, offset, func(o uint32) uint32 { return o ^ uint32(v) })) & 0xffffffff
+	return int64(atomicRmw32At(m, atomicEA(m, addr, offset, 4), func(o uint32) uint32 { return o ^ uint32(v) })) & 0xffffffff
 }
 
 //go:noinline
 func atomicRmwXchg64_8u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 1, 8, func(uint32) uint32 { return uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXchg64_16u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomicRmwSubword(m, addr, offset, 2, 16, func(uint32) uint32 { return uint32(v) }))
+	return int64(atomicSubword32(m, atomicEA(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) }))
 }
 
 //go:noinline
 func atomicRmwXchg64_32u(m *Module, addr, offset int32, v int64) int64 {
-	return int64(atomic.SwapUint32(atomicPtr32(m, addr, offset), uint32(v)))
+	return atomicRmwXchg64_32uAt(m, atomicEA(m, addr, offset, 4), v)
 }
 
 //go:noinline
 func atomicRmwCmpxchg64_8u(m *Module, addr, offset int32, expected, replacement int64) int64 {
-	return int64(atomicCmpxchgSubword(m, addr, offset, 1, 8, uint32(expected), uint32(replacement)))
+	return int64(atomicCmpxchgSubword(m, atomicEA(m, addr, offset, 1), 8, uint32(expected), uint32(replacement)))
 }
 
 //go:noinline
 func atomicRmwCmpxchg64_16u(m *Module, addr, offset int32, expected, replacement int64) int64 {
-	return int64(atomicCmpxchgSubword(m, addr, offset, 2, 16, uint32(expected), uint32(replacement)))
+	return int64(atomicCmpxchgSubword(m, atomicEA(m, addr, offset, 2), 16, uint32(expected), uint32(replacement)))
 }
 
 //go:noinline
 func atomicRmwCmpxchg64_32u(m *Module, addr, offset int32, expected, replacement int64) int64 {
-	p := atomicPtr32(m, addr, offset)
-	for {
-		cur := atomic.LoadUint32(p)
-		if cur != uint32(expected) {
-			return int64(cur)
-		}
-		if atomic.CompareAndSwapUint32(p, cur, uint32(replacement)) {
-			return int64(cur)
-		}
-	}
+	return atomicRmwCmpxchg64_32uAt(m, atomicEA(m, addr, offset, 4), expected, replacement)
 }
 
 // atomicFence is a sequentially consistent full barrier. Locking any mutex
@@ -1817,8 +1922,7 @@ func atomicFence(m *Module) int32 {
 //
 //go:noinline
 func atomicNotify(m *Module, addr int32, offset int32, count int32) int32 {
-	ea := atomicEA(m, addr, offset, 4)
-	return m.threads.wake(ea, count)
+	return m.threads.wake(atomicEA(m, addr, offset, 4), count)
 }
 
 // atomicWait32/64 implement memory.atomic.wait: compare-and-park. The compare
@@ -1830,21 +1934,29 @@ func atomicNotify(m *Module, addr int32, offset int32, count int32) int32 {
 // deadlock, so it traps rather than hanging the process.
 //
 //go:noinline
-func atomicWait32(m *Module, addr int32, offset int32, expected int32, timeout int64) int32 {
-	ea := atomicEA(m, addr, offset, 4)
-	p := (*uint32)(unsafe.Add(m.M, uintptr(ea)))
+func atomicWait32At(m *Module, ea uint64, expected int32, timeout int64) int32 {
+	p := atomicPtr32At(m, ea)
 	return atomicWait(m, ea, timeout, func() bool {
 		return int32(atomic.LoadUint32(p)) == expected
 	})
 }
 
 //go:noinline
-func atomicWait64(m *Module, addr int32, offset int32, expected int64, timeout int64) int32 {
-	ea := atomicEA(m, addr, offset, 8)
-	p := (*uint64)(unsafe.Add(m.M, uintptr(ea)))
+func atomicWait64At(m *Module, ea uint64, expected int64, timeout int64) int32 {
+	p := atomicPtr64At(m, ea)
 	return atomicWait(m, ea, timeout, func() bool {
 		return int64(atomic.LoadUint64(p)) == expected
 	})
+}
+
+//go:noinline
+func atomicWait32(m *Module, addr int32, offset int32, expected int32, timeout int64) int32 {
+	return atomicWait32At(m, atomicEA(m, addr, offset, 4), expected, timeout)
+}
+
+//go:noinline
+func atomicWait64(m *Module, addr int32, offset int32, expected int64, timeout int64) int32 {
+	return atomicWait64At(m, atomicEA(m, addr, offset, 8), expected, timeout)
 }
 
 //go:noinline
@@ -1906,6 +2018,349 @@ func atomicWait(m *Module, ea uint64, timeout int64, stillEqual func() bool) int
 	}
 }
 
+// ----- memory64 atomic helpers ---------------------------------------------
+//
+// The _m64 family: one twin per atomic helper the lowering can name on a
+// memory64 module. Signatures mirror the wasm32 forms with i64 address and
+// offset; every body is a one-liner through atomicEA64 (overflow-safe u64
+// effective-address math) into the shared ...At core, so op semantics —
+// including the atomicsContended fast paths — are identical across widths.
+// atomicFence has no twin: it takes no address.
+
+//go:noinline
+func atomicLoad32_m64(m *Module, addr int64, offset int64) int32 {
+	return atomicLoad32At(m, atomicEA64(m, addr, offset, 4))
+}
+
+//go:noinline
+func atomicLoad64_m64(m *Module, addr int64, offset int64) int64 {
+	return atomicLoad64At(m, atomicEA64(m, addr, offset, 8))
+}
+
+//go:noinline
+func atomicLoad32_8u_m64(m *Module, addr int64, offset int64) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad32_16u_m64(m *Module, addr int64, offset int64) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_8u_m64(m *Module, addr int64, offset int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_16u_m64(m *Module, addr int64, offset int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(old uint32) uint32 { return old }))
+}
+
+//go:noinline
+func atomicLoad64_32u_m64(m *Module, addr int64, offset int64) int64 {
+	return int64(atomic.LoadUint32(atomicPtr32At(m, atomicEA64(m, addr, offset, 4))))
+}
+
+//go:noinline
+func atomicStore32_m64(m *Module, addr int64, offset int64, v int32) int32 {
+	return atomicStore32At(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicStore64_m64(m *Module, addr int64, offset int64, v int64) int32 {
+	return atomicStore64At(m, atomicEA64(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicStore32_8_m64(m *Module, addr int64, offset int64, v int32) int32 {
+	atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore32_16_m64(m *Module, addr int64, offset int64, v int32) int32 {
+	atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_8_m64(m *Module, addr int64, offset int64, v int64) int32 {
+	atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_16_m64(m *Module, addr int64, offset int64, v int64) int32 {
+	atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) })
+	return 0
+}
+
+//go:noinline
+func atomicStore64_32_m64(m *Module, addr int64, offset int64, v int64) int32 {
+	return atomicStore32At(m, atomicEA64(m, addr, offset, 4), int32(v))
+}
+
+//go:noinline
+func atomicRmwAdd32_m64(m *Module, addr, offset int64, v int32) int32 {
+	return atomicRmwAdd32At(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwSub32_m64(m *Module, addr, offset int64, v int32) int32 {
+	return atomicRmwSub32At(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwAnd32_m64(m *Module, addr, offset int64, v int32) int32 {
+	return atomicRmw32At(m, atomicEA64(m, addr, offset, 4), func(o uint32) uint32 { return o & uint32(v) })
+}
+
+//go:noinline
+func atomicRmwOr32_m64(m *Module, addr, offset int64, v int32) int32 {
+	return atomicRmw32At(m, atomicEA64(m, addr, offset, 4), func(o uint32) uint32 { return o | uint32(v) })
+}
+
+//go:noinline
+func atomicRmwXor32_m64(m *Module, addr, offset int64, v int32) int32 {
+	return atomicRmw32At(m, atomicEA64(m, addr, offset, 4), func(o uint32) uint32 { return o ^ uint32(v) })
+}
+
+//go:noinline
+func atomicRmwXchg32_m64(m *Module, addr, offset int64, v int32) int32 {
+	return atomicRmwXchg32At(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwCmpxchg32_m64(m *Module, addr, offset int64, expected, replacement int32) int32 {
+	return atomicRmwCmpxchg32At(m, atomicEA64(m, addr, offset, 4), expected, replacement)
+}
+
+//go:noinline
+func atomicRmwAdd64_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmwAdd64At(m, atomicEA64(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicRmwSub64_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmwSub64At(m, atomicEA64(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicRmwAnd64_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmw64At(m, atomicEA64(m, addr, offset, 8), func(o uint64) uint64 { return o & uint64(v) })
+}
+
+//go:noinline
+func atomicRmwOr64_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmw64At(m, atomicEA64(m, addr, offset, 8), func(o uint64) uint64 { return o | uint64(v) })
+}
+
+//go:noinline
+func atomicRmwXor64_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmw64At(m, atomicEA64(m, addr, offset, 8), func(o uint64) uint64 { return o ^ uint64(v) })
+}
+
+//go:noinline
+func atomicRmwXchg64_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmwXchg64At(m, atomicEA64(m, addr, offset, 8), v)
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_m64(m *Module, addr, offset int64, expected, replacement int64) int64 {
+	return atomicRmwCmpxchg64At(m, atomicEA64(m, addr, offset, 8), expected, replacement)
+}
+
+//go:noinline
+func atomicRmwAdd32_8u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAdd32_16u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub32_8u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub32_16u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd32_8u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd32_16u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr32_8u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr32_16u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor32_8u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor32_16u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg32_8u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg32_16u_m64(m *Module, addr, offset int64, v int32) int32 {
+	return int32(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwCmpxchg32_8u_m64(m *Module, addr, offset int64, expected, replacement int32) int32 {
+	return int32(atomicCmpxchgSubword(m, atomicEA64(m, addr, offset, 1), 8, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg32_16u_m64(m *Module, addr, offset int64, expected, replacement int32) int32 {
+	return int32(atomicCmpxchgSubword(m, atomicEA64(m, addr, offset, 2), 16, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwAdd64_8u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAdd64_16u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o + uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAdd64_32u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmwAdd64_32uAt(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwSub64_8u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub64_16u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o - uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwSub64_32u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmwSub64_32uAt(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwAnd64_8u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd64_16u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o & uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwAnd64_32u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicRmw32At(m, atomicEA64(m, addr, offset, 4), func(o uint32) uint32 { return o & uint32(v) })) & 0xffffffff
+}
+
+//go:noinline
+func atomicRmwOr64_8u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr64_16u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o | uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwOr64_32u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicRmw32At(m, atomicEA64(m, addr, offset, 4), func(o uint32) uint32 { return o | uint32(v) })) & 0xffffffff
+}
+
+//go:noinline
+func atomicRmwXor64_8u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor64_16u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(o uint32) uint32 { return o ^ uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXor64_32u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicRmw32At(m, atomicEA64(m, addr, offset, 4), func(o uint32) uint32 { return o ^ uint32(v) })) & 0xffffffff
+}
+
+//go:noinline
+func atomicRmwXchg64_8u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 1), 8, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg64_16u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return int64(atomicSubword32(m, atomicEA64(m, addr, offset, 2), 16, func(uint32) uint32 { return uint32(v) }))
+}
+
+//go:noinline
+func atomicRmwXchg64_32u_m64(m *Module, addr, offset int64, v int64) int64 {
+	return atomicRmwXchg64_32uAt(m, atomicEA64(m, addr, offset, 4), v)
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_8u_m64(m *Module, addr, offset int64, expected, replacement int64) int64 {
+	return int64(atomicCmpxchgSubword(m, atomicEA64(m, addr, offset, 1), 8, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_16u_m64(m *Module, addr, offset int64, expected, replacement int64) int64 {
+	return int64(atomicCmpxchgSubword(m, atomicEA64(m, addr, offset, 2), 16, uint32(expected), uint32(replacement)))
+}
+
+//go:noinline
+func atomicRmwCmpxchg64_32u_m64(m *Module, addr, offset int64, expected, replacement int64) int64 {
+	return atomicRmwCmpxchg64_32uAt(m, atomicEA64(m, addr, offset, 4), expected, replacement)
+}
+
+//go:noinline
+func atomicNotify_m64(m *Module, addr int64, offset int64, count int32) int32 {
+	return m.threads.wake(atomicEA64(m, addr, offset, 4), count)
+}
+
+//go:noinline
+func atomicWait32_m64(m *Module, addr int64, offset int64, expected int32, timeout int64) int32 {
+	return atomicWait32At(m, atomicEA64(m, addr, offset, 4), expected, timeout)
+}
+
+//go:noinline
+func atomicWait64_m64(m *Module, addr int64, offset int64, expected int64, timeout int64) int32 {
+	return atomicWait64At(m, atomicEA64(m, addr, offset, 8), expected, timeout)
+}
+
 // ----- wasi-threads ---------------------------------------------------------
 //
 // A wasm thread is a goroutine. wasi_thread_spawn hands the guest a TID and
@@ -1946,15 +2401,11 @@ func (p *threadPool) wake(ea uint64, count int32) int32 {
 	return n
 }
 
-// threadSpawn implements the wasi_thread_spawn import: run the guest's thread
-// entry on a goroutine, return the new TID (negative means "cannot spawn").
+// threadLaunch allocates a TID and runs body — the guest's thread entry
+// already bound to its start argument — on a fresh goroutine-agent.
 //
 //go:noinline
-func threadSpawn(m *Module, arg int32) int32 {
-	start := m.threadStart
-	if start == nil {
-		return -1 // module exports no wasi_thread_start: nothing to run
-	}
+func threadLaunch(m *Module, body func(child *Module, tid int32)) int32 {
 	tid := m.threads.nextTID.Add(1)
 	m.threads.wg.Add(1)
 	// The agent runs on a struct COPY: same memory (the slice header is
@@ -1982,9 +2433,34 @@ func threadSpawn(m *Module, arg int32) int32 {
 				panic(r)
 			}
 		}()
-		start(child, tid, arg)
+		body(child, tid)
 	}()
 	return tid
+}
+
+// threadSpawn implements the wasi_thread_spawn import: run the guest's thread
+// entry on a goroutine, return the new TID (negative means "cannot spawn").
+//
+//go:noinline
+func threadSpawn(m *Module, arg int32) int32 {
+	start := m.threadStart
+	if start == nil {
+		return -1 // module exports no wasi_thread_start: nothing to run
+	}
+	return threadLaunch(m, func(child *Module, tid int32) { start(child, tid, arg) })
+}
+
+// threadSpawn_m64 is threadSpawn for a memory64 module: the guest's
+// start_arg is a linear-memory pointer and therefore an i64. The TID
+// stays an i32 — wasi_thread_spawn returns i32 in both widths.
+//
+//go:noinline
+func threadSpawn_m64(m *Module, arg int64) int32 {
+	start := m.threadStart64
+	if start == nil {
+		return -1 // module exports no wasi_thread_start: nothing to run
+	}
+	return threadLaunch(m, func(child *Module, tid int32) { start(child, tid, arg) })
 }
 
 // ThreadsWait blocks until every spawned agent has returned. Hosts call it
@@ -2626,6 +3102,18 @@ func memoryGrow64(m *Module, n int64) int64 {
 	}
 	if m.maxMem != 0 && want > m.maxMem {
 		return -1
+	}
+	if m.memShared {
+		// Same contract as memoryGrow: the backing array of a shared
+		// memory already spans the declared maximum (New reserved it;
+		// untouched pages are not resident), so growth is a single
+		// atomic store — no copy, no reslice, and above all no
+		// relocation, since other agents deref m.M concurrently.
+		if want > uint64(len(m.memory)) {
+			return -1
+		}
+		m.memSize.Store(want)
+		return prev
 	}
 	if want <= uint64(cap(m.memory)) {
 		m.memory = m.memory[:want]

--- a/internal/codegen/helpers/helpers_atomic_m64_test.go
+++ b/internal/codegen/helpers/helpers_atomic_m64_test.go
@@ -1,0 +1,374 @@
+package helpers
+
+// Coverage for the memory64 atomic helper family (_m64) and its
+// effective-address core atomicEA64. Codegen selects these by name for
+// memory64 modules, so nothing in-package references them statically;
+// the tests both guard their semantics against the wasm32 twins' and give
+// the 64-bit address-computation paths direct coverage — including the
+// beyond-4GiB addresses no wasm32 helper can form.
+
+import (
+	"math"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAtomicEA64(t *testing.T) {
+	// Only memSize is consulted by atomicEA64, so a module with a fake
+	// size beyond 4 GiB exercises the wide-address path without having
+	// to allocate that much memory.
+	m := &Module{memSize: &atomic.Uint64{}}
+	m.memSize.Store(5 << 30) // 5 GiB
+
+	// An address beyond 4 GiB is accepted when in bounds.
+	if got := atomicEA64(m, 1<<32, 16, 8); got != (1<<32)+16 {
+		t.Errorf("atomicEA64(4GiB+16) = %d, want %d", got, (1<<32)+16)
+	}
+	// addr + offset in u64, both halves contributing beyond 32 bits.
+	if got := atomicEA64(m, 3<<30, 1<<30, 4); got != 4<<30 {
+		t.Errorf("atomicEA64(3GiB+1GiB) = %d, want %d", got, uint64(4<<30))
+	}
+	// The last in-bounds word.
+	if got := atomicEA64(m, (5<<30)-4, 0, 4); got != (5<<30)-4 {
+		t.Errorf("atomicEA64(end-4) = %d", got)
+	}
+	// One past the end traps.
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicEA64(m, (5<<30)-3, 0, 4) })
+	// Negative address / negative offset trap as out of bounds.
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicEA64(m, -8, 0, 4) })
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicEA64(m, 0, -8, 4) })
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicEA64(m, -4, 8, 4) })
+	// addr+offset wrapping u64 traps rather than aliasing a low address.
+	mustPanic(t, "wasm: atomic access out of bounds", func() {
+		atomicEA64(m, math.MaxInt64, math.MaxInt64, 4)
+	})
+	// ea+size wrapping u64 traps (ea itself did not wrap).
+	mustPanic(t, "wasm: atomic access out of bounds", func() {
+		atomicEA64(m, 0, -1, 8)
+	})
+	// Misalignment traps AFTER the bounds check, like atomicEA.
+	mustPanic(t, "wasm: unaligned atomic access", func() { atomicEA64(m, (1<<32)+2, 0, 4) })
+	mustPanic(t, "wasm: unaligned atomic access", func() { atomicEA64(m, 1, 0, 2) })
+}
+
+// TestAtomicM64FullWidth drives the full-width _m64 load/store/RMW helpers
+// against the semantics their wasm32 twins are already tested for.
+func TestAtomicM64FullWidth(t *testing.T) {
+	m := newMemModuleM(64)
+
+	atomicStore32_m64(m, 0, 0, 0x11223344)
+	if got := atomicLoad32_m64(m, 0, 0); got != 0x11223344 {
+		t.Errorf("atomicLoad32_m64 = %#x", got)
+	}
+	atomicStore64_m64(m, 8, 0, 0x1122334455667788)
+	if got := atomicLoad64_m64(m, 8, 0); got != 0x1122334455667788 {
+		t.Errorf("atomicLoad64_m64 = %#x", got)
+	}
+	// addr/offset split across the two i64 operands.
+	if got := atomicLoad64_m64(m, 4, 4); got != 0x1122334455667788 {
+		t.Errorf("atomicLoad64_m64 split addr/offset = %#x", got)
+	}
+
+	atomicStore32_m64(m, 0, 0, 100)
+	if old := atomicRmwAdd32_m64(m, 0, 0, 5); old != 100 || atomicLoad32_m64(m, 0, 0) != 105 {
+		t.Errorf("atomicRmwAdd32_m64: old %d new %d", old, atomicLoad32_m64(m, 0, 0))
+	}
+	if old := atomicRmwSub32_m64(m, 0, 0, 6); old != 105 || atomicLoad32_m64(m, 0, 0) != 99 {
+		t.Errorf("atomicRmwSub32_m64: old %d new %d", old, atomicLoad32_m64(m, 0, 0))
+	}
+	atomicStore32_m64(m, 0, 0, 0xF0)
+	if old := atomicRmwAnd32_m64(m, 0, 0, 0x3C); old != 0xF0 || atomicLoad32_m64(m, 0, 0) != 0x30 {
+		t.Errorf("atomicRmwAnd32_m64: old %#x new %#x", old, atomicLoad32_m64(m, 0, 0))
+	}
+	if old := atomicRmwOr32_m64(m, 0, 0, 0x0F); old != 0x30 || atomicLoad32_m64(m, 0, 0) != 0x3F {
+		t.Errorf("atomicRmwOr32_m64: old %#x new %#x", old, atomicLoad32_m64(m, 0, 0))
+	}
+	if old := atomicRmwXor32_m64(m, 0, 0, 0xFF); old != 0x3F || atomicLoad32_m64(m, 0, 0) != 0xC0 {
+		t.Errorf("atomicRmwXor32_m64: old %#x new %#x", old, atomicLoad32_m64(m, 0, 0))
+	}
+	if old := atomicRmwXchg32_m64(m, 0, 0, 7); old != 0xC0 || atomicLoad32_m64(m, 0, 0) != 7 {
+		t.Errorf("atomicRmwXchg32_m64: old %#x new %d", old, atomicLoad32_m64(m, 0, 0))
+	}
+	if old := atomicRmwCmpxchg32_m64(m, 0, 0, 7, 9); old != 7 || atomicLoad32_m64(m, 0, 0) != 9 {
+		t.Errorf("atomicRmwCmpxchg32_m64 hit: old %d new %d", old, atomicLoad32_m64(m, 0, 0))
+	}
+	if old := atomicRmwCmpxchg32_m64(m, 0, 0, 7, 11); old != 9 || atomicLoad32_m64(m, 0, 0) != 9 {
+		t.Errorf("atomicRmwCmpxchg32_m64 miss: old %d new %d", old, atomicLoad32_m64(m, 0, 0))
+	}
+
+	atomicStore64_m64(m, 8, 0, 4_000_000_000)
+	if old := atomicRmwAdd64_m64(m, 8, 0, 4_000_000_000); old != 4_000_000_000 || atomicLoad64_m64(m, 8, 0) != 8_000_000_000 {
+		t.Errorf("atomicRmwAdd64_m64: old %d new %d", old, atomicLoad64_m64(m, 8, 0))
+	}
+	if old := atomicRmwSub64_m64(m, 8, 0, 1); old != 8_000_000_000 || atomicLoad64_m64(m, 8, 0) != 7_999_999_999 {
+		t.Errorf("atomicRmwSub64_m64: old %d new %d", old, atomicLoad64_m64(m, 8, 0))
+	}
+	atomicStore64_m64(m, 8, 0, 0xF0)
+	if old := atomicRmwAnd64_m64(m, 8, 0, 0x3C); old != 0xF0 || atomicLoad64_m64(m, 8, 0) != 0x30 {
+		t.Errorf("atomicRmwAnd64_m64: old %#x new %#x", old, atomicLoad64_m64(m, 8, 0))
+	}
+	if old := atomicRmwOr64_m64(m, 8, 0, 0x0F); old != 0x30 || atomicLoad64_m64(m, 8, 0) != 0x3F {
+		t.Errorf("atomicRmwOr64_m64: old %#x new %#x", old, atomicLoad64_m64(m, 8, 0))
+	}
+	if old := atomicRmwXor64_m64(m, 8, 0, 0xFF); old != 0x3F || atomicLoad64_m64(m, 8, 0) != 0xC0 {
+		t.Errorf("atomicRmwXor64_m64: old %#x new %#x", old, atomicLoad64_m64(m, 8, 0))
+	}
+	if old := atomicRmwXchg64_m64(m, 8, 0, 7); old != 0xC0 || atomicLoad64_m64(m, 8, 0) != 7 {
+		t.Errorf("atomicRmwXchg64_m64: old %#x new %d", old, atomicLoad64_m64(m, 8, 0))
+	}
+	if old := atomicRmwCmpxchg64_m64(m, 8, 0, 7, 9); old != 7 || atomicLoad64_m64(m, 8, 0) != 9 {
+		t.Errorf("atomicRmwCmpxchg64_m64 hit: old %d new %d", old, atomicLoad64_m64(m, 8, 0))
+	}
+	if old := atomicRmwCmpxchg64_m64(m, 8, 0, 7, 11); old != 9 || atomicLoad64_m64(m, 8, 0) != 9 {
+		t.Errorf("atomicRmwCmpxchg64_m64 miss: old %d new %d", old, atomicLoad64_m64(m, 8, 0))
+	}
+
+	// Out-of-bounds and misaligned addresses trap through atomicEA64.
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicLoad32_m64(m, 64, 0) })
+	mustPanic(t, "wasm: atomic access out of bounds", func() { atomicStore64_m64(m, -8, 0, 1) })
+	mustPanic(t, "wasm: unaligned atomic access", func() { atomicRmwAdd32_m64(m, 2, 0, 1) })
+}
+
+// TestAtomicM64Subword drives the sub-word lane forms (8/16-bit lanes of
+// the i32 family, 8/16/32-bit lanes of the i64 family).
+func TestAtomicM64Subword(t *testing.T) {
+	m := newMemModuleM(64)
+
+	atomicStore32_8_m64(m, 1, 0, 0xAB)
+	if got := atomicLoad32_8u_m64(m, 1, 0); got != 0xAB {
+		t.Errorf("atomicLoad32_8u_m64 = %#x", got)
+	}
+	atomicStore32_16_m64(m, 2, 0, 0x1234)
+	if got := atomicLoad32_16u_m64(m, 2, 0); got != 0x1234 {
+		t.Errorf("atomicLoad32_16u_m64 = %#x", got)
+	}
+	atomicStore64_8_m64(m, 8, 0, 0xCD)
+	if got := atomicLoad64_8u_m64(m, 8, 0); got != 0xCD {
+		t.Errorf("atomicLoad64_8u_m64 = %#x", got)
+	}
+	atomicStore64_16_m64(m, 10, 0, 0x5678)
+	if got := atomicLoad64_16u_m64(m, 10, 0); got != 0x5678 {
+		t.Errorf("atomicLoad64_16u_m64 = %#x", got)
+	}
+	atomicStore64_32_m64(m, 12, 0, 0x1_9999_0001) // truncates to the 32-bit lane
+	if got := atomicLoad64_32u_m64(m, 12, 0); got != 0x9999_0001 {
+		t.Errorf("atomicLoad64_32u_m64 = %#x (zero-extended lane)", got)
+	}
+
+	// i32-family RMW lanes: old value returned zero-extended, op applied.
+	atomicStore32_8_m64(m, 1, 0, 250)
+	if old := atomicRmwAdd32_8u_m64(m, 1, 0, 10); old != 250 || atomicLoad32_8u_m64(m, 1, 0) != 4 {
+		t.Errorf("atomicRmwAdd32_8u_m64: old %d new %d (mod 256)", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwSub32_8u_m64(m, 1, 0, 5); old != 4 || atomicLoad32_8u_m64(m, 1, 0) != 255 {
+		t.Errorf("atomicRmwSub32_8u_m64: old %d new %d", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwAnd32_8u_m64(m, 1, 0, 0x0F); old != 255 || atomicLoad32_8u_m64(m, 1, 0) != 0x0F {
+		t.Errorf("atomicRmwAnd32_8u_m64: old %d new %d", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwOr32_8u_m64(m, 1, 0, 0xA0); old != 0x0F || atomicLoad32_8u_m64(m, 1, 0) != 0xAF {
+		t.Errorf("atomicRmwOr32_8u_m64: old %#x new %#x", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwXor32_8u_m64(m, 1, 0, 0xFF); old != 0xAF || atomicLoad32_8u_m64(m, 1, 0) != 0x50 {
+		t.Errorf("atomicRmwXor32_8u_m64: old %#x new %#x", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwXchg32_8u_m64(m, 1, 0, 0x7E); old != 0x50 || atomicLoad32_8u_m64(m, 1, 0) != 0x7E {
+		t.Errorf("atomicRmwXchg32_8u_m64: old %#x new %#x", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwCmpxchg32_8u_m64(m, 1, 0, 0x7E, 0x11); old != 0x7E || atomicLoad32_8u_m64(m, 1, 0) != 0x11 {
+		t.Errorf("atomicRmwCmpxchg32_8u_m64 hit: old %#x new %#x", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+	if old := atomicRmwCmpxchg32_8u_m64(m, 1, 0, 0x7E, 0x22); old != 0x11 || atomicLoad32_8u_m64(m, 1, 0) != 0x11 {
+		t.Errorf("atomicRmwCmpxchg32_8u_m64 miss: old %#x new %#x", old, atomicLoad32_8u_m64(m, 1, 0))
+	}
+
+	atomicStore32_16_m64(m, 2, 0, 0xFFF0)
+	if old := atomicRmwAdd32_16u_m64(m, 2, 0, 0x20); old != 0xFFF0 || atomicLoad32_16u_m64(m, 2, 0) != 0x10 {
+		t.Errorf("atomicRmwAdd32_16u_m64: old %#x new %#x (mod 2^16)", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwSub32_16u_m64(m, 2, 0, 0x11); old != 0x10 || atomicLoad32_16u_m64(m, 2, 0) != 0xFFFF {
+		t.Errorf("atomicRmwSub32_16u_m64: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwAnd32_16u_m64(m, 2, 0, 0x0F0F); old != 0xFFFF || atomicLoad32_16u_m64(m, 2, 0) != 0x0F0F {
+		t.Errorf("atomicRmwAnd32_16u_m64: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwOr32_16u_m64(m, 2, 0, 0xA000); old != 0x0F0F || atomicLoad32_16u_m64(m, 2, 0) != 0xAF0F {
+		t.Errorf("atomicRmwOr32_16u_m64: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwXor32_16u_m64(m, 2, 0, 0xFFFF); old != 0xAF0F || atomicLoad32_16u_m64(m, 2, 0) != 0x50F0 {
+		t.Errorf("atomicRmwXor32_16u_m64: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwXchg32_16u_m64(m, 2, 0, 0x1357); old != 0x50F0 || atomicLoad32_16u_m64(m, 2, 0) != 0x1357 {
+		t.Errorf("atomicRmwXchg32_16u_m64: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwCmpxchg32_16u_m64(m, 2, 0, 0x1357, 0x2468); old != 0x1357 || atomicLoad32_16u_m64(m, 2, 0) != 0x2468 {
+		t.Errorf("atomicRmwCmpxchg32_16u_m64 hit: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+	if old := atomicRmwCmpxchg32_16u_m64(m, 2, 0, 0x1357, 0x9); old != 0x2468 || atomicLoad32_16u_m64(m, 2, 0) != 0x2468 {
+		t.Errorf("atomicRmwCmpxchg32_16u_m64 miss: old %#x new %#x", old, atomicLoad32_16u_m64(m, 2, 0))
+	}
+
+	// i64-family lanes: results are zero-extended into the i64.
+	atomicStore64_8_m64(m, 8, 0, 250)
+	if old := atomicRmwAdd64_8u_m64(m, 8, 0, 10); old != 250 || atomicLoad64_8u_m64(m, 8, 0) != 4 {
+		t.Errorf("atomicRmwAdd64_8u_m64: old %d new %d", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwSub64_8u_m64(m, 8, 0, 5); old != 4 || atomicLoad64_8u_m64(m, 8, 0) != 255 {
+		t.Errorf("atomicRmwSub64_8u_m64: old %d new %d", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwAnd64_8u_m64(m, 8, 0, 0x0F); old != 255 || atomicLoad64_8u_m64(m, 8, 0) != 0x0F {
+		t.Errorf("atomicRmwAnd64_8u_m64: old %d new %d", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwOr64_8u_m64(m, 8, 0, 0xA0); old != 0x0F || atomicLoad64_8u_m64(m, 8, 0) != 0xAF {
+		t.Errorf("atomicRmwOr64_8u_m64: old %#x new %#x", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwXor64_8u_m64(m, 8, 0, 0xFF); old != 0xAF || atomicLoad64_8u_m64(m, 8, 0) != 0x50 {
+		t.Errorf("atomicRmwXor64_8u_m64: old %#x new %#x", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwXchg64_8u_m64(m, 8, 0, 0x7E); old != 0x50 || atomicLoad64_8u_m64(m, 8, 0) != 0x7E {
+		t.Errorf("atomicRmwXchg64_8u_m64: old %#x new %#x", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwCmpxchg64_8u_m64(m, 8, 0, 0x7E, 0x11); old != 0x7E || atomicLoad64_8u_m64(m, 8, 0) != 0x11 {
+		t.Errorf("atomicRmwCmpxchg64_8u_m64 hit: old %#x new %#x", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+	if old := atomicRmwCmpxchg64_8u_m64(m, 8, 0, 0x7E, 0x22); old != 0x11 || atomicLoad64_8u_m64(m, 8, 0) != 0x11 {
+		t.Errorf("atomicRmwCmpxchg64_8u_m64 miss: old %#x new %#x", old, atomicLoad64_8u_m64(m, 8, 0))
+	}
+
+	atomicStore64_16_m64(m, 10, 0, 0xFFF0)
+	if old := atomicRmwAdd64_16u_m64(m, 10, 0, 0x20); old != 0xFFF0 || atomicLoad64_16u_m64(m, 10, 0) != 0x10 {
+		t.Errorf("atomicRmwAdd64_16u_m64: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwSub64_16u_m64(m, 10, 0, 0x11); old != 0x10 || atomicLoad64_16u_m64(m, 10, 0) != 0xFFFF {
+		t.Errorf("atomicRmwSub64_16u_m64: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwAnd64_16u_m64(m, 10, 0, 0x0F0F); old != 0xFFFF || atomicLoad64_16u_m64(m, 10, 0) != 0x0F0F {
+		t.Errorf("atomicRmwAnd64_16u_m64: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwOr64_16u_m64(m, 10, 0, 0xA000); old != 0x0F0F || atomicLoad64_16u_m64(m, 10, 0) != 0xAF0F {
+		t.Errorf("atomicRmwOr64_16u_m64: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwXor64_16u_m64(m, 10, 0, 0xFFFF); old != 0xAF0F || atomicLoad64_16u_m64(m, 10, 0) != 0x50F0 {
+		t.Errorf("atomicRmwXor64_16u_m64: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwXchg64_16u_m64(m, 10, 0, 0x1357); old != 0x50F0 || atomicLoad64_16u_m64(m, 10, 0) != 0x1357 {
+		t.Errorf("atomicRmwXchg64_16u_m64: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwCmpxchg64_16u_m64(m, 10, 0, 0x1357, 0x2468); old != 0x1357 || atomicLoad64_16u_m64(m, 10, 0) != 0x2468 {
+		t.Errorf("atomicRmwCmpxchg64_16u_m64 hit: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+	if old := atomicRmwCmpxchg64_16u_m64(m, 10, 0, 0x1357, 0x9); old != 0x2468 || atomicLoad64_16u_m64(m, 10, 0) != 0x2468 {
+		t.Errorf("atomicRmwCmpxchg64_16u_m64 miss: old %#x new %#x", old, atomicLoad64_16u_m64(m, 10, 0))
+	}
+
+	// 32-bit lanes of the i64 family, incl. the wraparound the lane math
+	// must confine to 32 bits.
+	atomicStore64_32_m64(m, 12, 0, 0xFFFF_FFF0)
+	if old := atomicRmwAdd64_32u_m64(m, 12, 0, 0x20); old != 0xFFFF_FFF0 || atomicLoad64_32u_m64(m, 12, 0) != 0x10 {
+		t.Errorf("atomicRmwAdd64_32u_m64: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwSub64_32u_m64(m, 12, 0, 0x11); old != 0x10 || atomicLoad64_32u_m64(m, 12, 0) != 0xFFFF_FFFF {
+		t.Errorf("atomicRmwSub64_32u_m64: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwAnd64_32u_m64(m, 12, 0, 0x0F0F_0F0F); old != 0xFFFF_FFFF || atomicLoad64_32u_m64(m, 12, 0) != 0x0F0F_0F0F {
+		t.Errorf("atomicRmwAnd64_32u_m64: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwOr64_32u_m64(m, 12, 0, 0xA000_0000); old != 0x0F0F_0F0F || atomicLoad64_32u_m64(m, 12, 0) != 0xAF0F_0F0F {
+		t.Errorf("atomicRmwOr64_32u_m64: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwXor64_32u_m64(m, 12, 0, 0xFFFF_FFFF); old != 0xAF0F_0F0F || atomicLoad64_32u_m64(m, 12, 0) != 0x50F0_F0F0 {
+		t.Errorf("atomicRmwXor64_32u_m64: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwXchg64_32u_m64(m, 12, 0, 0x1357_9BDF); old != 0x50F0_F0F0 || atomicLoad64_32u_m64(m, 12, 0) != 0x1357_9BDF {
+		t.Errorf("atomicRmwXchg64_32u_m64: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwCmpxchg64_32u_m64(m, 12, 0, 0x1357_9BDF, 0x2468_ACE0); old != 0x1357_9BDF || atomicLoad64_32u_m64(m, 12, 0) != 0x2468_ACE0 {
+		t.Errorf("atomicRmwCmpxchg64_32u_m64 hit: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+	if old := atomicRmwCmpxchg64_32u_m64(m, 12, 0, 0x1357_9BDF, 0x9); old != 0x2468_ACE0 || atomicLoad64_32u_m64(m, 12, 0) != 0x2468_ACE0 {
+		t.Errorf("atomicRmwCmpxchg64_32u_m64 miss: old %#x new %#x", old, atomicLoad64_32u_m64(m, 12, 0))
+	}
+}
+
+func TestAtomicM64WaitNotify(t *testing.T) {
+	m := newMemModuleM(64)
+	m.memShared = true
+
+	// notify with no waiters wakes nobody.
+	if got := atomicNotify_m64(m, 16, 0, -1); got != 0 {
+		t.Errorf("atomicNotify_m64 with no waiters = %d, want 0", got)
+	}
+	// wait with a mismatched expected value returns 1 (not-equal).
+	atomicStore32_m64(m, 16, 0, 5)
+	if got := atomicWait32_m64(m, 16, 0, 4, 0); got != 1 {
+		t.Errorf("atomicWait32_m64 not-equal = %d, want 1", got)
+	}
+	atomicStore64_m64(m, 24, 0, 5)
+	if got := atomicWait64_m64(m, 24, 0, 4, 0); got != 1 {
+		t.Errorf("atomicWait64_m64 not-equal = %d, want 1", got)
+	}
+	// wait on the current value with a zero timeout returns 2 (timed out).
+	if got := atomicWait32_m64(m, 16, 0, 5, 0); got != 2 {
+		t.Errorf("atomicWait32_m64 timeout = %d, want 2", got)
+	}
+	if got := atomicWait64_m64(m, 24, 0, 5, 0); got != 2 {
+		t.Errorf("atomicWait64_m64 timeout = %d, want 2", got)
+	}
+}
+
+func TestThreadSpawnM64(t *testing.T) {
+	m := newMemModuleM(64)
+
+	done := make(chan struct{})
+	var gotTID int32
+	var gotArg int64
+	m.threadStart64 = func(child *Module, tid int32, arg int64) {
+		gotTID, gotArg = tid, arg
+		close(done)
+	}
+	tid := threadSpawn_m64(m, 5<<32) // an arg only an i64 can carry
+	if tid != 1 {
+		t.Errorf("threadSpawn_m64 tid = %d, want 1", tid)
+	}
+	<-done
+	ThreadsWait(m)
+	if gotTID != 1 || gotArg != 5<<32 {
+		t.Errorf("threadStart64 saw tid=%d arg=%d, want 1 / %d", gotTID, gotArg, int64(5<<32))
+	}
+
+	// A module that exports no wasi_thread_start returns -1.
+	if got := threadSpawn_m64(newMemModuleM(8), 0); got != -1 {
+		t.Errorf("threadSpawn_m64 with no threadStart64 = %d, want -1", got)
+	}
+}
+
+// TestMemoryGrow64Shared: growing a shared memory64 must never reslice or
+// relocate the backing array — growth is a lone memSize store, and a grow
+// past the reserved ceiling fails with -1.
+func TestMemoryGrow64Shared(t *testing.T) {
+	m := newMemModuleM(3 * 65536) // ceiling: 3 pages reserved up front
+	m.memShared = true
+	m.memSize.Store(65536) // guest currently sees 1 page
+
+	base := &m.memory[0]
+	if got := memoryGrow64(m, 1); got != 1 {
+		t.Errorf("memoryGrow64(+1) = %d, want previous page count 1", got)
+	}
+	if m.memSize.Load() != 2*65536 {
+		t.Errorf("memSize after grow = %d, want 2 pages", m.memSize.Load())
+	}
+	if len(m.memory) != 3*65536 || &m.memory[0] != base {
+		t.Error("shared grow resliced or relocated the backing array")
+	}
+	// Growing past the reserved ceiling fails without touching anything.
+	if got := memoryGrow64(m, 2); got != -1 {
+		t.Errorf("memoryGrow64 past ceiling = %d, want -1", got)
+	}
+	if m.memSize.Load() != 2*65536 || &m.memory[0] != base {
+		t.Error("failed grow mutated the module")
+	}
+	// A further in-ceiling grow still works.
+	if got := memoryGrow64(m, 1); got != 2 {
+		t.Errorf("memoryGrow64(+1) = %d, want 2", got)
+	}
+}

--- a/internal/codegen/helpers/helpers_mematomic_test.go
+++ b/internal/codegen/helpers/helpers_mematomic_test.go
@@ -99,14 +99,14 @@ func TestAtomicMemoryOps(t *testing.T) {
 		t.Errorf("atomicRmwXor32: old %#x new %#x, want 0xFF / 0xF0", old, atomicLoad32(m, 0, 0))
 	}
 
-	// The generic op-taking RMW forms (atomicRmw32 / atomicRmw64).
+	// The generic op-taking RMW cores (atomicRmw32At / atomicRmw64At).
 	atomicStore32(m, 0, 0, 7)
-	if old := atomicRmw32(m, 0, 0, func(o uint32) uint32 { return o * 3 }); old != 7 || atomicLoad32(m, 0, 0) != 21 {
-		t.Errorf("atomicRmw32: old %d new %d, want 7 / 21", old, atomicLoad32(m, 0, 0))
+	if old := atomicRmw32At(m, atomicEA(m, 0, 0, 4), func(o uint32) uint32 { return o * 3 }); old != 7 || atomicLoad32(m, 0, 0) != 21 {
+		t.Errorf("atomicRmw32At: old %d new %d, want 7 / 21", old, atomicLoad32(m, 0, 0))
 	}
 	atomicStore64(m, 8, 0, 4)
-	if old := atomicRmw64(m, 8, 0, func(o uint64) uint64 { return o + 100 }); old != 4 || atomicLoad64(m, 8, 0) != 104 {
-		t.Errorf("atomicRmw64: old %d new %d, want 4 / 104", old, atomicLoad64(m, 8, 0))
+	if old := atomicRmw64At(m, atomicEA(m, 8, 0, 8), func(o uint64) uint64 { return o + 100 }); old != 4 || atomicLoad64(m, 8, 0) != 104 {
+		t.Errorf("atomicRmw64At: old %d new %d, want 4 / 104", old, atomicLoad64(m, 8, 0))
 	}
 
 	// Sub-word atomics: store and zero-extended load, 8- and 16-bit lanes.

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -265,8 +265,15 @@ func Translate(w io.Writer, m *wasm.Module, opts Options) (Result, error) {
 	fuseDebugEnabled = opts.FuseDebug
 	if m.Memory64() {
 		for _, mem := range m.Memories {
-			if mem.Limits.Shared {
-				return Result{}, fmt.Errorf("wasm2go: shared memory64 is not supported")
+			// A shared memory is allocated at its ceiling once (see the
+			// New() emission): other agents deref its data pointer
+			// concurrently, so the backing array must never move. On a
+			// memory64 the fallback ceiling would be the mem64 hard cap —
+			// absurd to reserve — so the declared maximum (which the
+			// threads proposal requires anyway; the parser tolerates its
+			// absence) becomes mandatory here.
+			if mem.Limits.Shared && !mem.Limits.HasMax {
+				return Result{}, fmt.Errorf("wasm2go: shared memory64 requires a declared maximum (it is reserved in full as the relocation-free growth ceiling)")
 			}
 		}
 	}
@@ -1787,11 +1794,18 @@ func (t *translator) emitModuleStruct() ast.Decl {
 		// threadStart carries the wasi_thread_start export as a function
 		// value: multi-package output emits exports as free functions in the
 		// main package, so base's threadSpawn helper cannot reach them any
-		// other way (no method to assert, no upward import).
+		// other way (no method to assert, no upward import). The field name
+		// and the start_arg width follow the memory width: a memory64
+		// module's start_arg is an i64 linear-memory pointer, read by the
+		// threadSpawn_m64 helper through the threadStart64 field.
+		threadStartField, argType := "threadStart", "int32"
+		if t.mod.Memory64() {
+			threadStartField, argType = "threadStart64", "int64"
+		}
 		fields = append(fields, &ast.Field{
-			Names: []*ast.Ident{newID(t.fieldName("threadStart"))},
+			Names: []*ast.Ident{newID(t.fieldName(threadStartField))},
 			Type: &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{
-				{Type: t.moduleType()}, {Type: newID("int32")}, {Type: newID("int32")},
+				{Type: t.moduleType()}, {Type: newID("int32")}, {Type: newID(argType)},
 			}}},
 		})
 	}
@@ -2568,10 +2582,16 @@ func (t *translator) emitNewFuncsMode(mode newMode) []ast.Decl {
 	}
 
 	// Wire the wasi_thread_start export into the Module so threadSpawn (in
-	// base) can launch agents without reaching into this package.
+	// base) can launch agents without reaching into this package. The field
+	// follows the memory width (threadStart64 with an i64 start_arg on a
+	// memory64 module), matching the struct declaration.
 	for _, exp := range t.mod.Exports {
 		if exp.Kind != wasm.ExportFunc || exp.Name != "wasi_thread_start" || !t.funcReachable(exp.Index) {
 			continue
+		}
+		threadStartField := "threadStart"
+		if t.mod.Memory64() {
+			threadStartField = "threadStart64"
 		}
 		// The export already takes the module as its first parameter, so the
 		// function value itself is what goes in the field — a closure over
@@ -2579,7 +2599,7 @@ func (t *translator) emitNewFuncsMode(mode newMode) []ast.Decl {
 		// threadSpawn passes in.
 		body.List = append(body.List, &ast.AssignStmt{
 			Tok: token.ASSIGN,
-			Lhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID(t.fieldName("threadStart"))}},
+			Lhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID(t.fieldName(threadStartField))}},
 			Rhs: []ast.Expr{t.funcRef(exp.Index)},
 		})
 		break

--- a/internal/codegen/wasip1_native.go
+++ b/internal/codegen/wasip1_native.go
@@ -3272,6 +3272,12 @@ func (w *WasiStubs) Fd_close64(m *Module, fd int64) int32 {
 	return w.Fd_close(m, int32(fd))
 }
 
+func (w *WasiStubs) Sched_yield64(m *Module) int32 {
+	// No arguments to widen; the LP64 twin exists only because a wasm64
+	// module binds every wasi import through the widened interface.
+	return w.Sched_yield(m)
+}
+
 func (w *WasiStubs) Fd_fdstat_get64(m *Module, fd int64, ptr int64) int32 {
 	// The fdstat struct holds no pointers, so its 24-byte layout is
 	// identical under LP64; only the out-pointer needs the 64-bit

--- a/internal/lower/lower.go
+++ b/internal/lower/lower.go
@@ -788,12 +788,6 @@ func (ls *lowerState) handleFEOp(r *wasm.InstrReader) error {
 	if err != nil {
 		return err
 	}
-	if ls.mem64 {
-		// The atomic helpers and the shared-memory reservation scheme
-		// are 32-bit; a shared memory64 has no toolchain producing it
-		// today. Fail loudly rather than mis-address.
-		return fmt.Errorf("%w: atomics on a memory64 memory", ErrSSAUnsupported)
-	}
 	if sub == 0x03 { // atomic.fence: reserved byte, no operands
 		if _, err := r.ReadByte(); err != nil {
 			return err
@@ -808,9 +802,25 @@ func (ls *lowerState) handleFEOp(r *wasm.InstrReader) error {
 	if _, err := r.ReadU32(); err != nil { // memarg align (validated upstream)
 		return err
 	}
-	offset, err := r.ReadU32()
-	if err != nil {
-		return err
+	// On a memory64 module the memarg offset is a u64, the address operand
+	// is an i64, and the op routes to the helper's _m64 twin (i64 address
+	// and offset, u64 effective-address math). atomic.fence above takes no
+	// address and needs no twin.
+	helper := spec.helper
+	var offVal *ssa.Value
+	if ls.mem64 {
+		offset, err := r.ReadU64()
+		if err != nil {
+			return err
+		}
+		offVal = ls.b.Const64(int64(offset))
+		helper += "_m64"
+	} else {
+		offset, err := r.ReadU32()
+		if err != nil {
+			return err
+		}
+		offVal = ls.b.Const32(int32(offset))
 	}
 	extras := make([]*ssa.Value, spec.extra)
 	for i := spec.extra - 1; i >= 0; i-- {
@@ -824,8 +834,8 @@ func (ls *lowerState) handleFEOp(r *wasm.InstrReader) error {
 	if err != nil {
 		return err
 	}
-	args := append([]*ssa.Value{addr, ls.b.Const32(int32(offset))}, extras...)
-	v := ls.b.NewValueAux(ssa.OpAtomicCall, spec.resType, spec.helper, args...)
+	args := append([]*ssa.Value{addr, offVal}, extras...)
+	v := ls.b.NewValueAux(ssa.OpAtomicCall, spec.resType, helper, args...)
 	if strings.HasPrefix(spec.helper, "atomicStore") {
 		return nil // stores leave nothing on the stack
 	}

--- a/testdata/cg_atomics_m64.wat
+++ b/testdata/cg_atomics_m64.wat
@@ -1,0 +1,61 @@
+;; cg_atomics_m64.wat — cg_atomics.wat on a shared memory64: the same
+;; single-agent threads-proposal atomics (loads, stores, every RMW family
+;; incl. subword lanes, cmpxchg, fence, notify, zero-timeout wait) with i64
+;; addressing, so every op routes through the _m64 helper family. Results are
+;; deterministic observable values the driving test hardcodes.
+(module
+  (memory i64 1 1 shared)
+  (func (export "rmw32") (result i32)
+    (i32.atomic.store (i64.const 16) (i32.const 100))
+    (drop (i32.atomic.rmw.add (i64.const 16) (i32.const 5)))
+    (drop (i32.atomic.rmw.sub (i64.const 16) (i32.const 1)))
+    (drop (i32.atomic.rmw.and (i64.const 16) (i32.const 0xff)))
+    (drop (i32.atomic.rmw.or (i64.const 16) (i32.const 0x100)))
+    (drop (i32.atomic.rmw.xor (i64.const 16) (i32.const 0x1)))
+    (i32.atomic.load (i64.const 16)))
+  (func (export "rmw64") (result i64)
+    (i64.atomic.store (i64.const 24) (i64.const 4000000000))
+    (drop (i64.atomic.rmw.add (i64.const 24) (i64.const 4000000000)))
+    (i64.atomic.load (i64.const 24)))
+  (func (export "xchg") (result i32)
+    (i32.atomic.store (i64.const 32) (i32.const 7))
+    ;; old value (7) + new value (9) observed
+    (i32.add (i32.atomic.rmw.xchg (i64.const 32) (i32.const 9))
+             (i32.atomic.load (i64.const 32))))
+  (func (export "cmpxchg") (result i32)
+    (i32.atomic.store (i64.const 40) (i32.const 5))
+    (drop (i32.atomic.rmw.cmpxchg (i64.const 40) (i32.const 5) (i32.const 6)))  ;; hits
+    (drop (i32.atomic.rmw.cmpxchg (i64.const 40) (i32.const 5) (i32.const 7)))  ;; misses
+    (i32.atomic.load (i64.const 40)))
+  (func (export "subword") (result i32)
+    ;; byte lanes at 48..51: store 0xAA at 49, add 1 at lane, read back word
+    (i32.atomic.store (i64.const 48) (i32.const 0))
+    (i32.atomic.store8 (i64.const 49) (i32.const 0xaa))
+    (drop (i32.atomic.rmw8.add_u (i64.const 49) (i32.const 1)))
+    (drop (i32.atomic.rmw16.xchg_u (i64.const 50) (i32.const 0x1234)))
+    (i32.atomic.load (i64.const 48)))
+  (func (export "subword_cmpxchg") (result i32)
+    (i32.atomic.store8 (i64.const 56) (i32.const 3))
+    (drop (i32.atomic.rmw8.cmpxchg_u (i64.const 56) (i32.const 3) (i32.const 9)))
+    (i32.atomic.load8_u (i64.const 56)))
+  (func (export "wait_notify") (result i32)
+    (i32.atomic.store (i64.const 64) (i32.const 1))
+    ;; not-equal (expected 0, actual 1) => 1; notify returns 0 woken
+    (i32.add
+      (memory.atomic.wait32 (i64.const 64) (i32.const 0) (i64.const 0))
+      (memory.atomic.notify (i64.const 64) (i32.const 5))))
+  (func (export "fenced_load") (result i32)
+    (i32.atomic.store (i64.const 72) (i32.const 42))
+    (atomic.fence)
+    (i32.atomic.load (i64.const 72)))
+  (func (export "store_neg") (result i32)
+    ;; Negative constant operands: the inline-atomic emitter renders the
+    ;; store value through an unsigned cast, which must be a runtime
+    ;; conversion — `uint32(-1)` as a constant expression fails to
+    ;; compile. Locks the force-hoist of atomic-store value operands.
+    (i32.atomic.store (i64.const 80) (i32.const -1))
+    (i64.atomic.store (i64.const 88) (i64.const -0x8000000000000000))
+    (i32.add
+      (i32.atomic.load (i64.const 80))
+      (i32.wrap_i64 (i64.atomic.load (i64.const 88)))))
+)

--- a/testdata/cg_mem64_atomics_unshared.wat
+++ b/testdata/cg_mem64_atomics_unshared.wat
@@ -1,0 +1,14 @@
+;; cg_mem64_atomics_unshared.wat — threads-proposal atomics on a PLAIN
+;; (unshared) memory64, which is legal wasm: the transpiler used to reject
+;; every 0xFE opcode under memory64, so this locks the regression. A
+;; zero-timeout wait on an unshared memory returns not-equal semantics per
+;; the runtime's single-agent handling (never parks).
+(module
+  (memory i64 1)
+  (func (export "bump") (result i32)
+    (i32.atomic.store (i64.const 16) (i32.const 40))
+    (drop (i32.atomic.rmw.add (i64.const 16) (i32.const 2)))
+    (i32.atomic.load (i64.const 16)))
+  (func (export "wait_unshared") (result i32)
+    (i32.atomic.store (i64.const 32) (i32.const 1))
+    (memory.atomic.wait32 (i64.const 32) (i32.const 1) (i64.const 0))))

--- a/testdata/cg_threads_m64.wat
+++ b/testdata/cg_threads_m64.wat
@@ -1,0 +1,46 @@
+;; cg_threads_m64.wat — the shared-memory wasi_thread_spawn scenario of
+;; cg_threads.wat on a memory64: i64 addressing throughout, an i64 start_arg
+;; (a linear-memory pointer), and memory.size/grow in i64 pages. Exercises the
+;; goroutine-backed spawn, cross-goroutine _m64 atomics on shared memory64,
+;; and the wait/notify parking lot with 64-bit effective addresses.
+(module
+  (import "wasi" "thread-spawn" (func $thread_spawn (param i64) (result i32)))
+  (memory (export "memory") i64 1 2 shared)
+
+  ;; wasi-libc's thread entry: called on a fresh agent with (tid, arg).
+  ;; arg is the address of the counter to bump — an i64 pointer here.
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i64)
+    (drop (i32.atomic.rmw.add (local.get $arg) (i32.const 1)))
+    (drop (memory.atomic.notify (local.get $arg) (i32.const -1))))
+
+  ;; Spawn n agents on counter address 64 and spin-wait (with a bounded
+  ;; atomic wait, so a lost notify shows up as a timeout, not a hang)
+  ;; until the counter reaches n. Returns the final counter.
+  (func (export "spawn_and_join") (param $n i32) (result i32)
+    (local $i i32)
+    (i32.atomic.store (i64.const 64) (i32.const 0))
+    (block $spawned
+      (loop $spawn
+        (br_if $spawned (i32.ge_s (local.get $i) (local.get $n)))
+        (drop (call $thread_spawn (i64.const 64)))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $spawn)))
+    (block $done
+      (loop $wait
+        (br_if $done (i32.ge_s (i32.atomic.load (i64.const 64)) (local.get $n)))
+        ;; wait while the counter still holds its current value (1s cap)
+        (drop (memory.atomic.wait32 (i64.const 64)
+                                    (i32.atomic.load (i64.const 64))
+                                    (i64.const 1000000000)))
+        (br $wait)))
+    (i32.atomic.load (i64.const 64)))
+
+  ;; memory.grow on a shared memory must not relocate: the pointer other
+  ;; agents deref stays valid. Returns new size in bytes plus the sentinel
+  ;; written before the grow.
+  (func (export "grow_shared") (result i64)
+    (i32.atomic.store (i64.const 128) (i32.const 0xbeef))
+    (drop (memory.grow (i64.const 1)))
+    ;; data written before the grow must still be there, and the new size visible
+    (i64.add (i64.mul (memory.size) (i64.const 65536))
+             (i64.extend_i32_u (i32.atomic.load (i64.const 128))))))

--- a/testdata/cg_threads_visibility_m64.wat
+++ b/testdata/cg_threads_visibility_m64.wat
@@ -1,0 +1,28 @@
+;; Cross-thread visibility of PLAIN stores published via atomics — the
+;; cg_threads_visibility.wat scenario on a shared memory64: the main thread
+;; writes a value with a normal (i64-addressed) store, then publishes with an
+;; atomic store (release); the spawned thread spins on an atomic load
+;; (acquire) and must then observe the plain store.
+(module
+  (import "wasi" "thread-spawn" (func $spawn (param i64) (result i32)))
+  (memory i64 1 4 shared)
+  ;; addr 16: plain payload / addr 20: atomic flag / addr 24: agent's answer flag
+  (func (export "wasi_thread_start") (param $tid i32) (param $arg i64)
+    ;; spin until the flag publishes
+    (block $done
+      (loop $spin
+        (br_if $done (i32.eq (i32.atomic.load (i64.const 20)) (i32.const 1)))
+        (br $spin)))
+    ;; read the PLAIN store and publish the answer atomically
+    (i32.atomic.store (i64.const 24) (i32.load (i64.const 16))))
+  (func (export "run") (result i32)
+    (drop (call $spawn (i64.const 0)))
+    ;; plain store, then release-publish
+    (i32.store (i64.const 16) (i32.const 4242))
+    (i32.atomic.store (i64.const 20) (i32.const 1))
+    ;; wait for the agent's answer
+    (block $got
+      (loop $wait
+        (br_if $got (i32.ne (i32.atomic.load (i64.const 24)) (i32.const 0)))
+        (br $wait)))
+    (i32.atomic.load (i64.const 24))))


### PR DESCRIPTION
## Summary

The wasi-threads support (PR #30) and the memory64 support (PR #41) each worked alone but were kept apart by two hard gates: shared memory64 modules were rejected at translation, and every 0xFE atomic was rejected on a memory64 memory. A wasm64-wasip1-threads toolchain now exists (wasmify side), so this composes them.

- **addr64 atomics**: `atomicEA64` mirrors `simdEA64`'s overflow-guarded address math; every atomic op body moves into an ea-keyed core, the wasm32 helpers become one-line wrappers, and each gets an `_m64` twin (loads/stores/RMW families, wait/notify). Contended fast paths and memory orders are moved, not rewritten — wasm32 generated output is byte-identical.
- **Lowering**: the 0xFE memarg offset decodes as u64 under memory64 (the one remaining u32 read), passes as `Const64`, and selects the `_m64` helpers; the inline atomic fast path becomes width-correct.
- **Threads under memory64**: `wasi_thread_spawn`'s start_arg is a linear-memory pointer and therefore i64; `threadSpawn` splits into a shared launch core with per-width entries and the module wires a `threadStart64` field for the widened `wasi_thread_start` export.
- **Shared-memory grow**: `memoryGrow64` gains the no-relocation branch for shared memories; a shared memory64 requires a declared maximum (the reservation is the mapping ceiling).
- `WasiStubs` gains the trivial `Sched_yield64` LP64 twin (musl's spin paths import `sched_yield`; single-threaded modules never did).

## Verification

- New shared+i64 fixtures mirror the wasm32 threads fixtures and run under the race detector; an `atomicEA64` unit test covers beyond-4GiB addresses, overflow and misalignment; a regression test pins that unshared memory64 modules may use atomics.
- End to end: a wasm64-wasip1-threads pthread program (4 threads over a shared atomic counter) transpiles and runs correctly on goroutines, including under `-race`; llama.cpp built for wasm64-wasip1-threads reaches real ggml n_threads parallelism — threading efficiency 1.80x at 8 threads on the routing benchmark, exceeding native llama.cpp's 1.67x on the same machine.
- `make lint` 0 issues; full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)