### PR TITLE
wasm: bound vector element counts by remaining section bytes

### DIFF
--- a/internal/wasm/parser.go
+++ b/internal/wasm/parser.go
@@ -56,7 +56,7 @@ func Parse(r io.Reader) (*Module, error) {
 		if _, err := io.ReadFull(br, raw); err != nil {
 			return nil, fmt.Errorf("section %d: read payload: %w", id, err)
 		}
-		sr := &readerAt{r: bufio.NewReader(bytes.NewReader(raw))}
+		sr := &readerAt{r: bytes.NewReader(raw)}
 		if err := parseSection(m, id, sr, raw); err != nil {
 			return nil, fmt.Errorf("section %d: %w", id, err)
 		}
@@ -141,8 +141,8 @@ func parseTypeSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("type section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("type section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Types = make([]FuncType, n)
 	for i := uint32(0); i < n; i++ {
@@ -167,8 +167,8 @@ func readFuncType(r byteReader) (FuncType, error) {
 	if err != nil {
 		return FuncType{}, err
 	}
-	if np > maxVectorLen {
-		return FuncType{}, fmt.Errorf("functype params count %d exceeds %d-element cap", np, maxVectorLen)
+	if np > vecCap(r) {
+		return FuncType{}, fmt.Errorf("functype params count %d exceeds %d-element cap", np, vecCap(r))
 	}
 	params := make([]ValType, np)
 	for i := uint32(0); i < np; i++ {
@@ -182,8 +182,8 @@ func readFuncType(r byteReader) (FuncType, error) {
 	if err != nil {
 		return FuncType{}, err
 	}
-	if nr > maxVectorLen {
-		return FuncType{}, fmt.Errorf("functype results count %d exceeds %d-element cap", nr, maxVectorLen)
+	if nr > vecCap(r) {
+		return FuncType{}, fmt.Errorf("functype results count %d exceeds %d-element cap", nr, vecCap(r))
 	}
 	results := make([]ValType, nr)
 	for i := uint32(0); i < nr; i++ {
@@ -233,8 +233,8 @@ func parseImportSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("import section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("import section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Imports = make([]Import, n)
 	for i := uint32(0); i < n; i++ {
@@ -309,8 +309,8 @@ func parseTagSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("tag section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("tag section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Tags = make([]Tag, n)
 	for i := uint32(0); i < n; i++ {
@@ -332,8 +332,8 @@ func parseFunctionSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("function section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("function section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Functions = make([]Function, n)
 	for i := uint32(0); i < n; i++ {
@@ -351,8 +351,8 @@ func parseTableSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("table section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("table section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Tables = make([]TableType, n)
 	for i := uint32(0); i < n; i++ {
@@ -374,8 +374,8 @@ func parseMemorySection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("memory section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("memory section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Memories = make([]MemoryType, n)
 	for i := uint32(0); i < n; i++ {
@@ -393,8 +393,8 @@ func parseGlobalSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("global section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("global section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Globals = make([]Global, n)
 	for i := uint32(0); i < n; i++ {
@@ -423,8 +423,8 @@ func parseExportSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("export section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("export section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Exports = make([]Export, n)
 	for i := uint32(0); i < n; i++ {
@@ -450,8 +450,8 @@ func parseElementSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("element section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("element section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Elements = make([]ElementSegment, 0, n)
 	for i := uint32(0); i < n; i++ {
@@ -470,8 +470,8 @@ func parseElementSection(m *Module, r byteReader) error {
 			if err != nil {
 				return err
 			}
-			if cnt > maxVectorLen {
-				return fmt.Errorf("element[%d]: count %d exceeds %d-byte cap", i, cnt, maxVectorLen)
+			if cnt > vecCap(r) {
+				return fmt.Errorf("element[%d]: count %d exceeds %d-byte cap", i, cnt, vecCap(r))
 			}
 			idxs := make([]uint32, cnt)
 			for j := range idxs {
@@ -507,8 +507,8 @@ func parseElementSection(m *Module, r byteReader) error {
 			if err != nil {
 				return err
 			}
-			if cnt > maxVectorLen {
-				return fmt.Errorf("element[%d]: count %d exceeds %d-byte cap", i, cnt, maxVectorLen)
+			if cnt > vecCap(r) {
+				return fmt.Errorf("element[%d]: count %d exceeds %d-byte cap", i, cnt, vecCap(r))
 			}
 			idxs := make([]uint32, cnt)
 			for j := range idxs {
@@ -560,8 +560,8 @@ func parseDataSection(m *Module, r byteReader) error {
 	if err != nil {
 		return err
 	}
-	if n > maxVectorLen {
-		return fmt.Errorf("data section: count %d exceeds %d-element cap", n, maxVectorLen)
+	if n > vecCap(r) {
+		return fmt.Errorf("data section: count %d exceeds %d-element cap", n, vecCap(r))
 	}
 	m.Datas = make([]DataSegment, 0, n)
 	for i := uint32(0); i < n; i++ {
@@ -711,3 +711,29 @@ type readerAt struct {
 
 func (a *readerAt) Read(p []byte) (int, error) { return a.r.Read(p) }
 func (a *readerAt) ReadByte() (byte, error)    { return a.r.ReadByte() }
+
+// bytesRemaining reports how many bytes are still available to read, when the
+// underlying reader knows (a section payload is backed by a *bytes.Reader). It
+// returns -1 when the size is unknown (e.g. the streaming top-level reader).
+func (a *readerAt) bytesRemaining() int {
+	if l, ok := a.r.(interface{ Len() int }); ok {
+		return l.Len()
+	}
+	return -1
+}
+
+// vecCap returns the maximum plausible element count for a vector decoded from
+// r: every vec element occupies at least one byte on the wire, so a count
+// larger than the bytes remaining in the enclosing section payload is invalid
+// and would only serve to make the decoder pre-allocate a huge slice from a
+// tiny input. When the remaining size is unknown, fall back to maxVectorLen.
+func vecCap(r byteReader) uint32 {
+	if ra, ok := r.(*readerAt); ok {
+		if rem := ra.bytesRemaining(); rem >= 0 {
+			if uint64(rem) < uint64(maxVectorLen) {
+				return uint32(rem)
+			}
+		}
+	}
+	return maxVectorLen
+}

--- a/internal/wasm/vec_dos_test.go
+++ b/internal/wasm/vec_dos_test.go
@@ -1,0 +1,32 @@
+package wasm
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+)
+
+// A vector count field is bounded only by maxVectorLen (256Mi), independent of
+// the section's actual payload size. A tiny module could declare a huge count
+// and force the decoder to pre-allocate a large slice (make([]T, n)) before
+// reading any element. Because every vec element occupies at least one byte on
+// the wire, the count can never exceed the bytes remaining in the section, so
+// such a module must be rejected without a large allocation.
+func TestVectorCountDoS(t *testing.T) {
+	// magic+version, type section (id=1) with declared payload size 4, whose
+	// first bytes decode to a ~100M element count.
+	data := []byte("\x00asm\x01\x00\x00\x00\x01\x04\xc4\xc4\xc40")
+
+	var m0, m1 runtime.MemStats
+	runtime.ReadMemStats(&m0)
+	_, err := Parse(bytes.NewReader(data))
+	runtime.ReadMemStats(&m1)
+	mb := (m1.TotalAlloc - m0.TotalAlloc) / (1024 * 1024)
+
+	if err == nil {
+		t.Fatal("expected an error for an oversized vector count")
+	}
+	if mb > 16 {
+		t.Fatalf("allocated %d MB parsing a 14-byte module (vector-count DoS not bounded)", mb)
+	}
+}


### PR DESCRIPTION
## What

Every `vec(...)` count in the WebAssembly binary parser is validated only against `maxVectorLen` (256Mi *elements*), independent of the section's actual payload size:

```go
n, err := readU32(r)
...
if n > maxVectorLen {
    return fmt.Errorf("type section: count %d exceeds ...", n, maxVectorLen)
}
m.Types = make([]FuncType, n)   // eager allocation before reading any element
for i := uint32(0); i < n; i++ { ... }
```

Because the count drives an eager `make([]T, n)` before a single element is read, a tiny module can declare a huge count and force a large allocation. A **14-byte** module whose type section declares a ~100M element count makes the decoder allocate **several gigabytes** before it hits EOF on the first element — a cheap amplification DoS on untrusted `.wasm` input. (`FuncType` is a multi-word struct, so 256Mi elements is multi-GB; `make([]FuncType, ~100M)` measured at ~4.6 GB.)

The 256Mi cap doesn't help here: the whole point is that the declared count is wildly larger than the bytes actually present.

## Fix

Every vec element occupies at least one byte on the wire, so a count larger than the bytes remaining in the enclosing section payload is invalid. Add `vecCap(r)`, which bounds the count by the section reader's remaining length (falling back to `maxVectorLen` when the size is unknown), and use it for every count check. The section sub-reader now wraps the payload's `*bytes.Reader` directly (instead of `bufio.NewReader(bytes.NewReader(raw))`) so its `Len()` is exact.

This keeps all valid modules parsing unchanged while rejecting the amplified counts immediately, before allocating.

## Testing

Added `TestVectorCountDoS`: a 14-byte module with an oversized type-section count now returns an error and allocates **< 16 MB** (measured via `runtime.MemStats`); the same input allocates **~4.6 GB** before the fix.

Verified RED→GREEN. The full `internal/wasm` test suite passes with real modules (validated with `wat2wasm` installed). `go build ./...`, `go vet ./internal/wasm/` and `gofmt` are clean.
