### PR TITLE
Fix memoryInit64 saturating dataEnd: restores copy-on-write image sharing for threads builds

### DIFF
--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -3190,12 +3190,26 @@ func memoryInit64(m *Module, seg int, dst int64, src int32, n int32) {
 		wasm_trap_meminit_oob()
 	}
 	if dstEnd > uint64(m.dataEnd) {
-		// dataEnd is 32-bit bookkeeping for shared-image embeddings;
-		// memory64 images are not shareable yet, so saturate rather
-		// than truncate.
-		m.dataEnd = ^uint32(0)
+		// Same bookkeeping as the 32-bit memoryInit: the end of the
+		// data-segment region is where BSS begins, and image-sharing
+		// embeddings must know it. dataEnd is a uint32; a segment
+		// landing beyond 4GiB saturates it, which makes the sharing
+		// layer refuse the image instead of truncating the extent.
+		if dstEnd >= uint64(^uint32(0)) {
+			m.dataEnd = ^uint32(0)
+		} else {
+			m.dataEnd = uint32(dstEnd)
+		}
 	}
-	copy(m.memory[uint64(dst):dstEnd], data[uint32(src):uint32(src)+uint32(n)])
+	d := m.memory[uint64(dst):dstEnd]
+	s := data[uint32(src) : uint32(src)+uint32(n)]
+	// Write only what differs, exactly like the 32-bit memoryInit: an
+	// image-backed instance re-running memory.init over a copy-on-write
+	// map must not fault every page private with an identical copy.
+	if bytes.Equal(d, s) {
+		return
+	}
+	copy(d, s)
 }
 
 // simdEA64 is simdEA for 64-bit addresses: u64 effective address with

--- a/internal/codegen/helpers/helpers_mematomic_test.go
+++ b/internal/codegen/helpers/helpers_mematomic_test.go
@@ -62,6 +62,51 @@ func TestMemoryInitAndDataDrop(t *testing.T) {
 	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit(m, 0, 0, 0, 1) })
 }
 
+// TestMemoryInit64DataEnd pins the memory64 variant's shared-image
+// bookkeeping: a passive-segment install below 4GiB must RAISE dataEnd
+// to its real extent, not saturate it. Threads builds make every
+// segment passive (memory.init at start-up is the only installer), so
+// a saturating memoryInit64 silently disabled copy-on-write image
+// sharing for every wasm64-threads engine.
+func TestMemoryInit64DataEnd(t *testing.T) {
+	m := newMemModuleM(64)
+	m.dataSegs = [][]byte{[]byte("hello world")}
+
+	memoryInit64(m, 0, 4, 0, 5)
+	if got := string(m.memory[4:9]); got != "hello" {
+		t.Errorf("memoryInit64 copied %q, want %q", got, "hello")
+	}
+	if m.dataEnd != 9 {
+		t.Errorf("dataEnd = %d, want 9 (dst+n)", m.dataEnd)
+	}
+	// Zero-length init is a no-op.
+	memoryInit64(m, 0, 60, 0, 0)
+	if m.dataEnd != 9 {
+		t.Errorf("dataEnd moved on a zero-length init: %d", m.dataEnd)
+	}
+	// Identical re-init takes the compare-then-write path (an
+	// image-backed instance re-running the start section must not
+	// fault shared pages private) and leaves the bytes correct.
+	memoryInit64(m, 0, 4, 0, 5)
+	if got := string(m.memory[4:9]); got != "hello" {
+		t.Errorf("second memoryInit64 corrupted memory: %q", got)
+	}
+	// A later, higher install raises dataEnd monotonically.
+	memoryInit64(m, 0, 20, 6, 5)
+	if got := string(m.memory[20:25]); got != "world" {
+		t.Errorf("memoryInit64 copied %q, want %q", got, "world")
+	}
+	if m.dataEnd != 25 {
+		t.Errorf("dataEnd = %d, want 25", m.dataEnd)
+	}
+
+	// Bounds checks trap like the 32-bit variant.
+	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit64(m, 0, 0, 0, 100) })
+	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit64(m, 0, 60, 0, 10) })
+	dataDrop(m, 0)
+	mustPanic(t, "wasm: memory.init out of bounds", func() { memoryInit64(m, 0, 0, 0, 1) })
+}
+
 func TestAtomicMemoryOps(t *testing.T) {
 	m := newMemModuleM(64)
 


### PR DESCRIPTION
## Summary

`memoryInit64` saturated `dataEnd` to `MaxUint32` on **every** install — a leftover from before memory64 images were shareable. A threads build makes every data segment passive (`__wasm_init_memory` installs them via `memory.init` at start-up), so the very first install saturated the extent and the sharing layer refused the image with `no data segments were installed (dataEnd=4294967295)`: every wasm64-threads engine silently lost copy-on-write model sharing and fell back to private loads.

This is what has been failing `TestSharedModelSnapshot` on go-llama's main CI (all three matrix legs) since the engine moved to the threads build. Pre-threads wasm64 builds were unaffected because their segments are active and `dataEnd` is seeded at compile time.

The fix raises `dataEnd` to the real extent exactly like the 32-bit `memoryInit`, saturating only when a segment genuinely lands beyond the uint32 bookkeeping range, and adopts the 32-bit variant's compare-then-write path so an image-backed instance re-running the start section over a copy-on-write map does not fault identical pages private.

## Verification

- `TestMemoryInit64DataEnd` pins the bookkeeping (raise, monotonicity, zero-length no-op, compare-then-write, bounds traps).
- Full test suite and lint green.
- llama scale: with a wasm64-threads llama.wasm bundle built from this branch, the full go-llama test suite passes — including the previously failing `TestSharedModelSnapshot` — and the routing bench shows model load via the shared snapshot working again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
