### PR TITLE
gcasm: direct cross-chunk asm calls (drop the linkname forwarding hop)

### DIFF
--- a/internal/gcasm/asmsym.go
+++ b/internal/gcasm/asmsym.go
@@ -1,0 +1,39 @@
+package gcasm
+
+import "strings"
+
+// plan9AsmPathSafe reports whether an import path can be embedded in a
+// plan 9 asm symbol operand. The asm lexer accepts letters, digits,
+// "_", U+00B7 and U+2215 as identifier runes and maps the latter two
+// back to "." and "/" (src/cmd/asm/internal/lex), so "." and "/" are
+// the only ASCII punctuation an operand can carry — anything else
+// ("-", "+", "~", ...) is unrepresentable and forces the Go-wrapper
+// forwarding path. This mirrors codegen.isPlan9AsmSafe; the two
+// packages cannot share it without an import cycle.
+func plan9AsmPathSafe(path string) bool {
+	if path == "" {
+		return false
+	}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_' || c == '.' || c == '/':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// asmSpellPath renders an import path as a plan 9 asm identifier
+// prefix: "." becomes U+00B7 ("·") and "/" becomes U+2215 ("∕"),
+// which the asm lexer folds back to the ASCII forms, so the linker
+// sees the canonical dotted path. Only meaningful for paths
+// plan9AsmPathSafe accepts.
+func asmSpellPath(path string) string {
+	path = strings.ReplaceAll(path, ".", "·")
+	return strings.ReplaceAll(path, "/", "∕")
+}

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -953,7 +953,14 @@ func buildPkg(
 	// that reference resolves against this wrapper when the fn kept
 	// its Go body. Dead code (never jumped to), alive as an object
 	// symbol regardless of linker deadcode decisions.
-	if len(fallbackNames) > 0 {
+	//
+	// Needed ONLY when calleeSig actually emits spelled direct CALLs,
+	// i.e. when the import path is plan-9-spellable. An unspellable
+	// path (a hyphenated host repo) keeps the gcasmFwd linkname
+	// wrappers for every cross-chunk call, so no direct reference to a
+	// fallback fn is ever made and the anchor would be pure dead
+	// weight — skip it there.
+	if len(fallbackNames) > 0 && plan9AsmPathSafe(importPath) {
 		var names []string
 		for n := range fallbackNames {
 			names = append(names, n)

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -218,12 +218,17 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	sort.Strings(pkgList)
 
 	// Group each arch's captured fns by package relDir; record each
-	// symbol's owning package (arch-independent) for cross-chunk
-	// reference resolution.
-	fnOwner := map[string]string{} // "Fn83" → qualified path
+	// symbol's owning package for cross-chunk reference resolution.
+	// The owner map is PER ARCH: direct cross-chunk asm CALLs (see
+	// calleeSig) are sound only when the callee's own package emits
+	// either the TEXT or the gcasmABI0Keep anchor for it on the SAME
+	// arch, which is exactly membership in that arch's capture.
+	fnOwnerByArch := map[string]map[string]string{} // arch → "Fn83" → qualified path
 	for _, spec := range archSpecs {
 		ac := caps[spec.name]
 		ac.byPkg = map[string][]*Fn{}
+		fnOwner := map[string]string{}
+		fnOwnerByArch[spec.name] = fnOwner
 		for _, f := range ac.fns {
 			i := strings.LastIndex(f.Name, ".")
 			if i < 0 {
@@ -260,7 +265,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 			if len(pfns) == 0 {
 				continue
 			}
-			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwner, pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, cfg)
+			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, cfg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("gcasm bundle %s/%s: %w", pkgOrRoot(rel), spec.name, err)
 			}
@@ -675,14 +680,24 @@ func buildPkg(
 			if cpkg == selfPath {
 				return params, hasRes, res, "·" + cname, true
 			}
-			// Remote fn (transformed or fallback): a local Go wrapper
-			// forwards through //go:linkname — the classic alias.go
-			// shape. Imports cannot be used (chunk call graphs are
-			// cyclic) and direct asm references cannot either (real
-			// import paths contain dots, which Plan9 asm cannot
-			// spell). For transformed remotes the linkname resolves
-			// against the remote package's Go decl, whose compile
-			// provides the ABI bridge onto the asm body.
+			// Remote fn (transformed or fallback): CALL the remote
+			// symbol directly. The plan 9 lexer maps U+00B7 to "." and
+			// U+2215 to "/", so a dotted import path is spellable in an
+			// asm operand and the linker sees the canonical symbol —
+			// no forwarding frame. Transformed remotes resolve against
+			// the remote TEXT (ABI0, the exact layout the marshalling
+			// below stages); fallback remotes resolve against the ABI0
+			// wrapper their own package's gcasmABI0Keep anchor forces
+			// the compiler to emit. Imports still cannot be used (chunk
+			// call graphs are cyclic), but no import is needed: every
+			// chunk is linked via the root package's import chain, the
+			// same guarantee the old //go:linkname forwards relied on.
+			// A path plan 9 cannot spell (e.g. a hyphenated host repo)
+			// or a callee outside the capture keeps the historical
+			// Go-wrapper hop.
+			if fnOwner[cname] == cpkg && plan9AsmPathSafe(cpkg) {
+				return params, hasRes, res, asmSpellPath(cpkg) + "·" + cname, true
+			}
 			wrap := "gcasmFwd" + cname
 			goForwards[wrap] = sym
 			goForwardSig[wrap] = goSigB{params: params, hasRes: hasRes, res: res, ok: true}
@@ -929,6 +944,27 @@ func buildPkg(
 		if !seenSynth[n] {
 			return nil, fmt.Errorf("outlined %s: not present in the %s capture", n, arch.name)
 		}
+	}
+
+	// ABI0 anchor: reference every pure-Go fallback fn from this
+	// package's own asm, so the compiler emits its ABI0 wrapper
+	// (symabis marks the fn as asm-referenced). Other chunks' asm
+	// CALLs the fn's dotted symbol directly — see calleeSig — and
+	// that reference resolves against this wrapper when the fn kept
+	// its Go body. Dead code (never jumped to), alive as an object
+	// symbol regardless of linker deadcode decisions.
+	if len(fallbackNames) > 0 {
+		var names []string
+		for n := range fallbackNames {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		asmB.WriteString("// gcasmABI0Keep: asm references forcing ABI0 wrappers for the\n// pure-Go fallback fns, so cross-chunk direct CALLs link.\nTEXT ·gcasmABI0Keep(SB), NOSPLIT, $0-0\n")
+		for _, n := range names {
+			asmB.WriteString("\tJMP ·" + n + "(SB)\n")
+		}
+		asmB.WriteString("\n")
+		declFns.WriteString("\n// gcasmABI0Keep is an assembly-only anchor (see the .s file).\nfunc gcasmABI0Keep()\n\nvar _ = gcasmABI0Keep\n")
 	}
 
 	// Fallback bodies (extracted early: their Go-level FnN references

--- a/internal/gcasm/bundle_test.go
+++ b/internal/gcasm/bundle_test.go
@@ -23,7 +23,7 @@ import (
 // pure-only) — outputs must match exactly. Also asserts Build is
 // deterministic (two invocations → identical file map).
 func TestGate4Bundle(t *testing.T) {
-	for _, fixture := range []string{"control", "cg_brtable64", "cg_indirect", "cg_numerics", "cg_memops"} {
+	for _, fixture := range []string{"control", "cg_brtable64", "cg_indirect", "cg_numerics", "cg_memops", "cg_crosscall"} {
 		t.Run(fixture, func(t *testing.T) {
 			gate4(t, fixture)
 		})
@@ -35,16 +35,35 @@ func TestGate4Bundle(t *testing.T) {
 		defer codegen.SetMultiPackageThreshold(0)()
 		gate4(t, "control")
 	})
+	// A dotted module path — the real bundles live under
+	// github.com/... — proves the spelled direct cross-chunk CALLs
+	// (see calleeSig) assemble, link, and behave identically.
+	t.Run("control_multipkg_dotted", func(t *testing.T) {
+		defer codegen.SetMultiPackageThreshold(0)()
+		gate4At(t, "control", "github.com/gentest")
+	})
+	// A tiny chunk budget splits the crosscall fixture's caller and
+	// callees into separate chunk packages, so the transformed asm
+	// CALLs remote fns directly through their spelled dotted symbols
+	// — the exact production shape of the direct-call optimization.
+	t.Run("crosscall_multichunk_dotted", func(t *testing.T) {
+		defer codegen.SetMultiPackageThreshold(64)()
+		gate4At(t, "cg_crosscall", "github.com/gentest")
+	})
 }
 
 func gate4(t *testing.T, fixture string) {
+	gate4At(t, fixture, "gentest")
+}
+
+func gate4At(t *testing.T, fixture string, modPath string) {
 	bin := testfixture.Wasm(t, fixture)
 	mod, err := wasm.Parse(bytes.NewReader(bin))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: "gentest/pkg"})
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: modPath + "/pkg"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +77,7 @@ func gate4(t *testing.T, fixture string) {
 	}
 	build := func() map[string][]byte {
 		t.Helper()
-		files, stats, err := Build(mod, buf.Bytes(), treeIn, "gentest/pkg", nil, nil, nil, nil, nil, Config{})
+		files, stats, err := Build(mod, buf.Bytes(), treeIn, modPath+"/pkg", nil, nil, nil, nil, nil, Config{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +102,7 @@ func gate4(t *testing.T, fixture string) {
 		t.Helper()
 		dir := t.TempDir()
 		tree := map[string][]byte{
-			"go.mod": []byte("module gentest\n\ngo 1.25.0\n"),
+			"go.mod": []byte("module " + modPath + "\n\ngo 1.25.0\n"),
 		}
 		if buf.Len() > 0 { // multi-package mode leaves the main writer empty
 			tree["pkg/gen.go"] = buf.Bytes()
@@ -115,7 +134,7 @@ func gate4(t *testing.T, fixture string) {
 				pf[name] = data
 			}
 			pf = PureFilter(pf)
-			tree = map[string][]byte{"go.mod": []byte("module gentest\n\ngo 1.25.0\n")}
+			tree = map[string][]byte{"go.mod": []byte("module " + modPath + "\n\ngo 1.25.0\n")}
 			for name, data := range pf {
 				tree["pkg/"+name] = data
 			}
@@ -135,11 +154,11 @@ func gate4(t *testing.T, fixture string) {
 	// Export-level driver: call every exported method over an input
 	// sweep and print outcomes; both variants must print identically.
 	var driver strings.Builder
-	driver.WriteString(`package main
+	driver.WriteString(strings.ReplaceAll(`package main
 
 import (
 	"fmt"
-	"gentest/pkg"
+	"MODPATH/pkg"
 )
 
 func run(f func() int64) (val int64, panicked bool) {
@@ -152,7 +171,7 @@ func run(f func() int64) (val int64, panicked bool) {
 }
 
 func main() {
-`)
+`, "MODPATH", modPath))
 	exports := 0
 	for _, exp := range mod.Exports {
 		if exp.Kind != wasm.ExportFunc {

--- a/internal/gcasm/crosschunk_test.go
+++ b/internal/gcasm/crosschunk_test.go
@@ -105,10 +105,11 @@ func TestCrossChunkDirectCalls(t *testing.T) {
 // spell (a hyphen) keeps the historical Go-wrapper forwarding shape.
 func TestCrossChunkWrapperFallback(t *testing.T) {
 	files := buildMultiChunk(t, "cg_crosscall", "github.com/gen-test/pkg")
-	var spelled, wrappers int
+	var spelled, wrappers, anchors int
 	for name, data := range files {
 		if strings.HasSuffix(name, ".s") {
 			spelled += strings.Count(string(data), "∕")
+			anchors += strings.Count(string(data), "TEXT ·gcasmABI0Keep(SB)")
 		}
 		if strings.HasSuffix(name, ".go") {
 			wrappers += strings.Count(string(data), "func gcasmFwdFn")
@@ -119,5 +120,10 @@ func TestCrossChunkWrapperFallback(t *testing.T) {
 	}
 	if wrappers == 0 {
 		t.Error("no gcasmFwdFn wrappers emitted; the unspellable path must keep the forwarding shape")
+	}
+	// No direct CALL is ever made on this path, so the ABI0 keep
+	// anchor would be pure dead weight — it must not be emitted.
+	if anchors != 0 {
+		t.Errorf("%d gcasmABI0Keep anchors emitted for an unspellable path; none should be (no direct calls)", anchors)
 	}
 }

--- a/internal/gcasm/crosschunk_test.go
+++ b/internal/gcasm/crosschunk_test.go
@@ -127,3 +127,126 @@ func TestCrossChunkWrapperFallback(t *testing.T) {
 		t.Errorf("%d gcasmABI0Keep anchors emitted for an unspellable path; none should be (no direct calls)", anchors)
 	}
 }
+
+// finalBundleTree returns the file set an amd64/arm64 consumer would
+// actually compile: the codegen multi-package output with the gcasm
+// backend's delta merged in (a nil gcasm entry deletes the file).
+func finalBundleTree(t *testing.T, fixture, importPath string) map[string][]byte {
+	t.Helper()
+	defer codegen.SetMultiPackageThreshold(64)()
+	bin := testfixture.Wasm(t, fixture)
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: importPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := map[string][]byte{}
+	for name, data := range res.Sidecars {
+		tree[name] = data
+	}
+	for name, data := range res.Files {
+		tree[name] = data
+	}
+	delta, _, err := Build(mod, buf.Bytes(), tree, importPath, nil, nil, nil, nil, nil, Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range delta {
+		if data == nil {
+			delete(tree, name)
+			continue
+		}
+		tree[name] = data
+	}
+	return tree
+}
+
+// buildDirectiveOf returns the first //go:build expression in a Go
+// source file, or "" for an untagged (all-arch) file.
+func buildDirectiveOf(src []byte) string {
+	for _, ln := range strings.Split(string(src), "\n") {
+		ln = strings.TrimSpace(ln)
+		if strings.HasPrefix(ln, "//go:build ") {
+			return strings.TrimSpace(strings.TrimPrefix(ln, "//go:build "))
+		}
+		if strings.HasPrefix(ln, "package ") {
+			break
+		}
+	}
+	return ""
+}
+
+// TestPlan9SafeBundleFileStructure asserts the final bundle a
+// plan-9-spellable consumer compiles has no amd64/arm64 linkname
+// alias file: the codegen amd64||arm64 alias.go is deleted by the
+// gcasm backend, its cross-chunk declarations fold into the
+// decls_<arch>.go the asm bodies need anyway, and every remaining
+// linkname-only alias file is guarded off the asm arches. This is the
+// file-set contract the direct-call path relies on for parse economy.
+func TestPlan9SafeBundleFileStructure(t *testing.T) {
+	// The file-set contract (no separate amd64/arm64 linkname alias
+	// file; cross-chunk decls in decls_<arch>.go) holds for BOTH the
+	// spellable and the hyphenated path — only the CONTENT of
+	// decls_<arch>.go differs (direct symbols vs gcasmFwd wrappers).
+	for _, importPath := range []string{"github.com/gentest/pkg", "github.com/gen-test/pkg"} {
+		t.Run(importPath, func(t *testing.T) { assertBundleFileStructure(t, importPath) })
+	}
+}
+
+func assertBundleFileStructure(t *testing.T, importPath string) {
+	tree := finalBundleTree(t, "cg_indirect", importPath)
+
+	// Collect the chunk packages (pN directories).
+	chunkDirs := map[string]bool{}
+	for name := range tree {
+		if i := strings.IndexByte(name, '/'); i > 0 && strings.HasPrefix(name[:i], "p") {
+			chunkDirs[name[:i]] = true
+		}
+	}
+	if len(chunkDirs) < 2 {
+		t.Fatalf("fixture did not split into multiple chunks: %v", chunkDirs)
+	}
+
+	for dir := range chunkDirs {
+		// No amd64||arm64 alias.go survives — it was deleted, its
+		// decls folded into decls_<arch>.go.
+		if _, ok := tree[dir+"/alias.go"]; ok {
+			t.Errorf("%s/alias.go survived; the gcasm backend must delete the amd64||arm64 alias", dir)
+		}
+		hasArchDecls := false
+		for _, arch := range []string{"amd64", "arm64"} {
+			if data, ok := tree[dir+"/decls_"+arch+".go"]; ok {
+				hasArchDecls = true
+				if d := buildDirectiveOf(data); !strings.Contains(d, arch) {
+					t.Errorf("%s/decls_%s.go build guard %q does not restrict to %s", dir, arch, d, arch)
+				}
+			}
+		}
+		if !hasArchDecls {
+			t.Errorf("%s: no decls_amd64.go/decls_arm64.go to carry the asm-body and cross-chunk decls", dir)
+		}
+		// Every linkname-only alias file left in the chunk must be
+		// guarded OFF the asm arches (the pure fallback path only).
+		for name, data := range tree {
+			if !strings.HasPrefix(name, dir+"/") || !strings.HasSuffix(name, ".go") {
+				continue
+			}
+			if !strings.Contains(string(data), "//go:linkname") {
+				continue
+			}
+			d := buildDirectiveOf(data)
+			// The arch decls legitimately carry linkname forwards; the
+			// concern is a SEPARATE alias file compiled on the asm arch.
+			if strings.HasSuffix(name, "/decls_amd64.go") || strings.HasSuffix(name, "/decls_arm64.go") {
+				continue
+			}
+			if !strings.Contains(d, "!amd64") && !strings.Contains(d, "!arm64") {
+				t.Errorf("%s carries //go:linkname but is not guarded off the asm arches (build %q)", name, d)
+			}
+		}
+	}
+}

--- a/internal/gcasm/crosschunk_test.go
+++ b/internal/gcasm/crosschunk_test.go
@@ -1,0 +1,123 @@
+package gcasm
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/codegen"
+	"github.com/goccy/wasm2go/internal/testfixture"
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+func TestPlan9AsmPathSafe(t *testing.T) {
+	for path, want := range map[string]bool{
+		"":                                  false,
+		"gentest/pkg":                       true,
+		"github.com/goccy/llamawasm2go/p1":  true,
+		"github.com/goccy/some-hyphen/pkg":  false,
+		"example.org/x_y/v2":                true,
+		"host.tld/a+b":                      false,
+		"host.tld/sp ace":                   false,
+		"github.com/goccy/wasm2go/internal": true,
+	} {
+		if got := plan9AsmPathSafe(path); got != want {
+			t.Errorf("plan9AsmPathSafe(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestAsmSpellPath(t *testing.T) {
+	got := asmSpellPath("github.com/goccy/llamawasm2go/p1")
+	want := "github·com∕goccy∕llamawasm2go∕p1"
+	if got != want {
+		t.Fatalf("asmSpellPath = %q, want %q", got, want)
+	}
+}
+
+// buildMultiChunk translates a fixture in linkname-split
+// multi-package mode under importPath and hands it to Build. The
+// tiny 64-byte chunk budget forces the fixture across several chunk
+// packages, so transformed bodies make cross-chunk calls.
+func buildMultiChunk(t *testing.T, fixture, importPath string) map[string][]byte {
+	t.Helper()
+	defer codegen.SetMultiPackageThreshold(64)()
+	bin := testfixture.Wasm(t, fixture)
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	res, err := codegen.Translate(&buf, mod, codegen.Options{Package: "pkg", OutputImportPath: importPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	treeIn := map[string][]byte{}
+	for name, data := range res.Sidecars {
+		treeIn[name] = data
+	}
+	for name, data := range res.Files {
+		treeIn[name] = data
+	}
+	files, _, err := Build(mod, buf.Bytes(), treeIn, importPath, nil, nil, nil, nil, nil, Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+// TestCrossChunkDirectCalls: a plan-9-spellable import path (dots and
+// slashes only, like the production bundles) gets direct cross-chunk
+// asm CALLs — the spelled remote symbol appears in the emitted asm and
+// no gcasmFwdFn forwarding wrapper is generated.
+func TestCrossChunkDirectCalls(t *testing.T) {
+	files := buildMultiChunk(t, "cg_crosscall", "github.com/gentest/pkg")
+	var direct, wrappers int
+	for name, data := range files {
+		if strings.HasSuffix(name, ".s") {
+			direct += strings.Count(string(data), "CALL github·com∕gentest∕pkg")
+		}
+		if strings.HasSuffix(name, ".go") {
+			wrappers += strings.Count(string(data), "func gcasmFwdFn")
+		}
+	}
+	if direct == 0 {
+		t.Error("no spelled direct cross-chunk CALL emitted")
+	}
+	if wrappers != 0 {
+		t.Errorf("%d gcasmFwdFn forwarding wrappers emitted; want 0 (direct calls should replace them)", wrappers)
+	}
+	// The fixture's wide-signature fn falls back to its pure Go body,
+	// so its package must anchor the ABI0 wrapper the remote direct
+	// CALL links against.
+	var anchors int
+	for name, data := range files {
+		if strings.HasSuffix(name, ".s") {
+			anchors += strings.Count(string(data), "TEXT ·gcasmABI0Keep(SB)")
+		}
+	}
+	if anchors == 0 {
+		t.Error("no gcasmABI0Keep anchor emitted for the fallback fn's package")
+	}
+}
+
+// TestCrossChunkWrapperFallback: an import path plan 9 asm cannot
+// spell (a hyphen) keeps the historical Go-wrapper forwarding shape.
+func TestCrossChunkWrapperFallback(t *testing.T) {
+	files := buildMultiChunk(t, "cg_crosscall", "github.com/gen-test/pkg")
+	var spelled, wrappers int
+	for name, data := range files {
+		if strings.HasSuffix(name, ".s") {
+			spelled += strings.Count(string(data), "∕")
+		}
+		if strings.HasSuffix(name, ".go") {
+			wrappers += strings.Count(string(data), "func gcasmFwdFn")
+		}
+	}
+	if spelled != 0 {
+		t.Errorf("%d spelled path references emitted for an unspellable import path", spelled)
+	}
+	if wrappers == 0 {
+		t.Error("no gcasmFwdFn wrappers emitted; the unspellable path must keep the forwarding shape")
+	}
+}

--- a/testdata/cg_crosscall.wat
+++ b/testdata/cg_crosscall.wat
@@ -1,0 +1,78 @@
+(module
+  ;; Direct cross-function calls between non-recursive functions.
+  ;; Each body is padded past the smallest chunk budgets the tests
+  ;; use, so under a tiny multi-package chunk budget every function
+  ;; lands in its own chunk package and the callers' transformed asm
+  ;; makes cross-chunk CALLs.
+
+  ;; mixA: a long dependent i64 chain (~30 ops).
+  (func $mixA (param $a i64) (param $b i64) (result i64)
+    (local $x i64)
+    (local.set $x (i64.add (local.get $a) (local.get $b)))
+    (local.set $x (i64.mul (local.get $x) (i64.const 31)))
+    (local.set $x (i64.xor (local.get $x) (i64.const 0x9e3779b97f4a7c15)))
+    (local.set $x (i64.add (local.get $x) (i64.shr_u (local.get $x) (i64.const 7))))
+    (local.set $x (i64.mul (local.get $x) (i64.const 0x100000001b3)))
+    (local.set $x (i64.xor (local.get $x) (i64.shl (local.get $x) (i64.const 13))))
+    (local.set $x (i64.add (local.get $x) (i64.const 12345)))
+    (local.set $x (i64.sub (local.get $x) (i64.rotl (local.get $a) (i64.const 17))))
+    (local.set $x (i64.xor (local.get $x) (i64.rotr (local.get $b) (i64.const 9))))
+    (local.set $x (i64.mul (local.get $x) (i64.const 7)))
+    (i64.add (local.get $x) (i64.shr_s (local.get $x) (i64.const 3))))
+
+  ;; mixB: a different long chain.
+  (func $mixB (param $a i64) (result i64)
+    (local $y i64)
+    (local.set $y (i64.mul (local.get $a) (i64.const 0x5851f42d4c957f2d)))
+    (local.set $y (i64.add (local.get $y) (i64.const 0x14057b7ef767814f)))
+    (local.set $y (i64.xor (local.get $y) (i64.shr_u (local.get $y) (i64.const 33))))
+    (local.set $y (i64.mul (local.get $y) (i64.const 0xff51afd7ed558ccd)))
+    (local.set $y (i64.xor (local.get $y) (i64.shr_u (local.get $y) (i64.const 29))))
+    (local.set $y (i64.add (local.get $y) (i64.rotl (local.get $a) (i64.const 5))))
+    (local.set $y (i64.sub (local.get $y) (i64.const 999)))
+    (local.set $y (i64.or (local.get $y) (i64.const 1)))
+    (i64.mul (local.get $y) (i64.const 3)))
+
+  ;; mid combines both leaves; its own padding keeps it a separate
+  ;; chunk too.
+  (func $mid (param $a i64) (param $b i64) (result i64)
+    (local $z i64)
+    (local.set $z (i64.add
+      (call $mixA (local.get $a) (local.get $b))
+      (call $mixB (local.get $a))))
+    (local.set $z (i64.xor (local.get $z) (i64.shr_u (local.get $z) (i64.const 11))))
+    (local.set $z (i64.mul (local.get $z) (i64.const 5)))
+    (local.set $z (i64.add (local.get $z) (i64.rotr (local.get $b) (i64.const 21))))
+    (local.set $z (i64.sub (local.get $z) (i64.rotl (local.get $a) (i64.const 2))))
+    (local.set $z (i64.xor (local.get $z) (i64.const 0x0f0f0f0f0f0f0f0f)))
+    (i64.add (local.get $z) (i64.const 42)))
+
+  ;; wide: enough i64 params to overflow the register ABI, so this
+  ;; function keeps its pure Go body (sig fallback) while its callers
+  ;; are transformed — the cross-chunk call then resolves against the
+  ;; ABI0 wrapper the gcasmABI0Keep anchor forces out.
+  (func $wide
+      (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64)
+      (result i64)
+    (i64.add (local.get 0)
+    (i64.add (local.get 1)
+    (i64.add (local.get 2)
+    (i64.add (local.get 3)
+    (i64.add (local.get 4)
+    (i64.add (local.get 5)
+    (i64.add (local.get 6)
+    (i64.add (local.get 7)
+    (i64.add (local.get 8)
+    (i64.add (local.get 9)
+    (i64.add (local.get 10) (local.get 11)))))))))))))
+
+  (func (export "crosscall") (param $a i64) (param $b i64) (result i64)
+    (i64.add
+      (i64.add
+        (call $mid (local.get $a) (local.get $b))
+        (call $mixB (local.get $b)))
+      (call $wide
+        (local.get $a) (local.get $b) (local.get $a) (local.get $b)
+        (local.get $a) (local.get $b) (local.get $a) (local.get $b)
+        (local.get $a) (local.get $b) (local.get $a) (local.get $b))))
+)


### PR DESCRIPTION
## Why

Cross-chunk calls from transformed asm route through a generated Go wrapper (`gcasmFwdFnN`) that forwards through a `//go:linkname` alias. At the machine level that is asm → ABI0 bridge → wrapper frame → ABI bridge → callee — several frames per call, paid on hot kernel paths (the go-llama decode profile shows the forwarding frames around the hot mul_mat/vec_dot cluster).

## What

- `calleeSig` emits a direct spelled reference — `CALL github·com∕goccy∕...∕p1·Fn19(SB)` — for remote fns captured on the same arch when the import path is plan-9-spellable (the asm lexer folds U+00B7/U+2215 to `.`/`/`). Hyphenated host paths keep the historical wrapper.
- Fallback fns (pure Go body, no TEXT) get a `gcasmABI0Keep` anchor in their own package's asm, forcing the compiler to emit the ABI0 wrapper the direct CALL links against — the decision stays package-local, no two-pass.
- The fn-owner map is per arch (a fn's TEXT/anchor existence is per arch).

## Testing

- New `cg_crosscall` fixture: direct calls across padded functions plus a wide-signature sig-fallback fn; under a 64-byte chunk budget every function lands in its own chunk package.
- gate4 now also runs it in multi-chunk + dotted-import-path layout — the gcasm build's export outputs match the pure build exactly, through both the direct TEXT calls and the keep-anchor wrapper path.
- `TestCrossChunkDirectCalls` / `TestCrossChunkWrapperFallback` assert the emitted shapes; `make lint` clean, full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)