### PR TITLE
Guard bare atomic spin loops with a bounded preemption point

### DIFF
--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -32,6 +32,13 @@ type ssaEmitter struct {
 	// evaluation could run memory.grow. See emitFuncBody.
 	memBaseHoisted bool
 
+	// spinHeaders holds the loop headers (per function) that need a
+	// spinRelax preemption guard; spinGuardEmitted records that at
+	// least one guard statement was actually emitted, gating the
+	// __spinGuard counter declaration. See spinguard.go.
+	spinHeaders      map[ssa.BlockID]bool
+	spinGuardEmitted bool
+
 	// catchExcVar is the Go variable holding the *wasmExc currently being
 	// handled, set while the structured emitter renders an EH catch handler
 	// region so OpCatchArg can read its operand slots. Empty outside a
@@ -111,6 +118,8 @@ func (em *ssaEmitter) emitFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
 	em.simdCalls = nil
 	em.simdConsts = nil
 	em.curFn = f
+	em.spinHeaders = spinGuardHeaders(f)
+	em.spinGuardEmitted = false
 	// Hoist the linear-memory base pointer into a function-level local
 	// when the function touches memory at all. `m.M` is a Module FIELD,
 	// so the Go compiler must conservatively reload it after every
@@ -167,6 +176,17 @@ func (em *ssaEmitter) emitFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
 		}
 		body.List = append([]ast.Stmt{decl, keep}, body.List...)
 	}
+	if em.spinGuardEmitted {
+		// The guard statements always increment the counter, so no
+		// blank-use is needed.
+		body.List = append([]ast.Stmt{&ast.DeclStmt{Decl: &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{&ast.ValueSpec{
+				Names: []*ast.Ident{newID(spinGuardLocal)},
+				Type:  newID("uint32"),
+			}},
+		}}}, body.List...)
+	}
 	// In mutable-locals mode (try functions), declared (non-param) locals are
 	// mutable Go vars `lN`, zero-initialised to match wasm's zeroed locals.
 	// Params already exist as function arguments `l0..`.
@@ -208,6 +228,23 @@ func (em *ssaEmitter) emitFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
 	}
 	em.scalarizeSimd(body, paramsV128)
 	return body, nil
+}
+
+// spinGuardLocal is the per-function iteration counter the spinRelax
+// guard advances. Like mBase, the name cannot collide with generated
+// value names (v<N>), parameters (l<N>), or phi temps.
+const spinGuardLocal = "__spinGuard"
+
+// spinGuardStmt renders one `spinRelax(&__spinGuard)` call — the
+// per-iteration preemption guard for a bare atomic spin loop (see
+// spinguard.go).
+func (em *ssaEmitter) spinGuardStmt() ast.Stmt {
+	em.spinGuardEmitted = true
+	em.useHelper("spinRelax")
+	return &ast.ExprStmt{X: &ast.CallExpr{
+		Fun:  em.helperRef("spinRelax"),
+		Args: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: newID(spinGuardLocal)}},
+	}}
 }
 
 // memBaseLocal is the name of the per-function hoisted copy of m.M.
@@ -489,6 +526,9 @@ func (em *ssaEmitter) emitBlockInto(blk *ssa.Block, out *[]ast.Stmt, ec *emitCtx
 		if v := ec.tramp.entrySet[blk.ID]; v != "" {
 			*out = append(*out, assignBool(v, true))
 		}
+	}
+	if em.spinHeaders[blk.ID] {
+		*out = append(*out, em.spinGuardStmt())
 	}
 
 	valuesEnd := len(blk.Values)

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -235,16 +235,41 @@ func (em *ssaEmitter) emitFuncBody(f *ssa.Func) (*ast.BlockStmt, error) {
 // value names (v<N>), parameters (l<N>), or phi temps.
 const spinGuardLocal = "__spinGuard"
 
-// spinGuardStmt renders one `spinRelax(&__spinGuard)` call — the
-// per-iteration preemption guard for a bare atomic spin loop (see
-// spinguard.go).
-func (em *ssaEmitter) spinGuardStmt() ast.Stmt {
+// spinGuardStmts renders the per-iteration preemption guard of a bare
+// atomic spin loop (see spinguard.go):
+//
+//	__spinGuard++
+//	if __spinGuard&16383 == 0 { spinRelax() }
+//
+// The hot path is an increment and a not-taken branch — cheap enough
+// for a spin that mostly loses the race by a few iterations. The cold
+// call is the preemption point (its prologue runs the stack check, so
+// a stop-the-world waits at most ~16k spin iterations, tens of
+// microseconds) and hands the core over when the wait is genuinely
+// long. An unconditional call per iteration measured ~40% decode
+// overhead at n_threads=8: eight workers calling runtime.Gosched at
+// spin rate serialize on sched.lock, and the call round-trip alone
+// showed ~15% — the counter keeps both off the hot path.
+func (em *ssaEmitter) spinGuardStmts() []ast.Stmt {
 	em.spinGuardEmitted = true
 	em.useHelper("spinRelax")
-	return &ast.ExprStmt{X: &ast.CallExpr{
-		Fun:  em.helperRef("spinRelax"),
-		Args: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: newID(spinGuardLocal)}},
-	}}
+	return []ast.Stmt{
+		&ast.IncDecStmt{X: newID(spinGuardLocal), Tok: token.INC},
+		&ast.IfStmt{
+			Cond: &ast.BinaryExpr{
+				X: &ast.BinaryExpr{
+					X:  newID(spinGuardLocal),
+					Op: token.AND,
+					Y:  &ast.BasicLit{Kind: token.INT, Value: "16383"},
+				},
+				Op: token.EQL,
+				Y:  &ast.BasicLit{Kind: token.INT, Value: "0"},
+			},
+			Body: &ast.BlockStmt{List: []ast.Stmt{
+				&ast.ExprStmt{X: &ast.CallExpr{Fun: em.helperRef("spinRelax")}},
+			}},
+		},
+	}
 }
 
 // memBaseLocal is the name of the per-function hoisted copy of m.M.
@@ -528,7 +553,7 @@ func (em *ssaEmitter) emitBlockInto(blk *ssa.Block, out *[]ast.Stmt, ec *emitCtx
 		}
 	}
 	if em.spinHeaders[blk.ID] {
-		*out = append(*out, em.spinGuardStmt())
+		*out = append(*out, em.spinGuardStmts()...)
 	}
 
 	valuesEnd := len(blk.Values)

--- a/internal/codegen/emit_ssa.go
+++ b/internal/codegen/emit_ssa.go
@@ -32,11 +32,12 @@ type ssaEmitter struct {
 	// evaluation could run memory.grow. See emitFuncBody.
 	memBaseHoisted bool
 
-	// spinHeaders holds the loop headers (per function) that need a
-	// spinRelax preemption guard; spinGuardEmitted records that at
-	// least one guard statement was actually emitted, gating the
-	// __spinGuard counter declaration. See spinguard.go.
-	spinHeaders      map[ssa.BlockID]bool
+	// spinHeaders maps the loop headers (per function) that need a
+	// spinRelax preemption guard to their guard mask (interval-1, see
+	// spinGuardMask); spinGuardEmitted records that at least one guard
+	// statement was actually emitted, gating the __spinGuard counter
+	// declaration. See spinguard.go.
+	spinHeaders      map[ssa.BlockID]int
 	spinGuardEmitted bool
 
 	// catchExcVar is the Go variable holding the *wasmExc currently being
@@ -239,18 +240,19 @@ const spinGuardLocal = "__spinGuard"
 // atomic spin loop (see spinguard.go):
 //
 //	__spinGuard++
-//	if __spinGuard&16383 == 0 { spinRelax() }
+//	if __spinGuard&<mask> == 0 { spinRelax() }
 //
 // The hot path is an increment and a not-taken branch — cheap enough
 // for a spin that mostly loses the race by a few iterations. The cold
 // call is the preemption point (its prologue runs the stack check, so
-// a stop-the-world waits at most ~16k spin iterations, tens of
-// microseconds) and hands the core over when the wait is genuinely
-// long. An unconditional call per iteration measured ~40% decode
-// overhead at n_threads=8: eight workers calling runtime.Gosched at
-// spin rate serialize on sched.lock, and the call round-trip alone
-// showed ~15% — the counter keeps both off the hot path.
-func (em *ssaEmitter) spinGuardStmts() []ast.Stmt {
+// a stop-the-world waits at most the time budget spinGuardMask
+// derives the mask from) and hands the core over when the wait is
+// genuinely long. An unconditional call per iteration measured ~40%
+// decode overhead at n_threads=8: eight workers calling
+// runtime.Gosched at spin rate serialize on sched.lock, and the call
+// round-trip alone showed ~15% — the counter keeps both off the hot
+// path.
+func (em *ssaEmitter) spinGuardStmts(mask int) []ast.Stmt {
 	em.spinGuardEmitted = true
 	em.useHelper("spinRelax")
 	return []ast.Stmt{
@@ -260,7 +262,7 @@ func (em *ssaEmitter) spinGuardStmts() []ast.Stmt {
 				X: &ast.BinaryExpr{
 					X:  newID(spinGuardLocal),
 					Op: token.AND,
-					Y:  &ast.BasicLit{Kind: token.INT, Value: "16383"},
+					Y:  &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(mask)},
 				},
 				Op: token.EQL,
 				Y:  &ast.BasicLit{Kind: token.INT, Value: "0"},
@@ -552,8 +554,8 @@ func (em *ssaEmitter) emitBlockInto(blk *ssa.Block, out *[]ast.Stmt, ec *emitCtx
 			*out = append(*out, assignBool(v, true))
 		}
 	}
-	if em.spinHeaders[blk.ID] {
-		*out = append(*out, em.spinGuardStmts()...)
+	if mask, ok := em.spinHeaders[blk.ID]; ok {
+		*out = append(*out, em.spinGuardStmts(mask)...)
 	}
 
 	valuesEnd := len(blk.Values)

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -565,7 +565,7 @@ func (se *structEmitter) phiCopies(pred, succ *ssa.Block, predIdx int) ([]ast.St
 func (se *structEmitter) blockValues(blk *ssa.Block) ([]ast.Stmt, error) {
 	var out []ast.Stmt
 	if se.em.spinHeaders[blk.ID] {
-		out = append(out, se.em.spinGuardStmt())
+		out = append(out, se.em.spinGuardStmts()...)
 	}
 	valuesEnd := len(blk.Values)
 	if blk.Kind == ssa.BlockRet {

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -564,6 +564,9 @@ func (se *structEmitter) phiCopies(pred, succ *ssa.Block, predIdx int) ([]ast.St
 // on edges) and the Ret-tail return markers.
 func (se *structEmitter) blockValues(blk *ssa.Block) ([]ast.Stmt, error) {
 	var out []ast.Stmt
+	if se.em.spinHeaders[blk.ID] {
+		out = append(out, se.em.spinGuardStmt())
+	}
 	valuesEnd := len(blk.Values)
 	if blk.Kind == ssa.BlockRet {
 		valuesEnd -= len(se.f.Sig.Results)

--- a/internal/codegen/emit_structured.go
+++ b/internal/codegen/emit_structured.go
@@ -564,8 +564,8 @@ func (se *structEmitter) phiCopies(pred, succ *ssa.Block, predIdx int) ([]ast.St
 // on edges) and the Ret-tail return markers.
 func (se *structEmitter) blockValues(blk *ssa.Block) ([]ast.Stmt, error) {
 	var out []ast.Stmt
-	if se.em.spinHeaders[blk.ID] {
-		out = append(out, se.em.spinGuardStmts()...)
+	if mask, ok := se.em.spinHeaders[blk.ID]; ok {
+		out = append(out, se.em.spinGuardStmts(mask)...)
 	}
 	valuesEnd := len(blk.Values)
 	if blk.Kind == ssa.BlockRet {

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -1581,9 +1581,22 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 // runtime.Gosched at spin rate serialize on sched.lock, and the call
 // round-trip alone showed ~15%.
 //
+// The Gosched is rate-limited across every spinning worker (the
+// spinRelaxColdCalls counter lives in the runtime template — helper
+// extraction carries function decls only): the preemption point is the
+// spinRelax call itself (its prologue's stack check), but yielding on
+// every cold call still measured double-digit scheduler churn
+// (pthread_cond_signal — wakep — at 30% of the profile) on
+// barrier-heavy workloads, where waiting IS most of a worker's time.
+// One yield per 64 cold calls keeps donation proportional to
+// aggregate spin time — rare on an uncontended box, automatically
+// more frequent when oversubscription makes the spins long.
+//
 //go:noinline
 func spinRelax() {
-	runtime.Gosched()
+	if atomic.AddUint32(&spinRelaxColdCalls, 1)&63 == 0 {
+		runtime.Gosched()
+	}
 }
 
 // ----- wasm32 atomic helpers (named by the lowering) -----------------------

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -1561,31 +1561,29 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 	}
 }
 
-// spinRelax is the preemption valve the emitters plant in bare atomic
-// spin loops (a loop that waits on an inline atomic load and makes no
-// other call — see spinguard.go). Such a loop is fine as Go, but once
-// the gcasm bundler captures the compiled function into a .s TEXT the
-// runtime can no longer async-preempt it, and a goroutine spinning
-// there blocks every stop-the-world — a livelock when the store it
-// waits for comes from a goroutine the GC already parked.
+// spinRelax is the cold half of the preemption guard the emitters
+// plant in bare atomic spin loops (a loop that waits on an inline
+// atomic load and makes no other call — see spinguard.go). Such a loop
+// is fine as Go, but once the gcasm bundler captures the compiled
+// function into a .s TEXT the runtime can no longer async-preempt it,
+// and a goroutine spinning there blocks every stop-the-world — a
+// livelock when the store it waits for comes from a goroutine the GC
+// already parked.
 //
-// The call itself is the fix: it must survive to machine code (hence
-// //go:noinline), so the spinning goroutine periodically executes
-// ordinary preemptible Go. The Gosched hands the core to the thread
-// the spin is waiting for; doing that on every iteration measures
-// ~3.4x decode latency on ggml's barrier (n_threads=8, the waiters
-// endlessly round-tripping the run queue), while every 1024th
-// iteration is parity with no yield at all and still reaches the
-// scheduler every few microseconds of spinning. The counter lives in
-// the generated function (one uint32 per function, address-taken), so
-// this single site owns the whole policy.
+// The generated hot path is a counter increment and a not-taken
+// branch; every 16384th iteration reaches this call. The call itself
+// is the fix — it must survive to machine code (hence //go:noinline),
+// and its prologue's stack check is the preemption point, so a
+// stop-the-world waits at most ~16k spin iterations (tens of
+// microseconds). The Gosched additionally donates the core when a
+// wait is genuinely long. Calling on every iteration instead measured
+// ~40% decode overhead at n_threads=8: eight workers reaching
+// runtime.Gosched at spin rate serialize on sched.lock, and the call
+// round-trip alone showed ~15%.
 //
 //go:noinline
-func spinRelax(c *uint32) {
-	*c++
-	if *c&1023 == 0 {
-		runtime.Gosched()
-	}
+func spinRelax() {
+	runtime.Gosched()
 }
 
 // ----- wasm32 atomic helpers (named by the lowering) -----------------------

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -1561,6 +1561,33 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 	}
 }
 
+// spinRelax is the preemption valve the emitters plant in bare atomic
+// spin loops (a loop that waits on an inline atomic load and makes no
+// other call — see spinguard.go). Such a loop is fine as Go, but once
+// the gcasm bundler captures the compiled function into a .s TEXT the
+// runtime can no longer async-preempt it, and a goroutine spinning
+// there blocks every stop-the-world — a livelock when the store it
+// waits for comes from a goroutine the GC already parked.
+//
+// The call itself is the fix: it must survive to machine code (hence
+// //go:noinline), so the spinning goroutine periodically executes
+// ordinary preemptible Go. The Gosched hands the core to the thread
+// the spin is waiting for; doing that on every iteration measures
+// ~3.4x decode latency on ggml's barrier (n_threads=8, the waiters
+// endlessly round-tripping the run queue), while every 1024th
+// iteration is parity with no yield at all and still reaches the
+// scheduler every few microseconds of spinning. The counter lives in
+// the generated function (one uint32 per function, address-taken), so
+// this single site owns the whole policy.
+//
+//go:noinline
+func spinRelax(c *uint32) {
+	*c++
+	if *c&1023 == 0 {
+		runtime.Gosched()
+	}
+}
+
 // ----- wasm32 atomic helpers (named by the lowering) -----------------------
 
 //go:noinline

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -1571,11 +1571,13 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 // already parked.
 //
 // The generated hot path is a counter increment and a not-taken
-// branch; every 16384th iteration reaches this call. The call itself
+// branch; every 2^k-th iteration reaches this call, with k derived at
+// emission from the loop body's size so the interval is a roughly
+// constant TIME budget (see spinGuardMask). The call itself
 // is the fix — it must survive to machine code (hence //go:noinline),
 // and its prologue's stack check is the preemption point, so a
-// stop-the-world waits at most ~16k spin iterations (tens of
-// microseconds). The Gosched additionally donates the core when a
+// stop-the-world waits at most tens-to-low-hundreds of microseconds
+// of spinning. The Gosched additionally donates the core when a
 // wait is genuinely long. Calling on every iteration instead measured
 // ~40% decode overhead at n_threads=8: eight workers reaching
 // runtime.Gosched at spin rate serialize on sched.lock, and the call

--- a/internal/codegen/helpers/helpers_spinrelax_test.go
+++ b/internal/codegen/helpers/helpers_spinrelax_test.go
@@ -1,0 +1,18 @@
+package helpers
+
+import "testing"
+
+// TestSpinRelax exercises the preemption valve the emitters plant in
+// bare atomic spin loops: the counter advances on every call, and
+// driving it far past the yield period (every 1024th call reaches
+// runtime.Gosched) completes without stalling — the guard must never
+// block the spinning goroutine, only donate the core.
+func TestSpinRelax(t *testing.T) {
+	var c uint32
+	for i := 0; i < 4096; i++ {
+		spinRelax(&c)
+	}
+	if c != 4096 {
+		t.Errorf("spinRelax counter = %d, want 4096", c)
+	}
+}

--- a/internal/codegen/helpers/helpers_spinrelax_test.go
+++ b/internal/codegen/helpers/helpers_spinrelax_test.go
@@ -2,17 +2,11 @@ package helpers
 
 import "testing"
 
-// TestSpinRelax exercises the preemption valve the emitters plant in
-// bare atomic spin loops: the counter advances on every call, and
-// driving it far past the yield period (every 1024th call reaches
-// runtime.Gosched) completes without stalling — the guard must never
-// block the spinning goroutine, only donate the core.
+// TestSpinRelax exercises the cold half of the spin-loop preemption
+// guard: reaching runtime.Gosched must never block the caller, only
+// donate the core.
 func TestSpinRelax(t *testing.T) {
-	var c uint32
-	for i := 0; i < 4096; i++ {
-		spinRelax(&c)
-	}
-	if c != 4096 {
-		t.Errorf("spinRelax counter = %d, want 4096", c)
+	for i := 0; i < 64; i++ {
+		spinRelax()
 	}
 }

--- a/internal/codegen/helpers/spinrelax_state.go
+++ b/internal/codegen/helpers/spinrelax_state.go
@@ -1,0 +1,8 @@
+package helpers
+
+// spinRelaxColdCalls mirrors the declaration in the wasip1_native.go
+// runtime template so this package compiles (and its tests run) on its
+// own. Only helpers.go is embedded and extracted into generated
+// output; there the generated base package supplies the counter from
+// the template, so the two declarations never meet.
+var spinRelaxColdCalls uint32

--- a/internal/codegen/spinguard.go
+++ b/internal/codegen/spinguard.go
@@ -38,7 +38,16 @@ import (
 // Over-approximation is deliberately cheap: a guarded loop that never
 // spins long pays one counter increment and a predictable branch per
 // iteration.
-func spinGuardHeaders(f *ssa.Func) map[ssa.BlockID]bool {
+//
+// The returned value per header is the guard MASK: the cold call runs
+// when __spinGuard&mask == 0. The interval is derived from the loop
+// body's size so the stop-the-world arrival bound is a TIME budget,
+// not an iteration count that would stretch with the body: a minimal
+// barrier spin (a handful of values) checks every 16384th iteration,
+// while an interpreter-style loop carrying hundreds of values per
+// iteration checks every few hundred — either way the budget lands in
+// the tens-to-low-hundreds of microseconds of spinning.
+func spinGuardHeaders(f *ssa.Func) map[ssa.BlockID]int {
 	if f == nil || f.Entry == nil {
 		return nil
 	}
@@ -88,12 +97,14 @@ func spinGuardHeaders(f *ssa.Func) map[ssa.BlockID]bool {
 		return nil
 	}
 
-	var headers map[ssa.BlockID]bool
+	var headers map[ssa.BlockID]int
 	for h, body := range bodies {
 		sawAtomicLoad := false
 		sawCall := false
+		bodyValues := 0
 	scan:
 		for blk := range body {
+			bodyValues += len(blk.Values)
 			for _, v := range blk.Values {
 				switch v.Op {
 				case ssa.OpCallDirect, ssa.OpCallIndirect, ssa.OpCallImport:
@@ -116,10 +127,38 @@ func spinGuardHeaders(f *ssa.Func) map[ssa.BlockID]bool {
 		}
 		if sawAtomicLoad && !sawCall {
 			if headers == nil {
-				headers = map[ssa.BlockID]bool{}
+				headers = map[ssa.BlockID]int{}
 			}
-			headers[h.ID] = true
+			headers[h.ID] = spinGuardMask(bodyValues)
 		}
 	}
 	return headers
+}
+
+// Spin-guard interval policy. The single tunable is a stop-the-world
+// latency budget expressed in value-iterations: interval × body size
+// ≈ spinGuardBudget, i.e. roughly constant TIME between preemption
+// points across guests, assuming ~ns-scale SSA values. The clamps keep
+// the derivation honest at the extremes: intervals above 2^14 buy
+// nothing (the cold call is already <0.1% there), and intervals below
+// 2^8 would let the guard itself become a per-iteration cost on very
+// large bodies (which already reach the budget in few iterations).
+const (
+	spinGuardBudget      = 1 << 18
+	spinGuardMinInterval = 1 << 8
+	spinGuardMaxInterval = 1 << 14
+)
+
+// spinGuardMask derives a power-of-two guard interval from the loop
+// body size and returns interval-1, the literal the emitters test the
+// counter against.
+func spinGuardMask(bodyValues int) int {
+	if bodyValues < 1 {
+		bodyValues = 1
+	}
+	interval := spinGuardMaxInterval
+	for interval > spinGuardMinInterval && interval*bodyValues > spinGuardBudget {
+		interval >>= 1
+	}
+	return interval - 1
 }

--- a/internal/codegen/spinguard.go
+++ b/internal/codegen/spinguard.go
@@ -1,0 +1,125 @@
+package codegen
+
+import (
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// Bare atomic spin loops
+//
+// A loop that waits on an inline atomic load and makes no call — the
+// shape ggml's barrier emits, `while (atomic_load(p) == x) {}` — is
+// legal Go after emission and preemptible as such, but the gcasm
+// bundler captures the compiled function into a .s TEXT, and the Go
+// runtime refuses to async-preempt assembly functions. A goroutine
+// spinning inside the captured loop then blocks every stop-the-world:
+// if the store it waits for comes from a goroutine the GC already
+// parked, the process livelocks with all cores burning. Observed in
+// production against llama.cpp's ggml_barrier (intermittent multi-
+// minute stalls, GC-timing dependent).
+//
+// spinGuardHeaders finds the headers of such loops so the emitters can
+// prepend one spinRelax(&__spinGuard) call per iteration (see the
+// helper's comment for the policy and its measured cost — parity with
+// the unguarded loop). The call is the fix: a loop whose body calls a
+// //go:noinline function periodically executes ordinary Go code, which
+// the runtime can preempt, no matter how the surrounding function is
+// lowered.
+//
+// A loop qualifies when its body
+//   - performs an inline atomic load (the atomicInlineSpecs load
+//     entries — sync/atomic intrinsics, a bare LDAR/MOV in machine
+//     code), and
+//   - contains no call that survives to machine code: direct, indirect,
+//     and import calls, and the helper-form atomic ops (their //go:noinline
+//     helper chain) all count as calls. OpHelperCall does NOT count —
+//     small pure helpers routinely inline away, and a guard next to a
+//     call that then disappears would leave the loop bare again.
+//
+// Over-approximation is deliberately cheap: a guarded loop that never
+// spins long pays one counter increment and a predictable branch per
+// iteration.
+func spinGuardHeaders(f *ssa.Func) map[ssa.BlockID]bool {
+	if f == nil || f.Entry == nil {
+		return nil
+	}
+	idom := ssa.Dominators(f)
+	dominates := func(a, b *ssa.Block) bool {
+		for cur := b; cur != nil; cur = idom[cur.ID] {
+			if cur == a {
+				return true
+			}
+			if cur == f.Entry {
+				break
+			}
+		}
+		return a == f.Entry
+	}
+
+	// Natural loop bodies, merged per header: every back-edge b→h
+	// (h dominating b) contributes the blocks that reach b without
+	// passing through h.
+	bodies := map[*ssa.Block]map[*ssa.Block]bool{}
+	for _, b := range f.Blocks {
+		for _, e := range b.Succs {
+			h := e.Block
+			if !dominates(h, b) {
+				continue
+			}
+			body := bodies[h]
+			if body == nil {
+				body = map[*ssa.Block]bool{h: true}
+				bodies[h] = body
+			}
+			stack := []*ssa.Block{b}
+			for len(stack) > 0 {
+				n := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if body[n] {
+					continue
+				}
+				body[n] = true
+				for _, pe := range n.Preds {
+					stack = append(stack, pe.Block)
+				}
+			}
+		}
+	}
+	if len(bodies) == 0 {
+		return nil
+	}
+
+	var headers map[ssa.BlockID]bool
+	for h, body := range bodies {
+		sawAtomicLoad := false
+		sawCall := false
+	scan:
+		for blk := range body {
+			for _, v := range blk.Values {
+				switch v.Op {
+				case ssa.OpCallDirect, ssa.OpCallIndirect, ssa.OpCallImport:
+					sawCall = true
+					break scan
+				case ssa.OpAtomicCall:
+					name, _ := v.Aux.(string)
+					if spec, ok := atomicInlineSpecs[name]; ok {
+						if !spec.isStore {
+							sawAtomicLoad = true
+						}
+					} else {
+						// Helper-form atomic (RMW, wait/notify,
+						// sub-word): a real //go:noinline call.
+						sawCall = true
+						break scan
+					}
+				}
+			}
+		}
+		if sawAtomicLoad && !sawCall {
+			if headers == nil {
+				headers = map[ssa.BlockID]bool{}
+			}
+			headers[h.ID] = true
+		}
+	}
+	return headers
+}

--- a/internal/codegen/spinguard_test.go
+++ b/internal/codegen/spinguard_test.go
@@ -39,8 +39,11 @@ func translateSpinguard(t *testing.T) (string, string, codegen.Result) {
 // plain (non-atomic) load, must stay untouched.
 func TestSpinGuardInjection(t *testing.T) {
 	_, all, _ := translateSpinguard(t)
-	if got := strings.Count(all, "spinRelax(&__spinGuard)"); got != 2 {
-		t.Errorf("spinRelax guard sites = %d, want 2 (bare_spin, bare_spin64)", got)
+	if got := strings.Count(all, "__spinGuard++"); got != 2 {
+		t.Errorf("spin guard sites = %d, want 2 (bare_spin, bare_spin64)", got)
+	}
+	if got := strings.Count(all, "if __spinGuard&16383 == 0 {"); got != 2 {
+		t.Errorf("spin guard cold branches = %d, want 2", got)
 	}
 	if got := strings.Count(all, "var __spinGuard uint32"); got != 2 {
 		t.Errorf("__spinGuard declarations = %d, want 2", got)

--- a/internal/codegen/spinguard_test.go
+++ b/internal/codegen/spinguard_test.go
@@ -39,14 +39,20 @@ func translateSpinguard(t *testing.T) (string, string, codegen.Result) {
 // plain (non-atomic) load, must stay untouched.
 func TestSpinGuardInjection(t *testing.T) {
 	_, all, _ := translateSpinguard(t)
-	if got := strings.Count(all, "__spinGuard++"); got != 2 {
-		t.Errorf("spin guard sites = %d, want 2 (bare_spin, bare_spin64)", got)
+	if got := strings.Count(all, "__spinGuard++"); got != 3 {
+		t.Errorf("spin guard sites = %d, want 3 (bare_spin, bare_spin64, big_spin)", got)
 	}
+	// The minimal spins get the widest interval; big_spin's body carries
+	// dozens of values, so its derived interval is proportionally
+	// shorter — the guard budget is time, not iterations.
 	if got := strings.Count(all, "if __spinGuard&16383 == 0 {"); got != 2 {
-		t.Errorf("spin guard cold branches = %d, want 2", got)
+		t.Errorf("spin guard cold branches at max interval = %d, want 2", got)
 	}
-	if got := strings.Count(all, "var __spinGuard uint32"); got != 2 {
-		t.Errorf("__spinGuard declarations = %d, want 2", got)
+	if got := strings.Count(all, "if __spinGuard&2047 == 0 {"); got != 1 {
+		t.Errorf("spin guard cold branches at derived big-body interval = %d, want 1", got)
+	}
+	if got := strings.Count(all, "var __spinGuard uint32"); got != 3 {
+		t.Errorf("__spinGuard declarations = %d, want 3", got)
 	}
 	if !strings.Contains(all, "func spinRelax(") {
 		t.Error("spinRelax helper source not included")
@@ -69,6 +75,7 @@ import (
 
 func main() {
 	m := pkg.New()
+	m.BigSpin(1) // exits on the first check; pins that the guarded big-body loop runs
 	fmt.Println(m.BareSpin(1), m.BareSpin64(1), m.SpinWithCall(1), m.PlainLoop(1))
 }
 `

--- a/internal/codegen/spinguard_test.go
+++ b/internal/codegen/spinguard_test.go
@@ -1,0 +1,76 @@
+package codegen_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// translateSpinguard translates the spinguard fixture and returns the
+// primary source, the concatenation of every emitted file (function
+// bodies land in sidecar files), and the Translate result.
+func translateSpinguard(t *testing.T) (string, string, codegen.Result) {
+	t.Helper()
+	bin := testfixture.Wasm(t, "spinguard.wasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	all := buf.String()
+	for _, data := range res.Files {
+		all += "\n" + string(data)
+	}
+	return buf.String(), all, res
+}
+
+// TestSpinGuardInjection pins where the bare-atomic-spin preemption
+// guard lands: exactly the two bare spin loops (i32 and i64 waits with
+// no call in the body) get a spinRelax call and the counter local; the
+// same wait with a direct call in the body, and a loop spinning on a
+// plain (non-atomic) load, must stay untouched.
+func TestSpinGuardInjection(t *testing.T) {
+	_, all, _ := translateSpinguard(t)
+	if got := strings.Count(all, "spinRelax(&__spinGuard)"); got != 2 {
+		t.Errorf("spinRelax guard sites = %d, want 2 (bare_spin, bare_spin64)", got)
+	}
+	if got := strings.Count(all, "var __spinGuard uint32"); got != 2 {
+		t.Errorf("__spinGuard declarations = %d, want 2", got)
+	}
+	if !strings.Contains(all, "func spinRelax(") {
+		t.Error("spinRelax helper source not included")
+	}
+}
+
+// TestSpinGuardRuns compiles and runs the guarded output: the wait
+// condition fails on the first check (memory is zeroed, the argument is
+// nonzero), so each spin executes its guard once and returns. This is
+// the compile-level assertion that the injected statements are legal Go
+// in both loop shapes.
+func TestSpinGuardRuns(t *testing.T) {
+	src, _, res := translateSpinguard(t)
+	main := `package main
+
+import (
+	"fmt"
+	"gentest/pkg"
+)
+
+func main() {
+	m := pkg.New()
+	fmt.Println(m.BareSpin(1), m.BareSpin64(1), m.SpinWithCall(1), m.PlainLoop(1))
+}
+`
+	got := runGoSnippetNoRace(t, src, main, res.Sidecars, res.Files)
+	if strings.TrimSpace(got) != "0 0 0 0" {
+		t.Errorf("guarded spins: got %q, want \"0 0 0 0\"", got)
+	}
+}

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -3651,6 +3651,19 @@ func (t *translator) emitHelpers() ([]ast.Decl, error) {
 		}
 		out = append(out, fn)
 	}
+	// spinRelax carries package-level state the function-only extraction
+	// above cannot see: emit its Gosched rate-limit counter alongside it.
+	// The name stays unexported even in multi-package mode — only the
+	// helper itself is called cross-package, the counter is base-internal.
+	if t.helpers["spinRelax"] {
+		out = append(out, &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{&ast.ValueSpec{
+				Names: []*ast.Ident{newID("spinRelaxColdCalls")},
+				Type:  newID("uint32"),
+			}},
+		})
+	}
 	// The wasmExc type is not a FuncDecl, so pull it in explicitly whenever the
 	// module throws or catches. In multi-package mode the type lives in base and
 	// must be exported (WasmExc) so chunk packages can name it; single-package

--- a/testdata/spinguard.wat
+++ b/testdata/spinguard.wat
@@ -4,7 +4,10 @@
 ;; shape that must receive a spinRelax guard. `spin_with_call` is the
 ;; same wait but with a direct call in the body (already preemptible —
 ;; no guard), and `plain_loop` spins on a non-atomic load (not a
-;; cross-thread wait — no guard).
+;; cross-thread wait — no guard). `big_spin` is a bare spin whose body
+;; carries dozens of data-dependent values: it must still be guarded,
+;; at a shorter derived interval (the guard budget is time, not
+;; iterations).
 (module
   (memory 1 1 shared)
   ;; $tick recurses on its own (compile-time-unknown) argument, so no
@@ -31,6 +34,13 @@
       (drop (call $tick (i32.atomic.load (i32.const 48))))
       (br_if $w (i32.eq (i32.atomic.load (i32.const 16)) (local.get 0))))
     (i32.atomic.load (i32.const 16)))
+  (func (export "big_spin") (param i32) (result i32)
+    (local i32)
+    (loop $w
+      (local.set 1 (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (i32.add (i32.xor (i32.mul (local.get 1) (i32.const 654435747)) (i32.const 147483637)) (i32.const 723777223)) (i32.const 297842322)) (i32.const 874135908)) (i32.const 300713404)) (i32.const 877006734)) (i32.const 451071065)) (i32.const 18975748)) (i32.const 445557479)) (i32.const 954737977)) (i32.const 528803076)) (i32.const 105096655)) (i32.const 531678126)) (i32.const 107970553)) (i32.const 682031787)) (i32.const 248887926)) (i32.const 677566809)) (i32.const 178021163)) (i32.const 687070589)) (i32.const 261265992)) (i32.const 837493786)) (i32.const 264075474)) (i32.const 831980196)) (i32.const 406041327)) (i32.const 982334913)) (i32.const 408916381)) (i32.const 985208943)) (i32.const 492165306)) (i32.const 68454501)) (i32.const 495036228)) (i32.const 61892367)) (i32.const 638054881)) (i32.const 212250156)) (i32.const 640924687)) (i32.const 215121114)) (i32.const 717541523)) (i32.const 224629086)) (i32.const 792398768)) (i32.const 219111304)))
+      (br_if $w (i32.eq (i32.atomic.load (i32.const 16))
+                        (i32.add (local.get 0) (local.get 1)))))
+    (local.get 1))
   (func (export "plain_loop") (param i32) (result i32)
     (loop $w
       (br_if $w (i32.eq (i32.load (i32.const 16)) (local.get 0))))

--- a/testdata/spinguard.wat
+++ b/testdata/spinguard.wat
@@ -1,0 +1,37 @@
+;; spinguard.wat — loop shapes for the bare-atomic-spin preemption guard
+;; (spinguard.go). `bare_spin` is ggml_barrier's wait: an inline atomic
+;; load compared against an argument, back-branching with no call — the
+;; shape that must receive a spinRelax guard. `spin_with_call` is the
+;; same wait but with a direct call in the body (already preemptible —
+;; no guard), and `plain_loop` spins on a non-atomic load (not a
+;; cross-thread wait — no guard).
+(module
+  (memory 1 1 shared)
+  ;; $tick recurses on its own (compile-time-unknown) argument, so no
+  ;; amount of inlining or constant folding removes the recursive call —
+  ;; the spin_with_call loop keeps a genuine OpCallDirect, which its
+  ;; no-guard expectation needs. (A constant or straight-line callee
+  ;; gets inlined away, correctly turning the caller into a bare spin —
+  ;; the guard analysis runs on the final, post-inline code.) At runtime
+  ;; the argument is a zeroed memory word, so the recursion never fires.
+  (func $tick (param i32) (result i32)
+    (if (result i32) (local.get 0)
+      (then (call $tick (local.get 0)))
+      (else (i32.const 1))))
+  (func (export "bare_spin") (param i32) (result i32)
+    (loop $w
+      (br_if $w (i32.eq (i32.atomic.load (i32.const 16)) (local.get 0))))
+    (i32.atomic.load (i32.const 16)))
+  (func (export "bare_spin64") (param i64) (result i64)
+    (loop $w
+      (br_if $w (i64.eq (i64.atomic.load (i32.const 24)) (local.get 0))))
+    (i64.atomic.load (i32.const 24)))
+  (func (export "spin_with_call") (param i32) (result i32)
+    (loop $w
+      (drop (call $tick (i32.atomic.load (i32.const 48))))
+      (br_if $w (i32.eq (i32.atomic.load (i32.const 16)) (local.get 0))))
+    (i32.atomic.load (i32.const 16)))
+  (func (export "plain_loop") (param i32) (result i32)
+    (loop $w
+      (br_if $w (i32.eq (i32.load (i32.const 16)) (local.get 0))))
+    (i32.load (i32.const 16))))


### PR DESCRIPTION
## Problem

A loop that waits on an inline atomic load and makes no call — the shape `ggml_barrier` compiles to — is legal, preemptible Go after emission, but the gcasm bundler captures the compiled function into a `.s` TEXT and the Go runtime refuses to async-preempt assembly functions. A goroutine spinning inside the captured loop blocks every stop-the-world: when the store it waits for comes from a goroutine the GC already parked, the process livelocks with all cores burning. Observed in production against llama.cpp's `ggml_barrier` as intermittent multi-minute stalls (GC-timing dependent). Until now every wasm guest had to patch its own spin sites (llama-wasm's sched-yield patch — which a stale build cache then silently dropped from a release, goccy/llama-wasm#10); this makes the generated code correct by construction, for every guest.

## Change

A new emission-time analysis (`spinguard.go`) runs on the final post-inline SSA and finds natural loops whose body performs an inline atomic load and contains no surviving call. Both block emitters prepend to such a loop's header:

```go
__spinGuard++
if __spinGuard&<mask> == 0 { spinRelax() }
```

- The hot path is an increment and a not-taken branch.
- The cold call is the fix: `spinRelax` is `//go:noinline`, so the call survives to machine code and its prologue's stack check is a preemption point regardless of how the function is lowered.
- **The interval is a time budget, not an iteration count.** `<mask>` is derived per loop from the body's size (interval × body values ≈ 2^18, power of two, clamped to [2^8, 2^14]), so the stop-the-world arrival bound stays in the tens-to-low-hundreds of microseconds whether the guest spins on a 4-instruction barrier or an interpreter-style loop carrying hundreds of values per iteration. Nothing about the policy is application-tunable: the only knobs are the transpiler's latency budget and a Gosched rate, each defined once with a single meaning.
- `spinRelax` gates `runtime.Gosched` behind a global 1-in-64 counter, so core donation is proportional to aggregate spin time: rare on an uncontended box, automatically more frequent when oversubscription makes spins long.

Helper calls do not count as preemption points in the analysis (small pure helpers routinely inline away), and the analysis running post-inline means a callee the translator folds into the loop cannot mask a spin — the fixtures pin both, plus the big-body interval derivation.

## Why this exact shape (measured on llama.wasm, qwen2.5-0.5b q8_0, n_threads=8, 16-token decode)

| variant | 8-ctx per-call | note |
|---|---|---|
| no guard (baseline transpile) | 117–119ms | **livelocks under GC pressure** |
| call+Gosched every iteration | 165–180ms (+40%) | 8 workers on `sched.lock`: `usleep` 38% + `cond_signal` 23% of profile |
| inline counter, Gosched on every cold call | 130–132ms (+10%) | `cond_signal` still 30% — waiting is most of a worker's time |
| **inline counter + derived interval + 1/64-gated Gosched (this PR)** | **116–121ms — parity** | |

Livelock A/B on the same input (v0.2.4 `llama.wasm`, which has bare spins): the unguarded bundle wedges **forever** at 700% CPU under a `runtime.GC()` hammer — an in-process watchdog cannot even fire, since the STW freeze stops the timer goroutine too — while the guarded bundle completes in ~350–800ms. Artifact checks: `.s` sizes and TEXT counts are unchanged (no fusion/window loss); the `spinRelax` call is present in the captured `arm64.s`/`amd64.s`; all 56 guarded ggml loops derive the maximum interval (their bodies are small), so the measured-parity configuration is exactly what ships. go-llama's full suite (root + internal, `GOAMD64=v2` and native arm64) passes against the guarded bundle.

## Follow-up (separate repos)

After this releases and the wasmify image picks it up, llama-wasm can drop `patches/wasm-spin-sched-yield.patch` entirely and update its `verify-patches` registry — the invariant moves into the transpiler, where it holds for every guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)