### PR TITLE
WASI runtime: fd-priority poll, spawn cwd, dup sharing, chmod/stat-mode imports

### DIFF
--- a/internal/codegen/proc_spawn_test.go
+++ b/internal/codegen/proc_spawn_test.go
@@ -45,7 +45,7 @@ func TestWasi_ProcSpawnWait(t *testing.T) {
 	argvOff := writeArgv(m, 2000, 3000, []string{"/bin/echo", "hello-proc"})
 	const pidOff, statusOff int32 = 4000, 4004
 
-	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, pidOff); rc != _wasiESUCCESS {
+	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 0, pidOff); rc != _wasiESUCCESS {
 		t.Fatalf("Proc_spawn rc=%d", rc)
 	}
 	pid := int32(binary.LittleEndian.Uint32(m.memory[pidOff:]))
@@ -75,7 +75,7 @@ func TestWasi_ProcSpawnExitCode(t *testing.T) {
 	argvOff := writeArgv(m, 2000, 3000, []string{"/bin/sh", "-c", "exit 7"})
 	const pidOff, statusOff int32 = 4000, 4004
 
-	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, pidOff); rc != _wasiESUCCESS {
+	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 0, pidOff); rc != _wasiESUCCESS {
 		t.Fatalf("Proc_spawn rc=%d", rc)
 	}
 	pid := int32(binary.LittleEndian.Uint32(m.memory[pidOff:]))
@@ -96,7 +96,7 @@ func TestWasi_ProcSpawnExecHookDenies(t *testing.T) {
 
 	pathOff := writeCStr(m, 1000, "/bin/echo")
 	argvOff := writeArgv(m, 2000, 3000, []string{"/bin/echo", "x"})
-	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 4000); rc != -_wasiEACCES {
+	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 0, 4000); rc != -_wasiEACCES {
 		t.Fatalf("denied spawn rc=%d, want -EACCES", rc)
 	}
 	if seen != "/bin/echo" {
@@ -109,7 +109,7 @@ func TestWasi_ProcSpawnNotFound(t *testing.T) {
 	w.stdout, w.stderr, w.stdin = &bytes.Buffer{}, &bytes.Buffer{}, bytes.NewReader(nil)
 	pathOff := writeCStr(m, 1000, "/no/such/binary-xyz")
 	argvOff := writeArgv(m, 2000, 3000, []string{"/no/such/binary-xyz"})
-	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 4000); rc != -_wasiENOENT {
+	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 0, 4000); rc != -_wasiENOENT {
 		t.Fatalf("missing binary rc=%d, want -ENOENT", rc)
 	}
 }
@@ -130,7 +130,7 @@ func TestWasi_ProcWaitWNOHANG(t *testing.T) {
 	pathOff := writeCStr(m, 1000, "/bin/sh")
 	argvOff := writeArgv(m, 2000, 3000, []string{"/bin/sh", "-c", "sleep 0.3; exit 3"})
 	const pidOff, statusOff int32 = 4000, 4004
-	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, pidOff); rc != _wasiESUCCESS {
+	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, -1, -1, 0, pidOff); rc != _wasiESUCCESS {
 		t.Fatalf("spawn rc=%d", rc)
 	}
 	pid := int32(binary.LittleEndian.Uint32(m.memory[pidOff:]))
@@ -176,7 +176,7 @@ func TestWasi_PipeCapture(t *testing.T) {
 	pathOff := writeCStr(m, 1000, "/bin/echo")
 	argvOff := writeArgv(m, 2000, 3000, []string{"/bin/echo", "captured-output"})
 	const pidOff, statusOff int32 = 4000, 4004
-	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, writeFd, -1, pidOff); rc != _wasiESUCCESS {
+	if rc := w.Proc_spawn(m, pathOff, argvOff, 0, -1, writeFd, -1, 0, pidOff); rc != _wasiESUCCESS {
 		t.Fatalf("Proc_spawn rc=%d", rc)
 	}
 	pid := int32(binary.LittleEndian.Uint32(m.memory[pidOff:]))

--- a/internal/codegen/wasip1_fdio_test.go
+++ b/internal/codegen/wasip1_fdio_test.go
@@ -1,0 +1,333 @@
+package codegen
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeSubClock encodes a poll_oneoff clock subscription (relative
+// timeout in ns) at off.
+func writeSubClock(m *Module, off int32, userdata uint64, ns int64) {
+	for i := int32(0); i < 48; i++ {
+		m.memory[off+i] = 0
+	}
+	binary.LittleEndian.PutUint64(m.memory[off:], userdata)
+	m.memory[off+8] = 0 // clock
+	binary.LittleEndian.PutUint64(m.memory[off+24:], uint64(ns))
+}
+
+// writeSubFd encodes a poll_oneoff fd_read/fd_write subscription at off.
+func writeSubFd(m *Module, off int32, userdata uint64, etype byte, fd int32) {
+	for i := int32(0); i < 48; i++ {
+		m.memory[off+i] = 0
+	}
+	binary.LittleEndian.PutUint64(m.memory[off:], userdata)
+	m.memory[off+8] = etype
+	binary.LittleEndian.PutUint32(m.memory[off+16:], uint32(fd))
+}
+
+func TestWasi_FdDupSharesOffsetAndDefersClose(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("abcdef"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, m := newTestStubs(t, dir)
+
+	fd, errno := w.pathOpen("f.txt", 0, 0, 1<<1 /* FD_READ */, 0)
+	if errno != _wasiESUCCESS {
+		t.Fatalf("pathOpen errno=%d", errno)
+	}
+	const outOff int32 = 100
+	if rc := w.Fd_dup(m, fd, outOff); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup rc=%d", rc)
+	}
+	dup := int32(binary.LittleEndian.Uint32(m.memory[outOff:]))
+	if dup == fd {
+		t.Fatalf("dup fd = original fd %d", fd)
+	}
+
+	// The two fds share one open descriptor: reads advance a single offset.
+	readByte := func(via int32) byte {
+		iovOff, bufOff, nOff := int32(200), int32(300), int32(400)
+		binary.LittleEndian.PutUint32(m.memory[iovOff:], uint32(bufOff))
+		binary.LittleEndian.PutUint32(m.memory[iovOff+4:], 1)
+		if rc := w.Fd_read(m, via, iovOff, 1, nOff); rc != _wasiESUCCESS {
+			t.Fatalf("Fd_read(%d) rc=%d", via, rc)
+		}
+		if n := binary.LittleEndian.Uint32(m.memory[nOff:]); n != 1 {
+			t.Fatalf("read %d bytes, want 1", n)
+		}
+		return m.memory[bufOff]
+	}
+	if got := readByte(fd); got != 'a' {
+		t.Fatalf("first read = %q, want 'a'", got)
+	}
+	if got := readByte(dup); got != 'b' {
+		t.Fatalf("read via dup = %q, want 'b' (shared offset)", got)
+	}
+
+	// Closing one reference keeps the descriptor open for the other.
+	if rc := w.Fd_close(m, fd); rc != _wasiESUCCESS {
+		t.Fatalf("close original rc=%d", rc)
+	}
+	if got := readByte(dup); got != 'c' {
+		t.Fatalf("read after closing one ref = %q, want 'c'", got)
+	}
+	if rc := w.Fd_close(m, dup); rc != _wasiESUCCESS {
+		t.Fatalf("close dup rc=%d", rc)
+	}
+	if rc := w.Fd_close(m, dup); rc != _wasiEBADF {
+		t.Fatalf("double close rc=%d, want EBADF", rc)
+	}
+}
+
+func TestWasi_FdDup2RedirectsAndRestoresStdio(t *testing.T) {
+	dir := t.TempDir()
+	w, m := newTestStubs(t, dir)
+	var out bytes.Buffer
+	w.stdout = &out
+
+	// Save fd 1 (an alias entry: closing it must not close the stream).
+	const savedOff int32 = 100
+	if rc := w.Fd_dup(m, 1, savedOff); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup(1) rc=%d", rc)
+	}
+	saved := int32(binary.LittleEndian.Uint32(m.memory[savedOff:]))
+
+	// Point fd 1 at a real file.
+	logFd, errno := w.pathOpen("log.txt", 0, 0x1 /* O_CREAT */, 1<<6 /* FD_WRITE */, 0)
+	if errno != _wasiESUCCESS {
+		t.Fatalf("pathOpen errno=%d", errno)
+	}
+	if rc := w.Fd_dup2(m, logFd, 1); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup2(log, 1) rc=%d", rc)
+	}
+
+	writeVia1 := func(s string) {
+		iovOff, bufOff, nOff := int32(200), int32(300), int32(400)
+		copy(m.memory[bufOff:], s)
+		binary.LittleEndian.PutUint32(m.memory[iovOff:], uint32(bufOff))
+		binary.LittleEndian.PutUint32(m.memory[iovOff+4:], uint32(len(s)))
+		if rc := w.Fd_write(m, 1, iovOff, 1, nOff); rc != _wasiESUCCESS {
+			t.Fatalf("Fd_write rc=%d", rc)
+		}
+	}
+	writeVia1("to-file")
+
+	// While redirected, a spawned child's stdout resolves to the file too.
+	w.mu.Lock()
+	cw := w.childWriterLocked(1, w.stdout)
+	w.mu.Unlock()
+	if _, isBuf := cw.(*bytes.Buffer); isBuf {
+		t.Fatal("childWriterLocked(1) ignored the redirection")
+	}
+
+	// Restore and close the saved alias; the stream must still work.
+	if rc := w.Fd_dup2(m, saved, 1); rc != _wasiESUCCESS {
+		t.Fatalf("restore rc=%d", rc)
+	}
+	if rc := w.Fd_close(m, saved); rc != _wasiESUCCESS {
+		t.Fatalf("close saved rc=%d", rc)
+	}
+	writeVia1("to-stream")
+
+	if got, err := os.ReadFile(filepath.Join(dir, "log.txt")); err != nil || string(got) != "to-file" {
+		t.Fatalf("log.txt = %q, %v; want %q", got, err, "to-file")
+	}
+	if out.String() != "to-stream" {
+		t.Fatalf("stdout = %q, want %q", out.String(), "to-stream")
+	}
+	if rc := w.Fd_dup2(m, 99, 1); rc != _wasiEBADF {
+		t.Fatalf("Fd_dup2 from bad fd rc=%d, want EBADF", rc)
+	}
+}
+
+func TestWasi_PathChmodAndFilestatMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, m := newTestStubs(t, dir)
+
+	pathOff := writeCStr(m, 1000, "f.txt")
+	if rc := w.Path_chmod(m, pathOff, 5, 0o460); rc != _wasiESUCCESS {
+		t.Fatalf("Path_chmod rc=%d", rc)
+	}
+	fi, err := os.Stat(filepath.Join(dir, "f.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o460 {
+		t.Fatalf("perm = %o, want 460", perm)
+	}
+
+	const modeOff int32 = 2000
+	if rc := w.Path_filestat_mode(m, pathOff, 5, 1, modeOff); rc != _wasiESUCCESS {
+		t.Fatalf("Path_filestat_mode rc=%d", rc)
+	}
+	if mode := binary.LittleEndian.Uint32(m.memory[modeOff:]); mode != 0o460 {
+		t.Fatalf("reported mode = %o, want 460", mode)
+	}
+
+	missOff := writeCStr(m, 3000, "missing")
+	if rc := w.Path_filestat_mode(m, missOff, 7, 1, modeOff); rc >= 0 {
+		t.Fatalf("stat of missing file rc=%d, want negative errno", rc)
+	}
+
+	// A backend without Chmod support reports ENOSYS.
+	w.fsys = NewMemFS()
+	if rc := w.Path_chmod(m, pathOff, 5, 0o600); rc != -_wasiENOSYS {
+		t.Fatalf("MemFS Path_chmod rc=%d, want -ENOSYS", rc)
+	}
+}
+
+func TestWasi_PollFdSubscriptionsPreemptTimeout(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, m := newTestStubs(t, dir)
+	fd, errno := w.pathOpen("f.txt", 0, 0, 1<<1, 0)
+	if errno != _wasiESUCCESS {
+		t.Fatalf("pathOpen errno=%d", errno)
+	}
+
+	const subsOff, evOff, nevOff int32 = 1000, 2000, 3000
+	// A one-second timeout plus a readable fd must return immediately
+	// with only the fd event.
+	writeSubClock(m, subsOff, 7, int64(time.Second))
+	writeSubFd(m, subsOff+48, 8, 1 /* fd_read */, fd)
+	start := time.Now()
+	if rc := w.Poll_oneoff(m, subsOff, evOff, 2, nevOff); rc != _wasiESUCCESS {
+		t.Fatalf("Poll_oneoff rc=%d", rc)
+	}
+	if d := time.Since(start); d > 500*time.Millisecond {
+		t.Fatalf("poll with ready fd slept %v", d)
+	}
+	if nev := binary.LittleEndian.Uint32(m.memory[nevOff:]); nev != 1 {
+		t.Fatalf("nevents = %d, want 1 (fd only)", nev)
+	}
+	if ud := binary.LittleEndian.Uint64(m.memory[evOff:]); ud != 8 {
+		t.Fatalf("event userdata = %d, want the fd subscription's 8", ud)
+	}
+
+	// A clock-only subscription paces the call and reports the timeout.
+	writeSubClock(m, subsOff, 9, int64(20*time.Millisecond))
+	start = time.Now()
+	if rc := w.Poll_oneoff(m, subsOff, evOff, 1, nevOff); rc != _wasiESUCCESS {
+		t.Fatalf("clock-only Poll_oneoff rc=%d", rc)
+	}
+	if d := time.Since(start); d < 15*time.Millisecond {
+		t.Fatalf("clock-only poll returned after %v, want ~20ms", d)
+	}
+	if nev := binary.LittleEndian.Uint32(m.memory[nevOff:]); nev != 1 {
+		t.Fatalf("clock nevents = %d, want 1", nev)
+	}
+	if ud := binary.LittleEndian.Uint64(m.memory[evOff:]); ud != 9 {
+		t.Fatalf("clock event userdata = %d, want 9", ud)
+	}
+}
+
+func TestWasi_FdDupEdgeCases(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("abc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, m := newTestStubs(t, dir)
+
+	if rc := w.Fd_dup(m, 99, 100); rc != _wasiEBADF {
+		t.Fatalf("Fd_dup(bad) rc=%d, want EBADF", rc)
+	}
+	fd, errno := w.pathOpen("f.txt", 0, 0, 1<<1, 0)
+	if errno != _wasiESUCCESS {
+		t.Fatalf("pathOpen errno=%d", errno)
+	}
+	if rc := w.Fd_dup2(m, fd, fd); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup2(fd, fd) rc=%d", rc)
+	}
+	// dup2 where the destination already references the same entry.
+	if rc := w.Fd_dup2(m, fd, fd+50); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup2 rc=%d", rc)
+	}
+	if rc := w.Fd_dup2(m, fd, fd+50); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup2 onto same entry rc=%d", rc)
+	}
+
+	// Reads through a descriptor dup2'd onto fd 0 come from the file,
+	// and childReaderLocked follows the same redirection.
+	if rc := w.Fd_dup2(m, fd, 0); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup2 onto 0 rc=%d", rc)
+	}
+	iovOff, bufOff, nOff := int32(200), int32(300), int32(400)
+	binary.LittleEndian.PutUint32(m.memory[iovOff:], uint32(bufOff))
+	binary.LittleEndian.PutUint32(m.memory[iovOff+4:], 3)
+	if rc := w.Fd_read(m, 0, iovOff, 1, nOff); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_read(0) rc=%d", rc)
+	}
+	if got := string(m.memory[bufOff : bufOff+3]); got != "abc" {
+		t.Fatalf("read via redirected fd 0 = %q", got)
+	}
+	w.mu.Lock()
+	cr := w.childReaderLocked(0)
+	crDefault := w.childReaderLocked(-1)
+	w.mu.Unlock()
+	if cr == w.stdin {
+		t.Fatal("childReaderLocked(0) ignored the redirection")
+	}
+	if crDefault != w.stdin {
+		t.Fatal("childReaderLocked(-1) should be the interpreter stdin")
+	}
+
+	// An alias of stderr placed on another fd writes to the stream.
+	var errBuf bytes.Buffer
+	w.stderr = &errBuf
+	const outOff int32 = 500
+	if rc := w.Fd_dup(m, 2, outOff); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_dup(2) rc=%d", rc)
+	}
+	alias := int32(binary.LittleEndian.Uint32(m.memory[outOff:]))
+	copy(m.memory[bufOff:], "E")
+	binary.LittleEndian.PutUint32(m.memory[iovOff+4:], 1)
+	if rc := w.Fd_write(m, alias, iovOff, 1, nOff); rc != _wasiESUCCESS {
+		t.Fatalf("Fd_write(alias) rc=%d", rc)
+	}
+	if errBuf.String() != "E" {
+		t.Fatalf("stderr alias wrote %q", errBuf.String())
+	}
+
+	// lstat flavor of the mode import.
+	pathOff := writeCStr(m, 1000, "f.txt")
+	const modeOff int32 = 1100
+	if rc := w.Path_filestat_mode(m, pathOff, 5, 0, modeOff); rc != _wasiESUCCESS {
+		t.Fatalf("Path_filestat_mode(lstat) rc=%d", rc)
+	}
+	if mode := binary.LittleEndian.Uint32(m.memory[modeOff:]); mode != 0o644 {
+		t.Fatalf("lstat mode = %o, want 644", mode)
+	}
+}
+
+func TestWasi_SockGetaddrinfoNumericAndHook(t *testing.T) {
+	w, m := newTestStubs(t, t.TempDir())
+	const outOff int32 = 100
+
+	hostOff := writeCStr(m, 1000, "1.2.3.4")
+	if rc := w.Sock_getaddrinfo(m, hostOff, 7, outOff); rc != _wasiESUCCESS {
+		t.Fatalf("numeric getaddrinfo rc=%d", rc)
+	}
+	if got := m.memory[outOff : outOff+4]; got[0] != 1 || got[1] != 2 || got[2] != 3 || got[3] != 4 {
+		t.Fatalf("resolved bytes = %v", got)
+	}
+
+	if rc := w.Sock_getaddrinfo(m, hostOff, 0, outOff); rc != _wasiESUCCESS {
+		t.Fatalf("empty-host getaddrinfo rc=%d", rc)
+	}
+
+	w.SetResolveHook(func(host string) bool { return false })
+	if rc := w.Sock_getaddrinfo(m, hostOff, 7, outOff); rc != -_wasiEACCES {
+		t.Fatalf("denied getaddrinfo rc=%d, want -EACCES", rc)
+	}
+}

--- a/internal/codegen/wasip1_native.go
+++ b/internal/codegen/wasip1_native.go
@@ -2012,7 +2012,9 @@ func (w *WasiStubs) Path_chmod(m *Module, pathPtr, pathLen, mode int32) int32 {
 	w.mu.Lock()
 	fsys := w.fsys
 	w.mu.Unlock()
-	ch, ok := fsys.(interface{ Chmod(string, os.FileMode) error })
+	ch, ok := fsys.(interface {
+		Chmod(string, os.FileMode) error
+	})
 	if !ok {
 		return -_wasiENOSYS
 	}

--- a/internal/codegen/wasip1_native.go
+++ b/internal/codegen/wasip1_native.go
@@ -163,6 +163,7 @@ func (o osFS) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
 	return f, nil
 }
 func (o osFS) Mkdir(name string, perm os.FileMode) error { return os.Mkdir(o.join(name), perm) }
+func (o osFS) Chmod(name string, mode os.FileMode) error { return os.Chmod(o.join(name), mode) }
 func (o osFS) Remove(name string) error                  { return os.Remove(o.join(name)) }
 func (o osFS) Rename(a, b string) error                  { return os.Rename(o.join(a), o.join(b)) }
 func (o osFS) Stat(name string) (os.FileInfo, error)     { return os.Stat(o.join(name)) }
@@ -576,6 +577,13 @@ type wasiOpen struct {
 	path     string // guest path relative to the preopen root
 	fdflags  int32  // last fdflags set via Path_open or Fd_fdstat_set_flags
 	dirCache []os.DirEntry
+	// stdio marks an alias of an interpreter stream (1/2/3 = the
+	// configured stdin/stdout/stderr; 0 = not an alias). Fd_dup of a bare
+	// fd 0/1/2 creates one; closing it never touches the real stream.
+	stdio int8
+	// refs counts EXTRA table slots sharing this entry (dup/dup2):
+	// closeWasiOpen only closes the descriptor when it reaches zero.
+	refs int32
 }
 
 // WasiStubs is the default Go-native implementation of wasi_snapshot_preview1.
@@ -821,7 +829,7 @@ func (w *WasiStubs) readCStrArray(m *Module, ptr int32) (out []string, ok bool) 
 // Only stdio inheritance is supported today (no fd remapping / pipes), which
 // covers subprocess.run/call with default streams; capture_output via host
 // pipes is a follow-up.
-func (w *WasiStubs) Proc_spawn(m *Module, pathPtr, argvPtr, envpPtr, stdinFd, stdoutFd, stderrFd, pidOutPtr int32) int32 {
+func (w *WasiStubs) Proc_spawn(m *Module, pathPtr, argvPtr, envpPtr, stdinFd, stdoutFd, stderrFd, cwdPtr, pidOutPtr int32) int32 {
 	path, ok := w.readCStr(m, pathPtr)
 	if !ok || path == "" {
 		return -_wasiEINVAL
@@ -831,6 +839,13 @@ func (w *WasiStubs) Proc_spawn(m *Module, pathPtr, argvPtr, envpPtr, stdinFd, st
 		return -_wasiEFAULT
 	}
 	env, ok := w.readCStrArray(m, envpPtr)
+	if !ok {
+		return -_wasiEFAULT
+	}
+	// The guest's working directory lives in its libc (WASI has no chdir
+	// syscall), so the bridge passes it explicitly; the child must start
+	// there, not in the host process's cwd.
+	cwd, ok := w.readCStr(m, cwdPtr)
 	if !ok {
 		return -_wasiEFAULT
 	}
@@ -854,6 +869,9 @@ func (w *WasiStubs) Proc_spawn(m *Module, pathPtr, argvPtr, envpPtr, stdinFd, st
 		cmd.Args = argv
 	} else {
 		cmd.Args = []string{path}
+	}
+	if cwd != "" {
+		cmd.Dir = cwd
 	}
 	// Sandbox: the child sees ONLY the guest-provided environment; a nil
 	// (NULL envp) must NOT fall through to the host process environment.
@@ -900,26 +918,26 @@ func (w *WasiStubs) Proc_spawn(m *Module, pathPtr, argvPtr, envpPtr, stdinFd, st
 	return _wasiESUCCESS
 }
 
-// childReaderLocked resolves a child stdin source fd. fd < 3 (including -1)
-// inherits the interpreter's stdin; otherwise it is a guest fd (a pipe read
-// end) whose backing file is used directly. Caller holds w.mu.
+// childReaderLocked resolves a child stdin source fd. A guest fd whose
+// table entry carries a real file (a pipe end, or a guest stdio fd the
+// program re-opened onto a file) is used directly; everything else —
+// including -1 and an unredirected fd 0 — inherits the interpreter's
+// stdin. Caller holds w.mu.
 func (w *WasiStubs) childReaderLocked(fd int32) io.Reader {
-	if fd < 3 {
-		return w.stdin
-	}
-	if op := w.fdTable[fd]; op != nil && op.f != nil {
-		return op.f
+	if fd >= 0 {
+		if op := w.fdTable[fd]; op != nil && op.f != nil {
+			return op.f
+		}
 	}
 	return w.stdin
 }
 
 // childWriterLocked is the stdout/stderr counterpart of childReaderLocked.
 func (w *WasiStubs) childWriterLocked(fd int32, deflt io.Writer) io.Writer {
-	if fd < 3 {
-		return deflt
-	}
-	if op := w.fdTable[fd]; op != nil && op.f != nil {
-		return op.f
+	if fd >= 0 {
+		if op := w.fdTable[fd]; op != nil && op.f != nil {
+			return op.f
+		}
 	}
 	return deflt
 }
@@ -1195,6 +1213,7 @@ const (
 	_wasiENOTDIR      int32 = 54
 	_wasiENOTSOCK     int32 = 57
 	_wasiENOTSUP      int32 = 58
+	_wasiENOSYS       int32 = 52
 	_wasiEPERM        int32 = 63
 	_wasiEPIPE        int32 = 64
 )
@@ -1393,6 +1412,11 @@ func (w *WasiStubs) clockNanos(clockID int32) (uint64, int32) {
 // joins any Close errors so callers can map them to a wasi errno
 // instead of silently dropping the failure.
 func closeWasiOpen(op *wasiOpen) error {
+	if op.refs > 0 {
+		// another table slot still references this descriptor (dup/dup2)
+		op.refs--
+		return nil
+	}
 	var err error
 	if op.f != nil {
 		err = errors.Join(err, op.f.Close())
@@ -1728,13 +1752,18 @@ func writeVec(dst io.Writer, bufs [][]byte) uint64 {
 // fdSrcLocked returns the io.Reader for fd and (when applicable) the
 // wasiOpen it came from, or nil if fd is invalid. Caller must hold w.mu.
 func (w *WasiStubs) fdSrcLocked(fd int32) (io.Reader, *wasiOpen) {
-	switch fd {
-	case 0:
-		return w.stdin, nil
-	}
+	// Table entries win over the stdio defaults: a program that dup2'd
+	// another descriptor onto fd 0 reads from THAT, like after a real
+	// dup2. A bare fd 0 (no entry) is the interpreter's stdin.
 	op := w.fdTable[fd]
 	if op == nil {
+		if fd == 0 {
+			return w.stdin, nil
+		}
 		return nil, nil
+	}
+	if op.stdio == 1 {
+		return w.stdin, op
 	}
 	if op.f != nil {
 		return op.f, op
@@ -1748,15 +1777,21 @@ func (w *WasiStubs) fdSrcLocked(fd int32) (io.Reader, *wasiOpen) {
 // fdDstLocked returns the io.Writer for fd or nil if fd is invalid.
 // Caller must hold w.mu.
 func (w *WasiStubs) fdDstLocked(fd int32) (io.Writer, *wasiOpen) {
-	switch fd {
-	case 1:
-		return w.stdout, nil
-	case 2:
-		return w.stderr, nil
-	}
 	op := w.fdTable[fd]
 	if op == nil {
+		switch fd {
+		case 1:
+			return w.stdout, nil
+		case 2:
+			return w.stderr, nil
+		}
 		return nil, nil
+	}
+	switch op.stdio {
+	case 2:
+		return w.stdout, op
+	case 3:
+		return w.stderr, op
 	}
 	if op.f != nil {
 		return op.f, op
@@ -1960,6 +1995,135 @@ func (w *WasiStubs) Fd_allocate(m *Module, fd int32, offset, length int64) int32
 	// to offset+length so the file is at least the requested size.
 	if err := op.f.Truncate(offset + length); err != nil {
 		return mapOSError(err)
+	}
+	return _wasiESUCCESS
+}
+
+// Path_chmod is a NON-STANDARD host import (module wasi_snapshot_preview1,
+// name "path_chmod") backing a bridge-provided chmod(): WASI preview1 has
+// no way to change file modes. The path at (pathPtr,pathLen) is
+// preopen-relative, like path_open's. Backends without chmod support
+// (MemFS keeps no modes) report ENOSYS. Returns 0 or a negative errno.
+func (w *WasiStubs) Path_chmod(m *Module, pathPtr, pathLen, mode int32) int32 {
+	pathSlice := w.memSlice(m, pathPtr, pathLen)
+	if pathSlice == nil {
+		return -_wasiEFAULT
+	}
+	w.mu.Lock()
+	fsys := w.fsys
+	w.mu.Unlock()
+	ch, ok := fsys.(interface{ Chmod(string, os.FileMode) error })
+	if !ok {
+		return -_wasiENOSYS
+	}
+	if err := ch.Chmod(string(pathSlice), os.FileMode(uint32(mode)&0o7777)); err != nil {
+		return -mapOSError(err)
+	}
+	return _wasiESUCCESS
+}
+
+// Path_filestat_mode is a NON-STANDARD host import (module
+// wasi_snapshot_preview1, name "path_filestat_mode") backing a
+// bridge-provided stat/lstat: WASI's filestat carries no permission
+// bits, so the bridge merges the real mode in from here. The path is
+// preopen-relative; follow selects stat vs lstat semantics. Writes the
+// unix permission bits at modeOutPtr; returns 0 or a negative errno.
+func (w *WasiStubs) Path_filestat_mode(m *Module, pathPtr, pathLen, follow, modeOutPtr int32) int32 {
+	pathSlice := w.memSlice(m, pathPtr, pathLen)
+	out := w.memSlice(m, modeOutPtr, 4)
+	if pathSlice == nil || out == nil {
+		return -_wasiEFAULT
+	}
+	w.mu.Lock()
+	fsys := w.fsys
+	w.mu.Unlock()
+	var fi os.FileInfo
+	var err error
+	if follow != 0 {
+		fi, err = fsys.Stat(string(pathSlice))
+	} else {
+		fi, err = fsys.Lstat(string(pathSlice))
+	}
+	if err != nil {
+		return -mapOSError(err)
+	}
+	mode := fi.Mode()
+	bits := uint32(mode.Perm())
+	if mode&os.ModeSetuid != 0 {
+		bits |= 0o4000
+	}
+	if mode&os.ModeSetgid != 0 {
+		bits |= 0o2000
+	}
+	if mode&os.ModeSticky != 0 {
+		bits |= 0o1000
+	}
+	binary.LittleEndian.PutUint32(out, bits)
+	return _wasiESUCCESS
+}
+
+// dupSourceLocked resolves the entry a dup of fd should share: the
+// existing table entry, or a fresh alias for a bare interpreter stdio fd.
+// Caller holds w.mu.
+func (w *WasiStubs) dupSourceLocked(fd int32) *wasiOpen {
+	if op := w.fdTable[fd]; op != nil {
+		return op
+	}
+	if fd >= 0 && fd <= 2 {
+		op := &wasiOpen{stdio: int8(fd + 1)}
+		w.fdTable[fd] = op
+		return op
+	}
+	return nil
+}
+
+// Fd_dup is a NON-STANDARD host import (module wasi_snapshot_preview1,
+// name "fd_dup") backing the bridge's dup(): the new fd shares the same
+// open descriptor (offset included), and the underlying file closes only
+// when the last sharing fd does. Writes the new fd at outPtr.
+func (w *WasiStubs) Fd_dup(m *Module, fd, outPtr int32) int32 {
+	out := w.memSlice(m, outPtr, 4)
+	if out == nil {
+		return _wasiEFAULT
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	op := w.dupSourceLocked(fd)
+	if op == nil {
+		return _wasiEBADF
+	}
+	nfd := w.nextFD
+	w.nextFD++
+	w.fdTable[nfd] = op
+	op.refs++
+	binary.LittleEndian.PutUint32(out, uint32(nfd))
+	return _wasiESUCCESS
+}
+
+// Fd_dup2 is a NON-STANDARD host import (module wasi_snapshot_preview1,
+// name "fd_dup2") backing the bridge's dup2(): to becomes another
+// reference to from's descriptor, closing whatever to previously held.
+func (w *WasiStubs) Fd_dup2(m *Module, from, to int32) int32 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	src := w.dupSourceLocked(from)
+	if src == nil {
+		return _wasiEBADF
+	}
+	if from == to {
+		return _wasiESUCCESS
+	}
+	var closeErr error
+	if dst := w.fdTable[to]; dst != nil {
+		if dst == src {
+			return _wasiESUCCESS
+		}
+		closeErr = closeWasiOpen(dst)
+	}
+	w.fdTable[to] = src
+	src.refs++
+	if closeErr != nil {
+		return mapOSError(closeErr)
 	}
 	return _wasiESUCCESS
 }
@@ -2581,15 +2745,22 @@ func (w *WasiStubs) Poll_oneoff(m *Module, inPtr, outPtr, nsubs, neventsPtr int3
 		}
 	}
 
-	// Sleep for the shortest clock subscription. fd events are polled
-	// best-effort with that as the deadline (or no wait if there is no
-	// clock).
-	if minClockNs > 0 {
+	// fd subscriptions report their (optimistic) readiness immediately, so
+	// when any are present the clock subscription must NOT be slept first —
+	// that would turn every select/poll carrying a timeout into a wait for
+	// the full timeout. The clock paces the call only when it is the sole
+	// kind of subscription, and its "timeout fired" event is suppressed
+	// while ready fds are being reported (a real poll returns ready fds
+	// without also claiming the timeout expired).
+	if minClockNs > 0 && len(fdEvents) == 0 {
 		time.Sleep(time.Duration(minClockNs))
 	}
 
 	written := int32(0)
 	for _, ev := range clockEvents {
+		if ev.etype == 0 && len(fdEvents) > 0 {
+			continue
+		}
 		writeEvent(events[written:written+32], ev.userdata, ev.etype, 0, 0)
 		written += 32
 	}


### PR DESCRIPTION
## Summary

Host-side WASI runtime additions that let a transpiled perl drive the CPAN build toolchain (cpanm, ExtUtils::MakeMaker, Module::Build):

- **Poll_oneoff**: fd subscriptions report readiness immediately instead of first sleeping the clock subscription's full timeout; the clock paces the call only when it is the sole kind subscribed. Previously every guest `select`/`poll` carrying a timeout took the whole timeout.
- **Proc_spawn cwd**: new argument carrying the guest's libc-tracked working directory (WASI has no chdir syscall, so the host cannot see it); children previously started in the host process's cwd.
- **Child stdio follows guest redirections**: child stdio resolution and `fdDstLocked`/`fdSrcLocked` consult the fd table before the interpreter streams, so a guest that re-opened stdout onto a file (cpanm's build.log) hands children the redirection.
- **fd_dup / fd_dup2 imports**: true dup sharing semantics (refcounted table entries; a bare stdio fd dups as an alias that never closes the real stream). `fd_renumber`'s move semantics cannot express the save/redirect/restore dance subprocess drivers do.
- **path_chmod / path_filestat_mode imports**: back bridge-provided `chmod`/`stat`/`lstat`. WASI can neither change file modes nor report permission bits, and build tools round-trip modes (`Module::Build`'s `make_executable` does `chmod((stat $f)[2] | 0111)`, which otherwise strips every permission). FS backends opt in via a `Chmod` method; MemFS reports ENOSYS.

## Pairing

The guest-side callers of the new/changed imports land in goccy/wasmify (`feat/guest-io-shims`); a wasm built with those shims needs this runtime, and vice versa for the proc_spawn signature change.

## Testing

- `go test ./...` (full suite, 11 packages)
- Downstream: perl-wasm rebuilt with these tools runs cpanm end-to-end (network fetch, configure, build) with no perl installed on the system; go-perl's full test suite and the Plack example pass against the regenerated bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
