### PR TITLE
gcasm: keep the x64 const-shuffle emulation inside the scratch set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,30 @@ jobs:
       - name: Test with coverage
         run: make test-cover
 
+  # The amd64 SIMD splices only compile into GOAMD64=v2+ binaries
+  # (v1 keeps the pure fallback), so the default job never EXECUTES
+  # them. This job runs the execution-heavy suites with the splices
+  # live on the runner's AVX2 hardware — the gate that would have
+  # caught the const-shuffle scratch clobber before release.
+  test-amd64-v2:
+    runs-on: ubuntu-latest
+    env:
+      GOAMD64: v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install wat2wasm
+        run: make install/wat2wasm
+
+      - name: Test with the amd64 splices enabled
+        run: go test -count=1 ./transpile/... ./internal/gcasm/... ./internal/codegen/...
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,12 @@ jobs:
       - name: Install wat2wasm
         run: make install/wat2wasm
 
+      # internal/codegen is deliberately absent: its runtime tests
+      # build codegen.Translate output, which by design carries the
+      # pure bodies under the asm-dormancy tag with no asm bundle —
+      # only the full transpile backend produces v2-runnable packages.
       - name: Test with the amd64 splices enabled
-        run: go test -count=1 ./transpile/... ./internal/gcasm/... ./internal/codegen/...
+        run: go test -count=1 ./transpile/... ./internal/gcasm/...
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Test with coverage
         run: make test-cover
 
-  # The amd64 SIMD splices only compile into GOAMD64=v2+ binaries
-  # (v1 keeps the pure fallback), so the default job never EXECUTES
-  # them. This job runs the execution-heavy suites with the splices
-  # live on the runner's AVX2 hardware — the gate that would have
-  # caught the const-shuffle scratch clobber before release.
+  # The default job (amd64 at GOAMD64=v1) executes only the PURE
+  # fallback: the amd64 splices compile into v2+ binaries and the
+  # arm64 splices need arm64 hardware. These jobs run the
+  # execution-heavy suites on each spliced backend — the gates that
+  # would have caught the const-shuffle scratch clobber before
+  # release. internal/codegen is deliberately absent from both: its
+  # runtime tests build codegen.Translate output, which by design
+  # carries the pure bodies under the asm-dormancy tag with no asm
+  # bundle — only the full transpile backend produces packages that
+  # run on the spliced targets.
   test-amd64-v2:
     runs-on: ubuntu-latest
     env:
@@ -56,11 +61,24 @@ jobs:
       - name: Install wat2wasm
         run: make install/wat2wasm
 
-      # internal/codegen is deliberately absent: its runtime tests
-      # build codegen.Translate output, which by design carries the
-      # pure bodies under the asm-dormancy tag with no asm bundle —
-      # only the full transpile backend produces v2-runnable packages.
       - name: Test with the amd64 splices enabled
+        run: go test -count=1 ./transpile/... ./internal/gcasm/...
+
+  test-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install wat2wasm
+        run: make install/wat2wasm
+
+      - name: Test with the arm64 splices enabled
         run: go test -count=1 ./transpile/... ./internal/gcasm/...
 
   lint:

--- a/internal/gcasm/gate1_test.go
+++ b/internal/gcasm/gate1_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -549,6 +550,9 @@ func TestFixtureGate(t *testing.T) {
 
 // TestGate1ControlFixture is the original whole-fixture gate.
 func TestGate1ControlFixture(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	fixtureGate(t, "control")
 }
 
@@ -556,6 +560,9 @@ func TestGate1ControlFixture(t *testing.T) {
 // fixture corpus: floats, i64, memory ops, globals, traps, indirect
 // calls, dense dispatch.
 func TestGate2Fixtures(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	for _, fixture := range []string{
 		"cg_brtable64",
 		"cg_bittest",

--- a/internal/gcasm/gcasm_test.go
+++ b/internal/gcasm/gcasm_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -46,6 +47,9 @@ func Rec(n int32) int32 {
 // with an ABI0 wrapper, run it against the pure implementation, and
 // verify the transform is DETERMINISTIC (two captures → identical .s).
 func TestGate0CaptureTransformRun(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	dir := writeRecModule(t)
 	sig := func(sym string) ([]ArgKind, bool, ArgKind, string, bool) {
 		if strings.HasSuffix(sym, ".Rec") {
@@ -141,6 +145,9 @@ func TestRec(t *testing.T) {
 // the wraparound-checking variant) through capture, transform,
 // assembly and a deep-recursion run.
 func TestGate0BigFrame(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	dir := t.TempDir()
 	libSrc := `package lib
 

--- a/internal/gcasm/ifacecall_test.go
+++ b/internal/gcasm/ifacecall_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -13,6 +14,9 @@ import (
 // slot load, CALL DX with ABIInternal register args). The python.wasm
 // consumer crashed on exactly this pattern.
 func TestIfaceCallGate(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	dir := t.TempDir()
 	libSrc := `package lib
 

--- a/internal/gcasm/jumptable_flags_test.go
+++ b/internal/gcasm/jumptable_flags_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -39,6 +40,9 @@ func flagDispatchSrc(fnName string) string {
 // false-negative holes and some leaves got no replay, so the tree's
 // leftover flags leaked into the arms and picked the wrong branch.
 func TestJumpTableFlagReplayRun(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	dir := t.TempDir()
 	src := "package lib\n\n//go:noinline\n" + flagDispatchSrc("FDispatch")
 	for name, content := range map[string]string{

--- a/internal/gcasm/jumptable_test.go
+++ b/internal/gcasm/jumptable_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -34,6 +35,9 @@ func dispatchSrc(fnName string) string {
 // against the pure implementation for every selector including
 // out-of-range ones. Also asserts transform determinism.
 func TestJumpTableTransformRun(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	dir := t.TempDir()
 	src := "package lib\n\n//go:noinline\n" + dispatchSrc("Dispatch")
 	for name, content := range map[string]string{

--- a/internal/gcasm/perfgate_test.go
+++ b/internal/gcasm/perfgate_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,9 @@ import (
 // The gate only asserts sanity bounds (transform not catastrophically
 // slower); the measured ratios go to the log for bench-metrics.md.
 func TestPerfGate(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	if testing.Short() {
 		t.Skip("perf gate skipped in -short")
 	}

--- a/internal/gcasm/simdsplice_fuse_loop_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_loop_x64_test.go
@@ -77,3 +77,64 @@ func TestX64LoopCarryReadsReservedRegister(t *testing.T) {
 		t.Errorf("carried register not seeded from arguments before the loop:\n%s", prologue)
 	}
 }
+
+// shuffleConstLoop puts an i8x16_shuffle_const between two loads and a
+// carried accumulator, with a splat that stays live across the
+// shuffle — the shape whose emulation once scratched X4/X5 and
+// clobbered pool-resident values.
+func shuffleConstLoop() *simdfuse.Loop {
+	sc := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgScalar, Index: i} }
+	cst := func(c int32) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgConst, Const: c} }
+	nd := func(i int) simdfuse.Arg { return simdfuse.Arg{Kind: simdfuse.ArgNode, Index: i} }
+	tree := &simdfuse.Tree{
+		Name:       "simd_p_fxl_shufconst",
+		NumScalars: 1,
+		NumPairs:   1,
+		NeedsMem:   true,
+		Nodes: []simdfuse.Node{
+			// node 0: a splat that must survive past the shuffle.
+			{Op: "v128_load32_splat", Args: []simdfuse.Arg{sc(0), cst(0)}},
+			{Op: "v128_load", Args: []simdfuse.Arg{sc(0), cst(16)}},
+			{Op: "v128_load", Args: []simdfuse.Arg{sc(0), cst(32)}},
+			// node 3: const-pattern shuffle of the two loads.
+			{Op: "i8x16_shuffle_const", Args: []simdfuse.Arg{
+				nd(1), nd(2),
+				cst(0x03020100), cst(0x0b0a0908), cst(0x13121110), cst(0x1b1a1918),
+			}},
+			// node 4: the splat is consumed AFTER the shuffle ran.
+			{Op: "i32x4_add", Args: []simdfuse.Arg{nd(3), nd(0)}},
+			{Op: "i32x4_add", Args: []simdfuse.Arg{{Kind: simdfuse.ArgPairIn, Index: 0}, nd(4)}},
+		},
+		Roots: []int{5},
+	}
+	return &simdfuse.Loop{
+		Tree:          tree,
+		CarriedPairs:  [][2]int{{0, 5}},
+		CounterScalar: 0,
+		Dec:           1,
+		PreTest:       true,
+	}
+}
+
+// The const-pattern shuffle emulation must stay inside the splicer's
+// scratch registers (X0-X3): pool values live in X4+ for the whole
+// loop body and there is no relocation pass here. The old body
+// staged the biased patterns in X4/X5 and corrupted whatever the
+// allocator had parked there.
+func TestX64LoopShuffleConstStaysInScratch(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceLoop(&b, shuffleConstLoop(), &ConstPool{}, fuseTestOffs, "0", false, 0)
+	if err != nil || !spliced {
+		t.Fatalf("spliced=%v err=%v", spliced, err)
+	}
+	body := b.String()
+	shuf := regexp.MustCompile(`(?s)MOVOU ·gcb16_[0-9a-f]+\(SB\), X2.*?POR X1, X0`).FindString(body)
+	if shuf == "" {
+		t.Fatalf("no shuffle-const emulation in body:\n%s", body)
+	}
+	for _, m := range regexp.MustCompile(`X(\d+)`).FindAllStringSubmatch(shuf, -1) {
+		if m[1] != "0" && m[1] != "1" && m[1] != "2" && m[1] != "3" {
+			t.Fatalf("shuffle-const emulation touches X%s (outside the X0-X3 scratch set):\n%s", m[1], shuf)
+		}
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -558,10 +558,19 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 				blob[bi] = byte(patLo >> (8 * bi))
 				blob[8+bi] = byte(patHi >> (8 * bi))
 			}
-			fmt.Fprintf(b, "\tMOVOU ·%s(SB), X2\n", pool.addBlob(blob))
+			// The emulation must stay inside the splicer's scratch set
+			// (X0-X3): pool values live in X4+ for the whole loop
+			// body, and the window path's relocate-out-of-reach scan
+			// does not run here. The pattern reloads from the pool
+			// instead of holding a second biased copy, and the bias
+			// constants apply as memory operands, so three registers
+			// suffice.
+			patBlob := pool.addBlob(blob)
 			shufLines, cok := simdSpliceRewriteConsts([]string{
-				"MOVOU ·simdConst70(SB), X3", "MOVOU X2, X4", "PADDUSB X3, X4", "PSHUFB X4, X0",
-				"MOVOU ·simdConst16(SB), X5", "PSUBB X5, X2", "PADDUSB X3, X2", "PSHUFB X2, X1",
+				"MOVOU ·" + patBlob + "(SB), X2",
+				"PADDUSB ·simdConst70(SB), X2", "PSHUFB X2, X0",
+				"MOVOU ·" + patBlob + "(SB), X2",
+				"PSUBB ·simdConst16(SB), X2", "PADDUSB ·simdConst70(SB), X2", "PSHUFB X2, X1",
 				"POR X1, X0",
 			}, pool)
 			if !cok {

--- a/internal/gcasm/stackarg_test.go
+++ b/internal/gcasm/stackarg_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -13,6 +14,9 @@ import (
 // itself stays pure — its own params stack-assign). Gate 3a validated
 // that such call sites TRANSFORM; this gate validates they RUN.
 func TestStackArgCallGate(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("fixture emits amd64-only asm; the harness builds and runs it on the host")
+	}
 	dir := t.TempDir()
 	libSrc := `package lib
 


### PR DESCRIPTION
Fixes the amd64 (GOAMD64=v2+) miscomputation in the fused repack gemv loops: the i8x16_shuffle_const emulation staged its biased PSHUFB patterns in X4/X5 — outside the splicer's X0-X3 scratch set — corrupting pool-resident values (the activation-scale splat on the repack gemv), so every output came out Inf/garbage on the spliced amd64 path. v1 builds use the pure fallback, which is why only the GOAMD64=v2 CI job caught it (via the numeric kernel tests newly added in goccy/go-llama#7).

The emulation now reloads the pattern from the constant pool and applies the bias constants as memory operands: three registers suffice and it stays inside X0-X2. Regression test rejects any X4+ mention in the emulated sequence.

Verified under GOAMD64=v2 (Rosetta): repack numeric kernel tests and the full engine suite pass against a bundle transpiled with this fix; arm64 output is byte-identical to v0.5.5.

After merge: tag v0.5.6 → image → llama-wasm v0.2.3 → rebundle → go-llama#7 rebases onto the fixed module (currently blocked on its amd64 v2 CI job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)