### PR TITLE
Fold constant-mask phis out of branch conditions

### DIFF
--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -2950,6 +2950,9 @@ func (t *translator) compileBodyViaSSA(funcIdx uint32, fn wasm.Function) (*ast.B
 		if pass.Simplify(ssaFn) {
 			changed = true
 		}
+		if pass.FoldCondMaskPhi(ssaFn) {
+			changed = true
+		}
 		if pass.CSE(ssaFn) {
 			changed = true
 		}

--- a/internal/ssa/pass/condmaskphi.go
+++ b/internal/ssa/pass/condmaskphi.go
@@ -1,0 +1,88 @@
+package pass
+
+import "github.com/goccy/wasm2go/internal/ssa"
+
+// FoldCondMaskPhi rewrites a BlockIf whose condition is a diamond-produced
+// constant mask back to the diamond's own condition:
+//
+//	head:  If c -> then, else
+//	then:  ...                     // arms may hold arbitrary values;
+//	else:  ...                     // only the phi's args must be consts
+//	join:  m = phi(K, 0)           // K != 0 on the then edge
+//	...
+//	b:     If m -> x, y            // ==> If c -> x, y
+//
+// m != 0 holds exactly when the head took its then edge, i.e. when
+// c != 0, so branching on c is an exact replacement (c dominates the
+// head, the head dominates the join, and SSA guarantees the join
+// dominates every use of m — so c is available at b). The mask value
+// itself is left alone for its other uses and dies in DCE when the
+// rewritten branch was the last one.
+//
+// Besides being a real simplification, this unblocks a code shape the
+// Go arm64 backend cannot assemble: a CSETM-materialized mask (an if
+// assigning -1/0) consumed as another conditional's operand makes the
+// compiler emit CSEL with an always-true condition, which the assembler
+// rejects ("illegal combination"). perl 5.44's charclass code produces
+// exactly that shape.
+func FoldCondMaskPhi(f *ssa.Func) bool {
+	changed := false
+	for _, b := range f.Blocks {
+		if b.Kind != ssa.BlockIf || b.Control == nil {
+			continue
+		}
+		phi := b.Control
+		if phi.Op != ssa.OpPhi || len(phi.Args) != 2 || phi.Block == nil {
+			continue
+		}
+		a0, a1 := phi.Args[0], phi.Args[1]
+		if a0 == nil || a1 == nil ||
+			a0.Op != ssa.OpConst32 || a1.Op != ssa.OpConst32 {
+			continue
+		}
+		if (a0.AuxInt == 0) == (a1.AuxInt == 0) {
+			continue // need exactly one zero arm
+		}
+		join := phi.Block
+		if len(join.Preds) != 2 {
+			continue
+		}
+		h0, s0 := maskDiamondHead(join, 0)
+		h1, s1 := maskDiamondHead(join, 1)
+		if h0 == nil || h0 != h1 || s0 == s1 || h0.Control == nil {
+			continue
+		}
+		// The phi arg riding the head's then edge (Succs[0]): nonzero
+		// there means the mask is truthy exactly when the condition is.
+		thenArg := phi.Args[0]
+		if s1 == 0 {
+			thenArg = phi.Args[1]
+		}
+		if thenArg.AuxInt == 0 {
+			continue // inverted mask: would need a negation value
+		}
+		b.Control = h0.Control
+		changed = true
+	}
+	return changed
+}
+
+// maskDiamondHead resolves join.Preds[i] to the BlockIf heading the
+// diamond and the index of the head successor edge (0 = then) that path
+// came through: either the predecessor IS the head (triangle form), or
+// it is a single-entry single-exit arm block under it. Arm contents do
+// not matter — the fold never touches them.
+func maskDiamondHead(join *ssa.Block, i int) (*ssa.Block, int) {
+	e := join.Preds[i]
+	p := e.Block
+	if p.Kind == ssa.BlockIf {
+		return p, e.Index
+	}
+	if len(p.Preds) == 1 && len(p.Succs) == 1 {
+		pe := p.Preds[0]
+		if pe.Block.Kind == ssa.BlockIf {
+			return pe.Block, pe.Index
+		}
+	}
+	return nil, 0
+}

--- a/internal/ssa/pass/condmaskphi_test.go
+++ b/internal/ssa/pass/condmaskphi_test.go
@@ -1,0 +1,168 @@
+package pass
+
+import (
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/ssa"
+)
+
+// buildMaskDiamond constructs
+//
+//	entry: If p0 -> thenB, elseB
+//	thenB: -> join        (phi arg thenVal)
+//	elseB: -> join        (phi arg elseVal)
+//	join:  m = phi(...); If m -> retA, retB
+//
+// and returns the function pieces the assertions need.
+func buildMaskDiamond(t *testing.T, thenVal, elseVal int32) (f *ssa.Func, entry, join *ssa.Block, cond *ssa.Value) {
+	t.Helper()
+	b := ssa.NewFuncBuilder("cmp", ssa.FuncSig{
+		Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32},
+	})
+	entry = b.NewBlock(ssa.BlockIf)
+	thenB := b.NewBlock(ssa.BlockPlain)
+	elseB := b.NewBlock(ssa.BlockPlain)
+	join = b.NewBlock(ssa.BlockIf)
+	retA := b.NewBlock(ssa.BlockRet)
+	retB := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+
+	b.SetCurrent(entry)
+	cond = b.Param(0, ssa.TypeI32)
+	tv := b.Const32(thenVal)
+	ev := b.Const32(elseVal)
+	b.LinkIf(cond, thenB, elseB)
+
+	b.SetCurrent(thenB)
+	b.LinkPlain(join)
+	b.SetCurrent(elseB)
+	b.LinkPlain(join)
+
+	b.SetCurrent(join)
+	m := b.NewValue(ssa.OpPhi, ssa.TypeI32, tv, ev)
+	b.LinkIf(m, retA, retB)
+
+	b.SetCurrent(retA)
+	b.FinishRet(b.Const32(10))
+	b.SetCurrent(retB)
+	b.FinishRet(b.Const32(20))
+	return b.Func(), entry, join, cond
+}
+
+// TestFoldCondMaskPhi_MaskThenNonzero: If(phi(-1, 0)) branches on the
+// diamond's own condition afterwards — the shape perl 5.44 produces that
+// the Go arm64 backend cannot assemble.
+func TestFoldCondMaskPhi_MaskThenNonzero(t *testing.T) {
+	f, _, join, cond := buildMaskDiamond(t, -1, 0)
+	if !FoldCondMaskPhi(f) {
+		t.Fatal("FoldCondMaskPhi reported no change")
+	}
+	if join.Control != cond {
+		t.Errorf("join.Control = %v, want the diamond condition", join.Control)
+	}
+	if err := ssa.Verify(f); err != nil {
+		t.Errorf("verify after fold: %v", err)
+	}
+}
+
+// TestFoldCondMaskPhi_OneZeroMask: the 1/0 flavor folds the same way.
+func TestFoldCondMaskPhi_OneZeroMask(t *testing.T) {
+	f, _, join, cond := buildMaskDiamond(t, 1, 0)
+	if !FoldCondMaskPhi(f) {
+		t.Fatal("FoldCondMaskPhi reported no change")
+	}
+	if join.Control != cond {
+		t.Errorf("join.Control = %v, want the diamond condition", join.Control)
+	}
+}
+
+// TestFoldCondMaskPhi_InvertedMaskSkipped: then=0/else=-1 would need a
+// negated condition; the pass must leave it alone.
+func TestFoldCondMaskPhi_InvertedMaskSkipped(t *testing.T) {
+	f, _, join, cond := buildMaskDiamond(t, 0, -1)
+	if FoldCondMaskPhi(f) {
+		t.Fatal("FoldCondMaskPhi changed an inverted mask")
+	}
+	if join.Control == cond {
+		t.Errorf("inverted mask must not branch on the raw condition")
+	}
+}
+
+// TestFoldCondMaskPhi_NonConstArmSkipped: a phi with a non-constant arm
+// is not a mask.
+func TestFoldCondMaskPhi_NonConstArmSkipped(t *testing.T) {
+	b := ssa.NewFuncBuilder("cmp2", ssa.FuncSig{
+		Params: []ssa.Type{ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32},
+	})
+	entry := b.NewBlock(ssa.BlockIf)
+	thenB := b.NewBlock(ssa.BlockPlain)
+	elseB := b.NewBlock(ssa.BlockPlain)
+	join := b.NewBlock(ssa.BlockIf)
+	retA := b.NewBlock(ssa.BlockRet)
+	retB := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+
+	b.SetCurrent(entry)
+	cond := b.Param(0, ssa.TypeI32)
+	other := b.Param(1, ssa.TypeI32)
+	zero := b.Const32(0)
+	b.LinkIf(cond, thenB, elseB)
+	b.SetCurrent(thenB)
+	b.LinkPlain(join)
+	b.SetCurrent(elseB)
+	b.LinkPlain(join)
+	b.SetCurrent(join)
+	m := b.NewValue(ssa.OpPhi, ssa.TypeI32, other, zero)
+	b.LinkIf(m, retA, retB)
+	b.SetCurrent(retA)
+	b.FinishRet(b.Const32(10))
+	b.SetCurrent(retB)
+	b.FinishRet(b.Const32(20))
+
+	if FoldCondMaskPhi(b.Func()) {
+		t.Fatal("FoldCondMaskPhi changed a non-constant mask")
+	}
+}
+
+// TestFoldCondMaskPhi_TriangleForm: one phi input arrives straight from
+// the head (no arm block) — the else edge here — and still folds.
+func TestFoldCondMaskPhi_TriangleForm(t *testing.T) {
+	b := ssa.NewFuncBuilder("cmp3", ssa.FuncSig{
+		Params: []ssa.Type{ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32},
+	})
+	entry := b.NewBlock(ssa.BlockIf)
+	thenB := b.NewBlock(ssa.BlockPlain)
+	join := b.NewBlock(ssa.BlockIf)
+	retA := b.NewBlock(ssa.BlockRet)
+	retB := b.NewBlock(ssa.BlockRet)
+	b.SetEntry(entry)
+
+	b.SetCurrent(entry)
+	cond := b.Param(0, ssa.TypeI32)
+	tv := b.Const32(-1)
+	ev := b.Const32(0)
+	b.LinkIf(cond, thenB, join) // else edge goes straight to the join
+
+	b.SetCurrent(thenB)
+	b.LinkPlain(join)
+
+	b.SetCurrent(join)
+	// Preds order: entry (else edge) first, thenB second.
+	m := b.NewValue(ssa.OpPhi, ssa.TypeI32, ev, tv)
+	b.LinkIf(m, retA, retB)
+	b.SetCurrent(retA)
+	b.FinishRet(b.Const32(10))
+	b.SetCurrent(retB)
+	b.FinishRet(b.Const32(20))
+	f := b.Func()
+
+	if !FoldCondMaskPhi(f) {
+		t.Fatal("FoldCondMaskPhi reported no change for triangle form")
+	}
+	if join.Control != cond {
+		t.Errorf("join.Control = %v, want the diamond condition", join.Control)
+	}
+	if err := ssa.Verify(f); err != nil {
+		t.Errorf("verify after fold: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an SSA pass (`FoldCondMaskPhi`) that rewrites a `BlockIf` whose condition is a diamond-produced constant mask — `phi(c ? K : 0)`, `K != 0` — to branch on the diamond's own condition `c`. The mask is truthy exactly when `c` is, and `c` dominates the consumer (head → join → use), so the rewrite is exact; the mask value survives for its other uses and falls to DCE when the branch was its last consumer.

## Why now

perl 5.44's charclass code produces exactly this shape, and it hits a Go arm64 backend bug: an `if` materializing `-1/0` whose result feeds another conditional makes gc emit `CSEL` with an always-true condition, which the assembler rejects:

```
illegal combination: ... CSEL PLDL1KEEP, R2, R3, R1 ... , 14 7
```

Reproducible with 14 lines of ordinary Go on both go1.25.0 and go1.26.2 (so not a recent regression — the 5.42 bundle simply never generated the shape). Without this pass the perl 5.44 bundle fails to compile for `GOARCH=arm64` entirely (plain `go build`, not just the gcasm capture).

## Testing

- Unit tests for the pass: normal (-1/0) and 1/0 masks, inverted-polarity and non-constant arms left untouched, triangle-form diamonds, `ssa.Verify` after rewrites.
- `go test ./...` (11 packages) and golangci-lint clean.
- End-to-end: the perl 5.44.0 wasm transpiles and the resulting bundle builds with `GOARCH=arm64` and `GOARCH=amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
