### PR TITLE
gcasm: amd64 cross-chain raw dots for the repack kernels + F16C scale conversion

### DIFF
--- a/cmd/wasm2go/main.go
+++ b/cmd/wasm2go/main.go
@@ -44,6 +44,7 @@ func main() {
 	fuseLoopUnroll := flag.Int("fuse-loop-unroll", 0, "in-splice unroll factor for fused loops (2..8; 0 disables)")
 	noF16Table := flag.Bool("no-f16-table", false, "disable the f16-table-keyed rewrites (the table address is auto-detected from the module; this switch turns the rewrites off entirely)")
 	fastMath := flag.Bool("fast-math", false, "allow asm splices that trade wasm bit-exactness for native-style rounding (SDOT raw grouping, FMA, SMMLA pairing)")
+	noRepackGemm := flag.Bool("no-repack-gemm", false, "keep the transformed wasm lowering for an exported dbg_gemm_q8_0_4x4 instead of the native tile-kernel retarget (A/B comparison; the retarget itself requires -fast-math)")
 	fuseDebug := flag.Bool("fuse-debug", false, "print SIMD fusion diagnostics (failed window trials and loop-upgrade rejections) to stderr")
 	vecDotPairEntry := flag.Int("vec-dot-pair-entry", 0, "trait-table entry index whose self vec_dot should pair rows/columns (0 disables; structural verification decides whether it applies)")
 	vecDotRows := flag.Bool("vec-dot-rows", false, "batch the verified vec_dot's caller row loops through a row-looped companion (requires -vec-dot-pair-entry)")
@@ -105,6 +106,7 @@ func main() {
 		FuseLoopUnroll:      *fuseLoopUnroll,
 		DisableF16Table:     *noF16Table,
 		FastMath:            *fastMath,
+		DisableRepackGemm:   *noRepackGemm,
 		FuseDebug:           *fuseDebug,
 		VecDotPairEntry:     *vecDotPairEntry,
 		DirectAsmFuncs:      splitCommaList(*directAsm),

--- a/internal/codegen/simd_fuse_loop.go
+++ b/internal/codegen/simd_fuse_loop.go
@@ -908,6 +908,138 @@ func (sc *simdScalarizer) tryFuseLoop(f *ast.ForStmt, prelude *[]ast.Stmt) (ast.
 		}
 		droppedBump[name] = true
 	}
+	// Derived slots of DIRECTLY-bumped arguments: an argument whose
+	// hoisted defining statement is `p + invariant`, with p itself a
+	// bumped scalar slot, advances in lockstep with p. The hoisted
+	// initial reads p's pre-loop value — exactly the slot's correct
+	// base — so give the slot p's step and exempt the definition from
+	// the invariance check below. (The reassociation above only
+	// covers bump targets that are NOT arguments themselves.)
+	directStep := map[string]ast.Expr{}
+	for _, bst := range cl.bumps {
+		name := bst.Lhs[0].(*ast.Ident).Name
+		if _, sok := scalarSlot[name]; sok {
+			directStep[name] = bst.Rhs[0].(*ast.BinaryExpr).Y
+		}
+	}
+	bumpedSlot := map[int]bool{}
+	for _, b := range loop.Bumps {
+		bumpedSlot[b.Scalar] = true
+	}
+	exemptWpre := map[ast.Stmt]bool{}
+	// invariantExpr: a resolvable constant, or a variable the loop
+	// never writes.
+	invariantExpr := func(e ast.Expr) bool {
+		if _, cok := resolveC(e); cok {
+			return true
+		}
+		id, iok := unwrapWidth(e).(*ast.Ident)
+		return iok && !bodyWrites[id.Name]
+	}
+	// affineBase resolves `bumpedArg ± invariants`, possibly through
+	// hoisted defining statements (the emitter derives per-iteration
+	// addresses in one or two steps). The base keeps coefficient +1 —
+	// it may not appear as a subtrahend — so the derived slot advances
+	// by exactly the base's step.
+	var affineBase func(e ast.Expr, depth int) (string, []ast.Stmt, bool)
+	affineBase = func(e ast.Expr, depth int) (string, []ast.Stmt, bool) {
+		if depth > 4 {
+			return "", nil, false
+		}
+		switch x := e.(type) {
+		case *ast.Ident:
+			if directStep[x.Name] != nil {
+				return x.Name, nil, true
+			}
+			if def := wpreDef(x.Name); def != nil {
+				if base, defs, ok := affineBase(def.Rhs[0], depth+1); ok {
+					return base, append(defs, ast.Stmt(def)), true
+				}
+			}
+			return "", nil, false
+		case *ast.ParenExpr:
+			return affineBase(x.X, depth+1)
+		case *ast.CallExpr:
+			if id, iok := x.Fun.(*ast.Ident); iok && len(x.Args) == 1 {
+				switch id.Name {
+				case "int32", "int64", "uint32", "uint64":
+					return affineBase(x.Args[0], depth+1)
+				}
+			}
+			return "", nil, false
+		case *ast.BinaryExpr:
+			if x.Op != token.ADD && x.Op != token.SUB {
+				return "", nil, false
+			}
+			if base, defs, ok := affineBase(x.X, depth+1); ok && invariantExpr(x.Y) {
+				return base, defs, true
+			}
+			if x.Op == token.ADD {
+				if base, defs, ok := affineBase(x.Y, depth+1); ok && invariantExpr(x.X) {
+					return base, defs, true
+				}
+			}
+			return "", nil, false
+		}
+		return "", nil, false
+	}
+	for i := 0; i < tree.NumScalars; i++ {
+		if bumpedSlot[i] {
+			continue
+		}
+		base, defs, aok := affineBase(unwrapWidth(call.Args[1+i]), 0)
+		if !aok || len(defs) == 0 {
+			continue
+		}
+		if !addBump(i, "_", directStep[base]) {
+			continue
+		}
+		bumpedSlot[i] = true
+		for _, d := range defs {
+			exemptWpre[d] = true
+		}
+	}
+	removedWpre := map[ast.Stmt]bool{}
+	// Uses that survive the upgrade: the fused call's arguments and
+	// the other leftover interveners. A variable read only by
+	// statements the window CONSUMED (its consumers now live inside
+	// the tree, which recomputes the value) is dead once the loop
+	// fuses.
+	liveUses := map[string]int{}
+	countIdents := func(e ast.Expr) {
+		ast.Inspect(e, func(n ast.Node) bool {
+			if id, ok := n.(*ast.Ident); ok && id.Name != "_" {
+				liveUses[id.Name]++
+			}
+			return true
+		})
+	}
+	for _, a := range call.Args {
+		countIdents(a)
+	}
+	for _, st := range wpre {
+		if as, aok := st.(*ast.AssignStmt); aok {
+			for _, r := range as.Rhs {
+				countIdents(r)
+			}
+		}
+	}
+	for _, st := range wpre {
+		as, aok := st.(*ast.AssignStmt)
+		if !aok || len(as.Lhs) != 1 || len(as.Rhs) != 1 {
+			continue
+		}
+		lhs, lok := as.Lhs[0].(*ast.Ident)
+		if !lok {
+			continue
+		}
+		// A dead intervener drops: its only readers were consumed
+		// into the fused tree (which recomputes the value through its
+		// own scalar chain), and nothing outside the loop reads it.
+		if liveUses[lhs.Name] == 0 && sc.identCount[lhs.Name] <= inLoop[lhs.Name]+1 && !hasSideEffects(as.Rhs[0]) {
+			removedWpre[st] = true
+		}
+	}
 	loop.NumDeltas = len(deltaArgs)
 	// The counter joins as one extra scalar (slot NumScalars); its
 	// final value and the bump pointers' final values return as extra
@@ -974,6 +1106,12 @@ func (sc *simdScalarizer) tryFuseLoop(f *ast.ForStmt, prelude *[]ast.Stmt) (ast.
 		delete(writes, name)
 	}
 	for _, st := range wpre {
+		// Consumed by the passes above: a derived-slot initial
+		// hoists by construction (it reads pre-loop values and the
+		// slot advances via its bump), and a dead intervener drops.
+		if exemptWpre[st] || removedWpre[st] {
+			continue
+		}
 		as, ok := st.(*ast.AssignStmt)
 		if !ok {
 			return sc.loopReject("L735")
@@ -1003,7 +1141,12 @@ func (sc *simdScalarizer) tryFuseLoop(f *ast.ForStmt, prelude *[]ast.Stmt) (ast.
 	for _, cs := range cl.consts {
 		*prelude = append(*prelude, cs)
 	}
-	*prelude = append(*prelude, wpre...)
+	for _, st := range wpre {
+		if removedWpre[st] {
+			continue
+		}
+		*prelude = append(*prelude, st)
+	}
 	args := make([]ast.Expr, 0, len(call.Args)+1)
 	args = append(args, call.Args[:1+tree.NumScalars]...)
 	args = append(args, newID(cl.counter.Name))
@@ -1236,5 +1379,34 @@ func fusedLoopDecl(name string, loop *simdfuse.Loop, multiPackage bool) *ast.Fun
 		Name: newID(name),
 		Type: &ast.FuncType{Params: &ast.FieldList{List: params}, Results: &ast.FieldList{List: results}},
 		Body: &ast.BlockStmt{List: body},
+	}
+}
+
+// hasSideEffects reports whether dropping an expression could change
+// program behavior: anything but idents, constants, conversions,
+// arithmetic and the inline memory-load form (whose only effect — a
+// wasm OOB trap — cannot fire here: validated modules do not trap on
+// addresses their own loop is about to dereference) is kept.
+func hasSideEffects(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident, *ast.BasicLit:
+		return false
+	case *ast.BinaryExpr:
+		return hasSideEffects(x.X) || hasSideEffects(x.Y)
+	case *ast.ParenExpr:
+		return hasSideEffects(x.X)
+	case *ast.CallExpr:
+		// Width conversions only (int64(v), uint64(v), ...).
+		id, ok := x.Fun.(*ast.Ident)
+		if !ok || len(x.Args) != 1 {
+			return true
+		}
+		switch id.Name {
+		case "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "uint", "int":
+			return hasSideEffects(x.Args[0])
+		}
+		return true
+	default:
+		return true
 	}
 }

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -157,6 +157,12 @@ type Options struct {
 	// gate it and validate with token-level equivalence instead of
 	// byte-equality probes.
 	FastMath bool
+	// DisableRepackGemm opts out of the repack GEMM retarget: under
+	// FastMath, the asm bundle replaces an exported dbg_gemm_q8_0_4x4
+	// body wholesale with a native 4x4 tile kernel; this switch keeps
+	// the transformed wasm lowering instead. It exists for A/B
+	// comparison and fault isolation of that one replacement.
+	DisableRepackGemm bool
 	// VecDotPairEntry opts into vec_dot row/column pairing: it names
 	// the per-type trait-table entry (the source runtime's type-enum
 	// value) whose self-dot should run two rows and columns per call

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -72,6 +72,25 @@ type SynthSig struct {
 	Packed bool
 }
 
+// repackGemmExport resolves the repack GEMM retarget target: llama-wasm
+// exports its wasm-shaped q8_0x4 GEMM under a stable debug name so the
+// transpiler can swap the whole body for a native 4x4 tile kernel (see
+// a64RepackGemmKernel / x64RepackGemmKernel). FastMath only — the
+// kernel fuses the per-block scale multiply-accumulate — and subject
+// to the DisableRepackGemm opt-out. Returns the FnN symbol, or ""
+// when the retarget is off or the export is absent.
+func repackGemmExport(mod *wasm.Module, cfg Config) string {
+	if !cfg.FastMath || cfg.DisableRepackGemm {
+		return ""
+	}
+	for _, e := range mod.Exports {
+		if e.Kind == wasm.ExportFunc && e.Name == "dbg_gemm_q8_0_4x4" {
+			return fmt.Sprintf("Fn%d", e.Index)
+		}
+	}
+	return ""
+}
+
 func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importPath string, fused map[string]*simdfuse.Tree, fusedLoops map[string]*simdfuse.Loop, outlined map[string][]string, synth map[string]SynthSig, nrc2 *Nrc2Spec, cfg Config) (map[string][]byte, *BuildStats, error) {
 	all := map[string][]byte{}
 	if len(mainSrc) > 0 {
@@ -82,19 +101,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	}
 	pure := PureFilter(all)
 
-	// The repack GEMM retarget: llama-wasm exports its wasm-shaped
-	// q8_0x4 GEMM under a stable debug name so the transpiler can
-	// swap the whole body for a native 4x4 tile kernel (see
-	// a64RepackGemmKernel / x64RepackGemmKernel). Fast-math only —
-	// the kernel fuses the per-block scale multiply-accumulate.
-	repackGemmFn := ""
-	if cfg.FastMath && os.Getenv("WASM2GO_NO_REPACK_GEMM") == "" {
-		for _, e := range mod.Exports {
-			if e.Kind == wasm.ExportFunc && e.Name == "dbg_gemm_q8_0_4x4" {
-				repackGemmFn = fmt.Sprintf("Fn%d", e.Index)
-			}
-		}
-	}
+	repackGemmFn := repackGemmExport(mod, cfg)
 
 	// Capture tree.
 	dir, err := os.MkdirTemp("", "gcasm-capture-*")

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -82,6 +82,20 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	}
 	pure := PureFilter(all)
 
+	// The repack GEMM retarget: llama-wasm exports its wasm-shaped
+	// q8_0x4 GEMM under a stable debug name so the transpiler can
+	// swap the whole body for a native 4x4 tile kernel (see
+	// a64RepackGemmKernel / x64RepackGemmKernel). Fast-math only —
+	// the kernel fuses the per-block scale multiply-accumulate.
+	repackGemmFn := ""
+	if cfg.FastMath {
+		for _, e := range mod.Exports {
+			if e.Kind == wasm.ExportFunc && e.Name == "dbg_gemm_q8_0_4x4" {
+				repackGemmFn = fmt.Sprintf("Fn%d", e.Index)
+			}
+		}
+	}
+
 	// Capture tree.
 	dir, err := os.MkdirTemp("", "gcasm-capture-*")
 	if err != nil {
@@ -265,7 +279,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 			if len(pfns) == 0 {
 				continue
 			}
-			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, cfg)
+			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, repackGemmFn, cfg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("gcasm bundle %s/%s: %w", pkgOrRoot(rel), spec.name, err)
 			}
@@ -630,6 +644,7 @@ func buildPkg(
 	outlinedNames []string,
 	synth map[string]SynthSig,
 	nrc2 *Nrc2Spec,
+	repackGemmFn string,
 	cfg Config,
 ) (map[string][]byte, error) {
 	directSSA := cfg.DirectAsm
@@ -872,6 +887,32 @@ func buildPkg(
 			// backend keep the bit-exact Go companion. The kernel and
 			// its declaration follow the module's pointer width — the
 			// LP64 companion takes i64 pointers and strides.
+			// Repack GEMM: the feature body is replaced WHOLESALE by
+			// the native 4x4 tile kernel (a64: by-element SDOT under
+			// the dotprod gate; x64: AVX2 with a VNNI entry branch
+			// under the AVX2 gate). The portable twin keeps the
+			// transformed wasm body, and the existing dual-body stub
+			// dispatches between them.
+			if repackGemmFn != "" && name == repackGemmFn && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {
+				trapSym := "wasm_trap_simd_oob"
+				if rel != "" && rel != "base" {
+					trapSym = "gcasmFwdH_base_Wasm_trap_simd_oob"
+				}
+				wide := mod.Memory64()
+				if arch.name == "amd64" {
+					featBody = x64RepackGemmKernel(featSym, trapSym, modOffs, pool, wide)
+					if !mirrorVars["gcasmHasAVX512VNNI"] {
+						mirrorVars["gcasmHasAVX512VNNI"] = true
+						vnniRef := "HasAVX512VNNI"
+						if rel != "" && rel != "base" {
+							vnniRef = "base." + vnniRef
+						}
+						fmt.Fprintf(&declFns, "// gcasmHasAVX512VNNI mirrors %s for the tile kernels'\n// entry branches (asm reads package-local data only).\nvar gcasmHasAVX512VNNI = %s\n\n", vnniRef, vnniRef)
+					}
+				} else {
+					featBody = a64RepackGemmKernel(featSym, trapSym, modOffs, wide)
+				}
+			}
 			if nrc2 != nil && name == nrc2.VecDot && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {
 				fastSym := nrc2.Companion + "fast"
 				retargeted := strings.ReplaceAll(featBody, "·"+nrc2.Companion+"(SB)", "·"+fastSym+"(SB)")

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -88,7 +88,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	// a64RepackGemmKernel / x64RepackGemmKernel). Fast-math only —
 	// the kernel fuses the per-block scale multiply-accumulate.
 	repackGemmFn := ""
-	if cfg.FastMath {
+	if cfg.FastMath && os.Getenv("WASM2GO_NO_REPACK_GEMM") == "" {
 		for _, e := range mod.Exports {
 			if e.Kind == wasm.ExportFunc && e.Name == "dbg_gemm_q8_0_4x4" {
 				repackGemmFn = fmt.Sprintf("Fn%d", e.Index)

--- a/internal/gcasm/repackgemm_a64.go
+++ b/internal/gcasm/repackgemm_a64.go
@@ -1,0 +1,203 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// a64RepackGemmKernel emits the q8_0x4 repack GEMM under sym: the
+// 4-rows x 4-columns tile the native q8_0_4x4 dotprod path computes,
+// replacing the engine's four sequential gemv-shaped passes. The wasm
+// activation block (block_q8_0x4) already interleaves the four rows'
+// 4-byte groups contiguously, so each 16-byte weight group pairs with
+// ONE 16-byte activation load and four BY-ELEMENT SDOTs:
+//
+//	sdot vAcc_r.4s, vWeights.16b, vActs.4b[r]
+//
+// — one instruction per (weight group, row), the native kernel's own
+// shape. Per block the four per-row i32x4 column sums convert once,
+// scale by d_col[4]*d_row (FMUL by element + vector FMLA), and
+// accumulate into four f32x4 row accumulators that store once per
+// column group. Integer arithmetic is exact; the f32 accumulation
+// keeps the same per-row block order as the sequential form but fuses
+// mul+add (single rounding), so the retarget is fast-math-only, like
+// the nrc2 tile kernel.
+//
+// C signature (see llama-wasm's arch/wasm/repack.cpp):
+//
+//	gemm(int n, float *s, size_t bs, void *vx, void *vy, int nr, int nc)
+//
+// with n%32==0, nr%4==0, nc%4==0 by the caller's contract; memory
+// safety does not rely on that contract — every span the loops will
+// touch is bounds-checked against memSize at entry.
+//
+// ABI0 stack args mirror the transformed Go body. ILP32: m+0,
+// l0(n)+8, l1(s)+12, l2(bs)+16, l3(vx)+20, l4(vy)+24, l5(nr)+28,
+// l6(nc)+32. LP64: l1..l4 are int64, 8-aligned — l0+8, l1+16, l2+24,
+// l3+32, l4+40, l5(nr)+48, l6(nc)+52.
+//
+// Requires FEAT_DotProd; callers gate the retarget on the dotprod
+// feature dispatch that guards the SDOT bodies.
+func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+	word := func(enc uint32, dis string) { w("\tWORD $0x%08x // %s", enc, dis) }
+	ldurQ := func(rt, rn, imm int) {
+		word(0x3CC00000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur q%d, [x%d, #%d]", rt, rn, imm))
+	}
+	sturQ := func(rt, rn, imm int) {
+		word(0x3C800000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("stur q%d, [x%d, #%d]", rt, rn, imm))
+	}
+	ldurD := func(rt, rn, imm int) {
+		word(0xFC400000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur d%d, [x%d, #%d]", rt, rn, imm))
+	}
+	movi0 := func(d int) { word(0x4F000400|uint32(d), fmt.Sprintf("movi v%d.4s, #0", d)) }
+	// SDOT (by element, 4S): acc.4s += dot4(weights.16b per lane,
+	// acts.4b[idx]).
+	sdotLane := func(d, n, m, idx int) {
+		enc := 0x4F80E000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
+		word(enc, fmt.Sprintf("sdot v%d.4s, v%d.16b, v%d.4b[%d]", d, n, m, idx))
+	}
+	fcvtl := func(d, n int) { word(0x0E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl v%d.4s, v%d.4h", d, n)) }
+	scvtf := func(d, n int) { word(0x4E21D800|uint32(n)<<5|uint32(d), fmt.Sprintf("scvtf v%d.4s, v%d.4s", d, n)) }
+	fmulLane := func(d, n, m, idx int) {
+		enc := 0x4F809000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
+		word(enc, fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+	}
+	fmlaV := func(d, n, m int) {
+		word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+
+	argOff := map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}
+	movArg, argBytes := "MOVWU", 36
+	if wide {
+		argOff = map[string]int{"l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 52}
+		movArg, argBytes = "MOVD", 56
+	}
+	arg := func(name string, reg int) {
+		mv := movArg
+		if name == "l5" || name == "l6" {
+			mv = "MOVWU" // nr/nc stay int32 at either width
+		}
+		w("\t%s\t%s+%d(FP), R%d", mv, name, argOff[name], reg)
+	}
+
+	w("// %s: q8_0x4 repack GEMM, 4x4 tile via by-element SDOT.", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	// nb = n >> 5; xtotal = nb*136 (the per-column-group byte span:
+	// nb interleaved blocks of 8-byte scales + 128-byte quants).
+	w("\tMOVW\tl0+8(FP), R1")
+	w("\tLSRW\t$5, R1, R1")
+	w("\tMOVD\t$136, R8")
+	w("\tMUL\tR1, R8, R8")
+	arg("l5", 6)
+	w("\tLSRW\t$2, R6, R6") // nr/4
+	arg("l6", 7)
+	w("\tLSRW\t$2, R7, R7") // nc/4
+	// Empty problem: nothing is read or written.
+	w("\tCBZW\tR6, gemmdone")
+	w("\tCBZW\tR7, gemmdone")
+	// Bounds: vx + nc4*xtotal, vy + nr4*xtotal, and the last store
+	// byte s + ((nr-1)*bs + nc)*4 must all sit inside memSize.
+	arg("l3", 4)
+	w("\tMUL\tR7, R8, R26")
+	w("\tADD\tR4, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tgemmoob")
+	arg("l4", 5)
+	w("\tMUL\tR6, R8, R26")
+	w("\tADD\tR5, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tgemmoob")
+	arg("l1", 2)
+	arg("l2", 3)
+	w("\tLSL\t$2, R3, R3") // bs in bytes
+	w("\tLSL\t$2, R6, R9")
+	w("\tSUB\t$1, R9, R9") // nr-1
+	w("\tMUL\tR3, R9, R26")
+	w("\tADD\tR2, R26, R26")
+	w("\tLSL\t$4, R7, R9")
+	w("\tADD\tR9, R26, R26") // + nc*4 bytes
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tgemmoob")
+	// Host pointers: activations row-group cursor, output row cursor.
+	w("\tADD\tR20, R5, R10") // a base (host)
+	w("\tADD\tR20, R2, R11") // s row base (host)
+	w("\tADD\tR20, R4, R22") // vx base (host)
+	w("\tLSL\t$2, R3, R23")  // 4*bs bytes: s row-group stride
+	w("gemmy:")
+	w("\tMOVD\tR22, R13") // b column-group cursor
+	w("\tMOVD\tR11, R14") // s column cursor
+	w("\tMOVD\tR7, R12")  // x counter
+	w("gemmx:")
+	movi0(28)
+	movi0(29)
+	movi0(30)
+	movi0(31)
+	w("\tMOVD\tR13, R16") // bp
+	w("\tMOVD\tR10, R17") // ap
+	w("\tMOVD\tR1, R15")  // block counter
+	w("\tCBZW\tR15, gemmstore")
+	w("gemmblk:")
+	movi0(24)
+	movi0(25)
+	movi0(26)
+	movi0(27)
+	for k := 0; k < 8; k++ {
+		ldurQ(0, 16, 8+16*k)
+		ldurQ(1, 17, 8+16*k)
+		sdotLane(24, 0, 1, 0)
+		sdotLane(25, 0, 1, 1)
+		sdotLane(26, 0, 1, 2)
+		sdotLane(27, 0, 1, 3)
+	}
+	// Scales: column d[4] and row d[4] (f16 -> f32), then per row
+	// sumv_r += f32(acc_r) * (dcol * drow[r]).
+	ldurD(2, 16, 0)
+	fcvtl(2, 2)
+	ldurD(3, 17, 0)
+	fcvtl(3, 3)
+	scvtf(24, 24)
+	scvtf(25, 25)
+	scvtf(26, 26)
+	scvtf(27, 27)
+	fmulLane(4, 2, 3, 0)
+	fmlaV(28, 24, 4)
+	fmulLane(4, 2, 3, 1)
+	fmlaV(29, 25, 4)
+	fmulLane(4, 2, 3, 2)
+	fmlaV(30, 26, 4)
+	fmulLane(4, 2, 3, 3)
+	fmlaV(31, 27, 4)
+	w("\tADD\t$136, R16, R16")
+	w("\tADD\t$136, R17, R17")
+	w("\tSUBW\t$1, R15, R15")
+	w("\tCBNZW\tR15, gemmblk")
+	w("gemmstore:")
+	sturQ(28, 14, 0)
+	w("\tADD\tR14, R3, R26")
+	sturQ(29, 26, 0)
+	w("\tADD\tR26, R3, R26")
+	sturQ(30, 26, 0)
+	w("\tADD\tR26, R3, R26")
+	sturQ(31, 26, 0)
+	w("\tADD\tR8, R13, R13")  // next column group's weights
+	w("\tADD\t$16, R14, R14") // next 4 output floats
+	w("\tSUBW\t$1, R12, R12")
+	w("\tCBNZW\tR12, gemmx")
+	w("\tADD\tR8, R10, R10")  // next activation row group
+	w("\tADD\tR23, R11, R11") // next 4 output rows
+	w("\tSUBW\t$1, R6, R6")
+	w("\tCBNZW\tR6, gemmy")
+	w("gemmdone:")
+	w("\tRET")
+	w("gemmoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/repackgemm_a64.go
+++ b/internal/gcasm/repackgemm_a64.go
@@ -18,10 +18,12 @@ import (
 // shape. Per block the four per-row i32x4 column sums convert once,
 // scale by d_col[4]*d_row (FMUL by element + vector FMLA), and
 // accumulate into four f32x4 row accumulators that store once per
-// column group. Integer arithmetic is exact; the f32 accumulation
-// keeps the same per-row block order as the sequential form but fuses
-// mul+add (single rounding), so the retarget is fast-math-only, like
-// the nrc2 tile kernel.
+// column group. Integer arithmetic is exact, and the f32 tail keeps
+// the wasm gemm's own multiply/multiply/add sequence and rounding —
+// the same sequence the fused GEMV loops execute — so the batched
+// and single-row paths stay as close as the wasm semantics themselves
+// (prompt batch-size invariance depends on it). FastMath-gated only
+// because the retarget replaces the verified wasm lowering wholesale.
 //
 // C signature (see llama-wasm's arch/wasm/repack.cpp):
 //
@@ -64,8 +66,11 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 		enc := 0x4F809000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
 		word(enc, fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
 	}
-	fmlaV := func(d, n, m int) {
-		word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	fmulV := func(d, n, m int) {
+		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+	faddV := func(d, n, m int) {
+		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
 
 	argOff := map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}
@@ -167,13 +172,17 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	scvtf(26, 26)
 	scvtf(27, 27)
 	fmulLane(4, 2, 3, 0)
-	fmlaV(28, 24, 4)
+	fmulV(5, 24, 4)
+	faddV(28, 28, 5)
 	fmulLane(4, 2, 3, 1)
-	fmlaV(29, 25, 4)
+	fmulV(5, 25, 4)
+	faddV(29, 29, 5)
 	fmulLane(4, 2, 3, 2)
-	fmlaV(30, 26, 4)
+	fmulV(5, 26, 4)
+	faddV(30, 30, 5)
 	fmulLane(4, 2, 3, 3)
-	fmlaV(31, 27, 4)
+	fmulV(5, 27, 4)
+	faddV(31, 31, 5)
 	w("\tADD\t$136, R16, R16")
 	w("\tADD\t$136, R17, R17")
 	w("\tSUBW\t$1, R15, R15")

--- a/internal/gcasm/repackgemm_a64.go
+++ b/internal/gcasm/repackgemm_a64.go
@@ -40,6 +40,17 @@ import (
 //
 // Requires FEAT_DotProd; callers gate the retarget on the dotprod
 // feature dispatch that guards the SDOT bodies.
+// repackGemmArgs returns the ABI0 stack offsets of the GEMM's l1..l6
+// arguments and the frame's argument-byte count for the module's
+// pointer width (see the layout comment above). Shared by the a64 and
+// x64 emitters — the frame is arch-independent.
+func repackGemmArgs(wide bool) (map[string]int, int) {
+	if wide {
+		return map[string]int{"l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 52}, 56
+	}
+	return map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}, 36
+}
+
 func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
 	var b strings.Builder
 	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
@@ -73,11 +84,10 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
 
-	argOff := map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}
-	movArg, argBytes := "MOVWU", 36
+	argOff, argBytes := repackGemmArgs(wide)
+	movArg := "MOVWU"
 	if wide {
-		argOff = map[string]int{"l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 52}
-		movArg, argBytes = "MOVD", 56
+		movArg = "MOVD"
 	}
 	arg := func(name string, reg int) {
 		mv := movArg

--- a/internal/gcasm/repackgemm_test.go
+++ b/internal/gcasm/repackgemm_test.go
@@ -16,6 +16,7 @@ func TestRepackGemmKernelShape(t *testing.T) {
 		"sdot v24.4s, v0.16b, v1.4b[0]",
 		"sdot v27.4s, v0.16b, v1.4b[3]",
 		"fmul v4.4s, v2.4s, v3.s[3]",
+		"fadd v31.4s, v31.4s, v5.4s",
 		"fcvtl v2.4s, v2.4h",
 		"gemmblk:", "gemmoob:",
 	} {
@@ -26,7 +27,7 @@ func TestRepackGemmKernelShape(t *testing.T) {
 	pool := &ConstPool{}
 	x := x64RepackGemmKernel("Fn9avx2", "trapstub", offs, pool, true)
 	for _, want := range []string{
-		"VPDPBUSD", "VPMADDWD", "VPHADDD", "VCVTPH2PS", "VFMADD231PS",
+		"VPDPBUSD", "VPMADDWD", "VPHADDD", "VCVTPH2PS", "VADDPS",
 		"gcasmHasAVX512VNNI", "vgemmblk:", "gemmblk:", "VZEROUPPER",
 	} {
 		if !strings.Contains(x, want) {

--- a/internal/gcasm/repackgemm_test.go
+++ b/internal/gcasm/repackgemm_test.go
@@ -1,0 +1,265 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRepackGemmKernelShape(t *testing.T) {
+	offs := &ModuleOffsets{M: 8, MemSize: 0}
+	a := a64RepackGemmKernel("Fn9dotprod", "trapstub", offs, true)
+	for _, want := range []string{
+		"sdot v24.4s, v0.16b, v1.4b[0]",
+		"sdot v27.4s, v0.16b, v1.4b[3]",
+		"fmul v4.4s, v2.4s, v3.s[3]",
+		"fcvtl v2.4s, v2.4h",
+		"gemmblk:", "gemmoob:",
+	} {
+		if !strings.Contains(a, want) {
+			t.Errorf("a64 kernel missing %q", want)
+		}
+	}
+	pool := &ConstPool{}
+	x := x64RepackGemmKernel("Fn9avx2", "trapstub", offs, pool, true)
+	for _, want := range []string{
+		"VPDPBUSD", "VPMADDWD", "VPHADDD", "VCVTPH2PS", "VFMADD231PS",
+		"gcasmHasAVX512VNNI", "vgemmblk:", "gemmblk:", "VZEROUPPER",
+	} {
+		if !strings.Contains(x, want) {
+			t.Errorf("x64 kernel missing %q", want)
+		}
+	}
+}
+
+// repackGemmRunSrc is the shared execution driver: builds a q8_0x4
+// problem in a mock module memory, runs the kernel, and compares
+// against a scalar reference (float64 accumulation, small relative
+// tolerance — the kernel fuses mul+add).
+const repackGemmRunSrc = `package gemmrun
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+type mockModule struct {
+	memSizePtr *uint64
+	mem        unsafe.Pointer
+}
+
+func f16bits(f float32) uint16 {
+	b := math.Float32bits(f)
+	sign := uint16(b>>16) & 0x8000
+	exp := int32(b>>23&0xFF) - 127 + 15
+	man := b >> 13 & 0x3FF
+	if exp <= 0 || exp >= 31 {
+		return sign | 0x3C00 // clamp to 1.0 for test data
+	}
+	return sign | uint16(exp)<<10 | uint16(man)
+}
+
+func f16val(h uint16) float64 {
+	sign := float64(1)
+	if h&0x8000 != 0 {
+		sign = -1
+	}
+	exp := int32(h >> 10 & 0x1F)
+	man := float64(h & 0x3FF)
+	if exp == 0 {
+		return sign * man / 1024 * math.Pow(2, -14)
+	}
+	return sign * (1 + man/1024) * math.Pow(2, float64(exp-15))
+}
+
+const (
+	n  = 64 // nb = 2
+	nr = 8
+	nc = 8
+	bs = 10 // output row stride in floats (> nc to catch stride bugs)
+)
+
+func buildProblem(mem []byte, sOff, vxOff, vyOff int) {
+	nb := n / 32
+	rng := uint32(0x12345)
+	nextI8 := func() int8 {
+		rng = rng*1664525 + 1013904223
+		return int8(int32(rng>>24)%255 - 127)
+	}
+	fill := func(off, groups int) {
+		for g := 0; g < groups; g++ {
+			base := off + g*136
+			for j := 0; j < 4; j++ {
+				h := f16bits(1.0 + float32(g%3)*0.5 + float32(j)*0.25)
+				mem[base+2*j] = byte(h)
+				mem[base+2*j+1] = byte(h >> 8)
+			}
+			for i := 0; i < 128; i++ {
+				mem[base+8+i] = byte(nextI8())
+			}
+		}
+	}
+	fill(vxOff, (nc/4)*nb)
+	fill(vyOff, (nr/4)*nb)
+	_ = sOff
+}
+
+func reference(mem []byte, vxOff, vyOff int) [nr][nc]float64 {
+	nb := n / 32
+	var out [nr][nc]float64
+	for y := 0; y < nr/4; y++ {
+		for x := 0; x < nc/4; x++ {
+			for l := 0; l < nb; l++ {
+				a := vyOff + (y*nb+l)*136
+				bq := vxOff + (x*nb+l)*136
+				for row := 0; row < 4; row++ {
+					da := f16val(uint16(mem[a+2*row]) | uint16(mem[a+2*row+1])<<8)
+					for col := 0; col < 4; col++ {
+						db := f16val(uint16(mem[bq+2*col]) | uint16(mem[bq+2*col+1])<<8)
+						sumi := 0
+						for k := 0; k < 8; k++ {
+							for i := 0; i < 4; i++ {
+								w := int8(mem[bq+8+k*16+col*4+i])
+								av := int8(mem[a+8+k*16+row*4+i])
+								sumi += int(w) * int(av)
+							}
+						}
+						out[y*4+row][x*4+col] += float64(sumi) * da * db
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func runOne(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)) {
+	mem := make([]byte, 1<<16)
+	sOff, vxOff, vyOff := 256, 8192, 32768
+	buildProblem(mem, sOff, vxOff, vyOff)
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	kernel(m, n, int64(sOff), int64(bs), int64(vxOff), int64(vyOff), nr, nc)
+	want := reference(mem, vxOff, vyOff)
+	for r := 0; r < nr; r++ {
+		for c := 0; c < nc; c++ {
+			bits := uint32(mem[sOff+(r*bs+c)*4]) | uint32(mem[sOff+(r*bs+c)*4+1])<<8 |
+				uint32(mem[sOff+(r*bs+c)*4+2])<<16 | uint32(mem[sOff+(r*bs+c)*4+3])<<24
+			got := float64(math.Float32frombits(bits))
+			w := want[r][c]
+			if diff := math.Abs(got - w); diff > 1e-3+1e-4*math.Abs(w) {
+				t.Fatalf("s[%d][%d] = %v, want %v", r, c, got, w)
+			}
+		}
+	}
+}
+`
+
+func writeGemmRunTree(t *testing.T, dir, arch, kernelAsm, extraGo, runTest string) {
+	t.Helper()
+	files := map[string]string{
+		"go.mod": "module gemmrun\n\ngo 1.25.0\n",
+		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + kernelAsm +
+			"\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n",
+		"run.go":      repackGemmRunSrc + extraGo,
+		"run_test.go": runTest,
+	}
+	if arch == "amd64" {
+		files["kernel_"+arch+".s"] = "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + kernelAsm +
+			"\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestA64RepackGemmKernelGate assembles and links the arm64 kernel on
+// every host, and executes the numeric comparison on arm64 hosts
+// (the CI arm64 runner has FEAT_DotProd).
+func TestA64RepackGemmKernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	kernel := a64RepackGemmKernel("GemmKernel", "trapstub", offs, true)
+	dir := t.TempDir()
+	writeGemmRunTree(t, dir, "arm64", kernel,
+		"\nfunc GemmKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\n",
+		`package gemmrun
+
+import "testing"
+
+func TestGemmA64(t *testing.T) { runOne(t, GemmKernel) }
+`)
+	runArm64Gate(t, dir, ".", "TestGemmA64", kernel)
+}
+
+func hostHasAVX2(t *testing.T) bool {
+	t.Helper()
+	switch runtime.GOOS {
+	case "linux":
+		data, err := os.ReadFile("/proc/cpuinfo")
+		return err == nil && strings.Contains(string(data), " avx2")
+	case "darwin":
+		out, err := exec.Command("sysctl", "-n", "hw.optional.avx2_0").Output()
+		return err == nil && strings.TrimSpace(string(out)) == "1"
+	}
+	return false
+}
+
+func hostHasVNNI(t *testing.T) bool {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	data, err := os.ReadFile("/proc/cpuinfo")
+	return err == nil && strings.Contains(string(data), "avx512_vnni")
+}
+
+// TestX64RepackGemmKernelGate assembles and links the amd64 kernel on
+// every host and executes the numeric comparison when the host has
+// AVX2 (both dispatch arms when it also has VNNI).
+func TestX64RepackGemmKernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	pool := &ConstPool{}
+	kernel := x64RepackGemmKernel("GemmKernel", "trapstub", offs, pool, true)
+	dir := t.TempDir()
+	writeGemmRunTree(t, dir, "amd64", kernel+"\n"+pool.Emit(),
+		"\nfunc GemmKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\nvar gcasmHasAVX512VNNI bool\n",
+		`package gemmrun
+
+import "testing"
+
+func TestGemmX64(t *testing.T) {
+	gcasmHasAVX512VNNI = false
+	runOne(t, GemmKernel)
+}
+
+func TestGemmX64VNNI(t *testing.T) {
+	gcasmHasAVX512VNNI = true
+	runOne(t, GemmKernel)
+}
+`)
+	bin := filepath.Join(dir, "gemmrun.test")
+	build := exec.Command("go", "test", "-c", "-o", bin, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOARCH=amd64")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 assemble/link failed: %v\n%s\n--- asm ---\n%s", err, out, kernel)
+	}
+	if runtime.GOARCH != "amd64" || !hostHasAVX2(t) {
+		t.Skipf("assembled+linked OK; skipping execution (GOARCH=%s, avx2=%v)", runtime.GOARCH, hostHasAVX2(t))
+	}
+	runName := "TestGemmX64$"
+	if hostHasVNNI(t) {
+		runName = "TestGemmX64"
+	}
+	cmd := exec.Command(bin, "-test.run", runName, "-test.v")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 execution failed: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/repackgemm_test.go
+++ b/internal/gcasm/repackgemm_test.go
@@ -7,7 +7,29 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/goccy/wasm2go/internal/wasm"
 )
+
+// The retarget fires only under FastMath without the opt-out, and
+// only when the module exports the repack GEMM by its debug name.
+func TestRepackGemmExportGate(t *testing.T) {
+	mod := &wasm.Module{Exports: []wasm.Export{
+		{Name: "dbg_gemm_q8_0_4x4", Kind: wasm.ExportFunc, Index: 9},
+	}}
+	if got := repackGemmExport(mod, Config{FastMath: true}); got != "Fn9" {
+		t.Errorf("FastMath retarget = %q, want Fn9", got)
+	}
+	if got := repackGemmExport(mod, Config{FastMath: true, DisableRepackGemm: true}); got != "" {
+		t.Errorf("DisableRepackGemm retarget = %q, want none", got)
+	}
+	if got := repackGemmExport(mod, Config{}); got != "" {
+		t.Errorf("non-FastMath retarget = %q, want none", got)
+	}
+	if got := repackGemmExport(&wasm.Module{}, Config{FastMath: true}); got != "" {
+		t.Errorf("no-export retarget = %q, want none", got)
+	}
+}
 
 func TestRepackGemmKernelShape(t *testing.T) {
 	offs := &ModuleOffsets{M: 8, MemSize: 0}

--- a/internal/gcasm/repackgemm_test.go
+++ b/internal/gcasm/repackgemm_test.go
@@ -162,16 +162,16 @@ func runOne(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3, l4 in
 
 func writeGemmRunTree(t *testing.T, dir, arch, kernelAsm, extraGo, runTest string) {
 	t.Helper()
+	trapstub := "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n"
+	if arch == "amd64" {
+		trapstub = "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
+	}
 	files := map[string]string{
 		"go.mod": "module gemmrun\n\ngo 1.25.0\n",
-		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + kernelAsm +
-			"\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n",
+		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" +
+			kernelAsm + trapstub,
 		"run.go":      repackGemmRunSrc + extraGo,
 		"run_test.go": runTest,
-	}
-	if arch == "amd64" {
-		files["kernel_"+arch+".s"] = "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" + kernelAsm +
-			"\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
 	}
 	for name, content := range files {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {

--- a/internal/gcasm/repackgemm_x64.go
+++ b/internal/gcasm/repackgemm_x64.go
@@ -1,0 +1,221 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// x64RepackGemmKernel emits the q8_0x4 repack GEMM under sym for
+// amd64 — the 4x4 tile the a64 twin computes with by-element SDOT,
+// with an entry branch to a VNNI loop on CPUs reporting AVX-512 VNNI
+// at 256-bit width. See a64RepackGemmKernel for the tile shape, the
+// bounds-check contract and the fast-math gating; the memory layouts
+// and the ABI0 argument frame are identical.
+//
+// AVX2 nest, per 16-byte weight group: the group sign-extends ONCE
+// across a ymm and each row's broadcast 4-byte activation group
+// multiplies into that row's pair-domain ymm accumulator
+// (VPMADDWD + VPADDD); the four accumulators collapse to per-column
+// i32x4 sums once per block. VNNI nest: VPDPBUSD with the exact +128
+// bias identity — the per-row byte sums the identity needs
+// accumulate in ONE extra VPDPBUSD per group (ones · activation
+// block = all four rows' group sums, one lane each).
+//
+// Register file after the prologue (memSize/M die once the entry
+// checks pass and every pointer is host-absolute):
+//
+//	CX vx base | SI a-row cursor | BX s-row cursor | R8 nb
+//	R9 xtotal | R10 y ctr | R11 nc4 | R14 bs bytes | R15 4*bs
+//	DX b-col cursor | DI s-col cursor | R13 x ctr
+//	R12 bp | AX ap | 0(SP) block ctr
+func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+
+	c16 := func(bt byte) string {
+		blob := make([]byte, 16)
+		for i := range blob {
+			blob[i] = bt
+		}
+		return pool.addBlob(blob)
+	}
+	biasSym := c16(0x80)
+	onesSym := c16(0x01)
+
+	argOff := map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}
+	movArg, argBytes := "MOVL", 36
+	if wide {
+		argOff = map[string]int{"l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 52}
+		movArg, argBytes = "MOVQ", 56
+	}
+	arg := func(name, reg string) {
+		mv := movArg
+		if name == "l5" || name == "l6" {
+			mv = "MOVL"
+		}
+		w("\t%s\t%s+%d(FP), %s", mv, name, argOff[name], reg)
+	}
+	memCheck := func() {
+		w("\tCMPQ\tR15, R12")
+		w("\tJCS\tgemmoob")
+	}
+
+	w("// %s: q8_0x4 repack GEMM, 4x4 tile via AVX2 / VNNI.", sym)
+	w("TEXT ·%s(SB), $8-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R15", offs.MemSize)
+	w("\tMOVQ\t(R15), R15")
+	w("\tMOVQ\t%d(AX), R14", offs.M)
+	w("\tMOVL\tl0+8(FP), R8")
+	w("\tSHRL\t$5, R8")
+	w("\tIMUL3Q\t$136, R8, R9")
+	arg("l5", "R10")
+	w("\tSHRL\t$2, R10")
+	arg("l6", "R11")
+	w("\tSHRL\t$2, R11")
+	w("\tTESTL\tR10, R10")
+	w("\tJZ\tgemmdone")
+	w("\tTESTL\tR11, R11")
+	w("\tJZ\tgemmdone")
+	// Bounds: vx + nc4*xtotal, vy + nr4*xtotal, s + ((nr-1)*bs+nc)*4.
+	arg("l3", "CX")
+	w("\tMOVQ\tR11, R12")
+	w("\tIMULQ\tR9, R12")
+	w("\tADDQ\tCX, R12")
+	memCheck()
+	arg("l4", "SI")
+	w("\tMOVQ\tR10, R12")
+	w("\tIMULQ\tR9, R12")
+	w("\tADDQ\tSI, R12")
+	memCheck()
+	arg("l1", "BX")
+	arg("l2", "DX")
+	w("\tSHLQ\t$2, DX")
+	w("\tMOVQ\tR10, R12")
+	w("\tSHLQ\t$2, R12")
+	w("\tSUBQ\t$1, R12")
+	w("\tIMULQ\tDX, R12")
+	w("\tADDQ\tBX, R12")
+	w("\tMOVQ\tR11, R13")
+	w("\tSHLQ\t$4, R13")
+	w("\tADDQ\tR13, R12")
+	memCheck()
+	// Host pointers; the strides take over memSize/M's registers.
+	w("\tADDQ\tR14, CX")
+	w("\tADDQ\tR14, SI")
+	w("\tADDQ\tR14, BX")
+	w("\tMOVQ\tDX, R14")
+	w("\tMOVQ\tDX, R15")
+	w("\tSHLQ\t$2, R15")
+	fmt.Fprintf(&b, "\tVMOVDQU ·%s(SB), X14\n", onesSym)
+	w("\tCMPB\t·gcasmHasAVX512VNNI(SB), $0")
+	w("\tJNE\tvgemmy")
+
+	// nest emits one complete y/x/block loop nest under the label
+	// prefix; the AVX2 and VNNI bodies differ only in the per-block
+	// integer tile.
+	nest := func(p string, vnni bool) {
+		w("%sy:", p)
+		w("\tMOVQ\tCX, DX")
+		w("\tMOVQ\tBX, DI")
+		w("\tMOVQ\tR11, R13")
+		w("%sx:", p)
+		w("\tVPXOR\tX8, X8, X8")
+		w("\tVPXOR\tX9, X9, X9")
+		w("\tVPXOR\tX10, X10, X10")
+		w("\tVPXOR\tX11, X11, X11")
+		w("\tMOVQ\tDX, R12")
+		w("\tMOVQ\tSI, AX")
+		w("\tMOVL\tR8, 0(SP)")
+		w("\tTESTL\tR8, R8")
+		w("\tJZ\t%sstore", p)
+		w("%sblk:", p)
+		if vnni {
+			w("\tVPXOR\tX0, X0, X0")
+			w("\tVPXOR\tX1, X1, X1")
+			w("\tVPXOR\tX2, X2, X2")
+			w("\tVPXOR\tX3, X3, X3")
+			w("\tVPXOR\tX7, X7, X7")
+			for k := 0; k < 8; k++ {
+				w("\tVMOVDQU\t%d(R12), X4", 8+16*k)
+				fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
+				w("\tVMOVDQU\t%d(AX), X5", 8+16*k)
+				w("\tVPDPBUSD\tX5, X14, X7") // rowsum += group sums
+				for row := 0; row < 4; row++ {
+					w("\tVPSHUFD\t$%#02x, X5, X6", row*0x55)
+					w("\tVPDPBUSD\tX6, X4, X%d", row)
+				}
+			}
+			// acc_row -= 128 * rowsum[row].
+			for row := 0; row < 4; row++ {
+				w("\tVPSHUFD\t$%#02x, X7, X6", row*0x55)
+				w("\tVPSLLD\t$7, X6, X6")
+				w("\tVPSUBD\tX6, X%d, X%d", row, row)
+			}
+		} else {
+			w("\tVPXOR\tY0, Y0, Y0")
+			w("\tVPXOR\tY1, Y1, Y1")
+			w("\tVPXOR\tY2, Y2, Y2")
+			w("\tVPXOR\tY3, Y3, Y3")
+			for k := 0; k < 8; k++ {
+				w("\tVPMOVSXBW\t%d(R12), Y4", 8+16*k)
+				w("\tVMOVDQU\t%d(AX), X5", 8+16*k)
+				for row := 0; row < 4; row++ {
+					w("\tVPSHUFD\t$%#02x, X5, X6", row*0x55)
+					w("\tVPMOVSXBW\tX6, Y6")
+					w("\tVPMADDWD\tY4, Y6, Y6")
+					w("\tVPADDD\tY6, Y%d, Y%d", row, row)
+				}
+			}
+			// Collapse pair-domain ymm to the per-column grouping.
+			for row := 0; row < 4; row++ {
+				w("\tVPHADDD\tY%d, Y%d, Y%d", row, row, row)
+				w("\tVEXTRACTI128\t$1, Y%d, X6", row)
+				w("\tVPUNPCKLQDQ\tX6, X%d, X%d", row, row)
+			}
+		}
+		// Scales: sumv_row += f32(acc_row) * (dcol * drow[row]).
+		w("\tVMOVQ\t(R12), X6")
+		w("\tVCVTPH2PS\tX6, X12")
+		w("\tVMOVQ\t(AX), X6")
+		w("\tVCVTPH2PS\tX6, X13")
+		for row := 0; row < 4; row++ {
+			w("\tVCVTDQ2PS\tX%d, X%d", row, row)
+			w("\tVPSHUFD\t$%#02x, X13, X7", row*0x55)
+			w("\tVMULPS\tX12, X7, X7")
+			w("\tVFMADD231PS\tX7, X%d, X%d", row, 8+row)
+		}
+		w("\tADDQ\t$136, R12")
+		w("\tADDQ\t$136, AX")
+		w("\tDECL\t0(SP)")
+		w("\tJNZ\t%sblk", p)
+		w("%sstore:", p)
+		w("\tVMOVUPS\tX8, (DI)")
+		w("\tLEAQ\t(DI)(R14*1), R12")
+		w("\tVMOVUPS\tX9, (R12)")
+		w("\tADDQ\tR14, R12")
+		w("\tVMOVUPS\tX10, (R12)")
+		w("\tADDQ\tR14, R12")
+		w("\tVMOVUPS\tX11, (R12)")
+		w("\tADDQ\tR9, DX")
+		w("\tADDQ\t$16, DI")
+		w("\tSUBL\t$1, R13")
+		w("\tJNZ\t%sx", p)
+		w("\tADDQ\tR9, SI")
+		w("\tADDQ\tR15, BX")
+		w("\tSUBL\t$1, R10")
+		w("\tJNZ\t%sy", p)
+		w("\tJMP\tgemmdone")
+	}
+	nest("gemm", false)
+	nest("vgemm", true)
+	w("gemmdone:")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("gemmoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/repackgemm_x64.go
+++ b/internal/gcasm/repackgemm_x64.go
@@ -184,7 +184,8 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 			w("\tVCVTDQ2PS\tX%d, X%d", row, row)
 			w("\tVPSHUFD\t$%#02x, X13, X7", row*0x55)
 			w("\tVMULPS\tX12, X7, X7")
-			w("\tVFMADD231PS\tX7, X%d, X%d", row, 8+row)
+			w("\tVMULPS\tX%d, X7, X7", row)
+			w("\tVADDPS\tX7, X%d, X%d", 8+row, 8+row)
 		}
 		w("\tADDQ\t$136, R12")
 		w("\tADDQ\t$136, AX")

--- a/internal/gcasm/repackgemm_x64.go
+++ b/internal/gcasm/repackgemm_x64.go
@@ -42,11 +42,10 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 	biasSym := c16(0x80)
 	onesSym := c16(0x01)
 
-	argOff := map[string]int{"l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32}
-	movArg, argBytes := "MOVL", 36
+	argOff, argBytes := repackGemmArgs(wide)
+	movArg := "MOVL"
 	if wide {
-		argOff = map[string]int{"l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 52}
-		movArg, argBytes = "MOVQ", 56
+		movArg = "MOVQ"
 	}
 	arg := func(name, reg string) {
 		mv := movArg

--- a/internal/gcasm/simdsplice_fuse_a64.go
+++ b/internal/gcasm/simdsplice_fuse_a64.go
@@ -955,6 +955,14 @@ var fusedMemOpsA64 = map[string]int{
 	"v128_load32_splat": 2,
 	"v128_load16x4_u":   2,
 	"v128_load32_lane":  3, // + the v128 operand the lane inserts into
+	// Unchecked twins the x64 loop-level window hoist rewrites narrow
+	// loads into (see x64SpliceLoop). They exist only inside that
+	// splicer's local tree copy — the a64 splicer and the Go fallback
+	// never see them.
+	"v128_load32_splat_nc": 2,
+	"v128_load16x4_u_nc":   2,
+	"v128_load32_zero_nc":  2,
+	"v128_load64_zero_nc":  2,
 }
 
 // dst0Src resolves a store's v128 VALUE operand register: a chained

--- a/internal/gcasm/simdsplice_fuse_crossdot_x64.go
+++ b/internal/gcasm/simdsplice_fuse_crossdot_x64.go
@@ -41,10 +41,27 @@ import (
 const (
 	// x64OpRawDot(a, b): the 16-byte signed 8-bit dot with SDOT's
 	// natural grouping — lane j sums the products of bytes 4j..4j+3.
+	// Self-contained (collapses in-place); used for single-leaf
+	// chains and as the fallback when the wide form is unavailable.
 	x64OpRawDot = "i32x4_rawdot8_avx2"
-	// x64OpRawDotAcc(acc, a, b): acc + the raw dot. acc is always a
-	// rebuilt chain node (ArgNode), never a pair input.
+	// x64OpRawDotAcc(acc, a, b): acc + the raw dot, acc and result in
+	// the collapsed 4-lane domain. acc is always a rebuilt chain node
+	// (ArgNode), never a pair input.
 	x64OpRawDotAcc = "i32x4_rawdot8_acc_avx2"
+	// Wide-chain forms: the accumulation stays in the 8-lane VPMADDWD
+	// pair domain across one full ymm — 4 ops per leaf, only the two
+	// unavoidable VPMOVSXBW lane crossings — and collapses ONCE per
+	// chain (the Zen 3 lesson: per-leaf ymm collapses lose to their
+	// own lane-crossing shuffles). The ymm upper half of the running
+	// value must survive between links, so these are selected only
+	// for fully-VEX trees, where the region defers VZEROUPPER to its
+	// exit and every other write is VEX (upper-zeroing only for its
+	// own destination).
+	x64OpRawDotWide    = "i32x8_rawdotwide8_avx2"     // (a, b)
+	x64OpRawDotWideAcc = "i32x8_rawdotwide8_acc_avx2" // (acc, a, b)
+	// x64OpRawDotFold(v): collapse the 8-lane pair-domain value to
+	// the four-consecutive-byte grouping.
+	x64OpRawDotFold = "i32x4_rawdotfold_avx2"
 )
 
 // x64CrossSelKind classifies node i as an even/odd dword-select
@@ -81,9 +98,12 @@ func x64CrossSelKind(nodes []simdfuse.Node, constPairs map[int][2]uint64, i int)
 // x64CrossDotRewrite matches the cross-chain combine shape on the RAW
 // node forms (adds over dot(extend, extend) leaves — nothing here has
 // been touched by the pairing walk, which skips all-low/all-high
-// chains) and rebuilds it as a raw-dot chain. Mutates nodes in place;
-// reports whether anything was rewritten.
-func x64CrossDotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[int][2]uint64) bool {
+// chains) and rebuilds it as a raw-dot chain. wide selects the
+// pair-domain chain forms (see the op comments); the caller falls
+// back to the self-contained per-leaf form for trees whose emission
+// is not fully VEX. Mutates nodes in place; reports whether anything
+// was rewritten.
+func x64CrossDotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[int][2]uint64, wide bool) bool {
 	uses := make([]int, len(nodes))
 	for _, n := range nodes {
 		for _, a := range n.Args {
@@ -214,9 +234,25 @@ func x64CrossDotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[int
 		}
 		nodes[e] = simdfuse.Node{Op: a64OpElided}
 		nodes[o] = simdfuse.Node{Op: a64OpElided}
-		if k == 1 {
+		switch {
+		case k == 1:
 			nodes[c] = simdfuse.Node{Op: x64OpRawDot, Args: []simdfuse.Arg{srcArgs[0][0], srcArgs[0][1]}}
-		} else {
+		case wide:
+			// Pair-domain chain: the last leaf's accumulation lands on
+			// the highest slot and the fold on the combine node, so
+			// consumers keep reading c.
+			prev := slots[0]
+			nodes[prev] = simdfuse.Node{Op: x64OpRawDotWide, Args: []simdfuse.Arg{srcArgs[0][0], srcArgs[0][1]}}
+			for j := 1; j < k; j++ {
+				nodes[slots[j]] = simdfuse.Node{Op: x64OpRawDotWideAcc, Args: []simdfuse.Arg{
+					{Kind: simdfuse.ArgNode, Index: prev}, srcArgs[j][0], srcArgs[j][1],
+				}}
+				prev = slots[j]
+			}
+			nodes[c] = simdfuse.Node{Op: x64OpRawDotFold, Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: prev},
+			}}
+		default:
 			prev := slots[0]
 			nodes[prev] = simdfuse.Node{Op: x64OpRawDot, Args: []simdfuse.Arg{srcArgs[0][0], srcArgs[0][1]}}
 			for j := 1; j < k-1; j++ {

--- a/internal/gcasm/simdsplice_fuse_crossdot_x64.go
+++ b/internal/gcasm/simdsplice_fuse_crossdot_x64.go
@@ -1,6 +1,8 @@
 package gcasm
 
 import (
+	"sort"
+
 	"github.com/goccy/wasm2go/internal/simdfuse"
 )
 
@@ -63,37 +65,6 @@ const (
 	// the four-consecutive-byte grouping.
 	x64OpRawDotFold = "i32x4_rawdotfold_avx2"
 )
-
-// x64CrossSelKind classifies node i as an even/odd dword-select
-// shuffle of two node sources (the a64CrossSdotRewrite selKind,
-// unchanged: the patterns are wasm-level constants).
-func x64CrossSelKind(nodes []simdfuse.Node, constPairs map[int][2]uint64, i int) (x, y int, even, ok bool) {
-	n := &nodes[i]
-	var pat [2]uint64
-	switch {
-	case n.Op == "i8x16_shuffle_const" && len(n.Args) == 6 &&
-		n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode:
-		u32c := func(a simdfuse.Arg) uint64 { return uint64(uint32(a.Const)) }
-		pat = [2]uint64{u32c(n.Args[2]) | u32c(n.Args[3])<<32, u32c(n.Args[4]) | u32c(n.Args[5])<<32}
-	case n.Op == "i8x16_shuffle" && len(n.Args) == 3 &&
-		n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode &&
-		n.Args[2].Kind == simdfuse.ArgPairIn:
-		var isConst bool
-		pat, isConst = constPairs[n.Args[2].Index]
-		if !isConst {
-			return 0, 0, false, false
-		}
-	default:
-		return 0, 0, false, false
-	}
-	switch pat {
-	case a64EvenSel:
-		return n.Args[0].Index, n.Args[1].Index, true, true
-	case a64OddSel:
-		return n.Args[0].Index, n.Args[1].Index, false, true
-	}
-	return 0, 0, false, false
-}
 
 // x64CrossDotRewrite matches the cross-chain combine shape on the RAW
 // node forms (adds over dot(extend, extend) leaves — nothing here has
@@ -164,8 +135,8 @@ func x64CrossDotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[int
 			continue
 		}
 		e, o := n.Args[0].Index, n.Args[1].Index
-		ex, ey, eEven, eok := x64CrossSelKind(nodes, constPairs, e)
-		ox, oy, oEven, ook := x64CrossSelKind(nodes, constPairs, o)
+		ex, ey, eEven, eok := crossSelKind(nodes, constPairs, e)
+		ox, oy, oEven, ook := crossSelKind(nodes, constPairs, o)
 		if !eok || !ook || eEven == oEven || ex != ox || ey != oy {
 			continue
 		}
@@ -207,24 +178,13 @@ func x64CrossDotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[int
 		// pairing above was positional; the chain's summation order is
 		// free (associative), so re-sorting the (slot, sources)
 		// triples together is exact.
-		type rawLeaf struct {
-			slot int
-			src  [2]simdfuse.Arg
-		}
-		rl := make([]rawLeaf, k)
-		for j, h := range lowLeaves {
-			rl[j] = rawLeaf{slot: h.dot, src: [2]simdfuse.Arg{h.srcA, h.srcB}}
-		}
-		for i := 1; i < k; i++ {
-			for j := i; j > 0 && rl[j].slot < rl[j-1].slot; j-- {
-				rl[j], rl[j-1] = rl[j-1], rl[j]
-			}
-		}
+		rl := append([]x64HalfDot(nil), lowLeaves...)
+		sort.Slice(rl, func(i, j int) bool { return rl[i].dot < rl[j].dot })
 		srcArgs := make([][2]simdfuse.Arg, k)
 		slots := make([]int, k)
-		for j, l := range rl {
-			srcArgs[j] = l.src
-			slots[j] = l.slot
+		for j, h := range rl {
+			srcArgs[j] = [2]simdfuse.Arg{h.srcA, h.srcB}
+			slots[j] = h.dot
 		}
 		for _, i := range lowAll {
 			nodes[i] = simdfuse.Node{Op: a64OpElided}

--- a/internal/gcasm/simdsplice_fuse_crossdot_x64.go
+++ b/internal/gcasm/simdsplice_fuse_crossdot_x64.go
@@ -1,0 +1,238 @@
+package gcasm
+
+import (
+	"github.com/goccy/wasm2go/internal/simdfuse"
+)
+
+// Cross-chain raw dot selection (amd64).
+//
+// Interleaved-layout kernels (ggml's q8_0x4 repack gemv/gemm) keep
+// TWO i32x4_add chains per block — one over all the extend_low half
+// dots, one over all the extend_high half dots of the same byte-source
+// pairs — and combine them with the even/odd dword-select shuffles:
+//
+//	add(shuffle(dl, dh, even), shuffle(dl, dh, odd))
+//
+// Per output lane that is the product sum of one FOUR-CONSECUTIVE-BYTE
+// group, summed over the chains' common leaf sequence (see the arm64
+// twin a64CrossSdotRewrite for the lane algebra). The x64Dot8Rewrite
+// (low, high)-pairing never fires on this shape: a chunk's low and
+// high dots live in different chains.
+//
+// The rewrite replaces both chains, both shuffles and the combine with
+// a chain of synthetic raw block dots. The AVX2 emission computes each
+// 16-byte leaf in the 8-lane madd domain and collapses to the 4-byte
+// grouping in-register:
+//
+//	VPMOVSXBW  a, Y2         ; 16 x i16
+//	VPMOVSXBW  b, Y3
+//	VPMADDWD   Y3, Y2, Y2    ; 8 x i32 two-byte pair sums p0..p7
+//	VPHADDD    Y2, Y2, Y2    ; [p01, p23, ., . | p45, p67, ., .]
+//	VEXTRACTI128 $1, Y2, X3
+//	VPUNPCKLQDQ  X3, X2, dst ; [p01, p23, p45, p67]
+//
+// i16 products of i8 lanes cannot overflow and VPMADDWD accumulates
+// into i32, so every step is exact for ALL inputs (unlike the
+// VPSIGNB/VPMADDUBSW route native kernels use, which wraps on -128);
+// i32 wraparound addition is associative and commutative, so
+// regrouping the chains' adds per leaf is bit-identical. Like the
+// block dot this is a feature-body-only upgrade: portable twins keep
+// the literal SSE lowering.
+const (
+	// x64OpRawDot(a, b): the 16-byte signed 8-bit dot with SDOT's
+	// natural grouping — lane j sums the products of bytes 4j..4j+3.
+	x64OpRawDot = "i32x4_rawdot8_avx2"
+	// x64OpRawDotAcc(acc, a, b): acc + the raw dot. acc is always a
+	// rebuilt chain node (ArgNode), never a pair input.
+	x64OpRawDotAcc = "i32x4_rawdot8_acc_avx2"
+)
+
+// x64CrossSelKind classifies node i as an even/odd dword-select
+// shuffle of two node sources (the a64CrossSdotRewrite selKind,
+// unchanged: the patterns are wasm-level constants).
+func x64CrossSelKind(nodes []simdfuse.Node, constPairs map[int][2]uint64, i int) (x, y int, even, ok bool) {
+	n := &nodes[i]
+	var pat [2]uint64
+	switch {
+	case n.Op == "i8x16_shuffle_const" && len(n.Args) == 6 &&
+		n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode:
+		u32c := func(a simdfuse.Arg) uint64 { return uint64(uint32(a.Const)) }
+		pat = [2]uint64{u32c(n.Args[2]) | u32c(n.Args[3])<<32, u32c(n.Args[4]) | u32c(n.Args[5])<<32}
+	case n.Op == "i8x16_shuffle" && len(n.Args) == 3 &&
+		n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode &&
+		n.Args[2].Kind == simdfuse.ArgPairIn:
+		var isConst bool
+		pat, isConst = constPairs[n.Args[2].Index]
+		if !isConst {
+			return 0, 0, false, false
+		}
+	default:
+		return 0, 0, false, false
+	}
+	switch pat {
+	case a64EvenSel:
+		return n.Args[0].Index, n.Args[1].Index, true, true
+	case a64OddSel:
+		return n.Args[0].Index, n.Args[1].Index, false, true
+	}
+	return 0, 0, false, false
+}
+
+// x64CrossDotRewrite matches the cross-chain combine shape on the RAW
+// node forms (adds over dot(extend, extend) leaves — nothing here has
+// been touched by the pairing walk, which skips all-low/all-high
+// chains) and rebuilds it as a raw-dot chain. Mutates nodes in place;
+// reports whether anything was rewritten.
+func x64CrossDotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[int][2]uint64) bool {
+	uses := make([]int, len(nodes))
+	for _, n := range nodes {
+		for _, a := range n.Args {
+			if a.Kind == simdfuse.ArgNode {
+				uses[a.Index]++
+			}
+		}
+	}
+	// rawChainOf collects the half-dot leaves of the add spine rooted
+	// at tail, all of the required lowness, in deterministic in-order
+	// walk order, plus every absorbed node (adds, dots, extends).
+	// Interior values must be unobservable (single use, not a root).
+	rawChainOf := func(tail int, low bool) (leaves []x64HalfDot, all []int, ok bool) {
+		ok = true
+		var walk func(a simdfuse.Arg, isTail bool)
+		walk = func(a simdfuse.Arg, isTail bool) {
+			if !ok {
+				return
+			}
+			if a.Kind != simdfuse.ArgNode {
+				ok = false
+				return
+			}
+			i := a.Index
+			if !isTail && (uses[i] != 1 || isRoot[i]) {
+				ok = false
+				return
+			}
+			if isAddAny(nodes, i) {
+				if nodes[i].Args[0].Kind != simdfuse.ArgNode || nodes[i].Args[1].Kind != simdfuse.ArgNode {
+					ok = false
+					return
+				}
+				all = append(all, i)
+				walk(nodes[i].Args[0], false)
+				walk(nodes[i].Args[1], false)
+				return
+			}
+			h, hok := x64ClassifyHalfDot(nodes, uses, isRoot, i)
+			if !hok || h.high == low {
+				ok = false
+				return
+			}
+			leaves = append(leaves, h)
+			all = append(all, i, h.e0, h.e1)
+		}
+		walk(simdfuse.Arg{Kind: simdfuse.ArgNode, Index: tail}, true)
+		if !ok || len(leaves) == 0 {
+			return nil, nil, false
+		}
+		return leaves, all, true
+	}
+	rewrote := false
+	for c := len(nodes) - 1; c >= 0; c-- {
+		n := &nodes[c]
+		if n.Op != "i32x4_add" || len(n.Args) != 2 ||
+			n.Args[0].Kind != simdfuse.ArgNode || n.Args[1].Kind != simdfuse.ArgNode {
+			continue
+		}
+		e, o := n.Args[0].Index, n.Args[1].Index
+		ex, ey, eEven, eok := x64CrossSelKind(nodes, constPairs, e)
+		ox, oy, oEven, ook := x64CrossSelKind(nodes, constPairs, o)
+		if !eok || !ook || eEven == oEven || ex != ox || ey != oy {
+			continue
+		}
+		if uses[e] != 1 || uses[o] != 1 || isRoot[e] || isRoot[o] {
+			continue
+		}
+		// Both shuffles read (dl, dh); each chain tail is consumed by
+		// exactly the two shuffles.
+		dl, dh := ex, ey
+		if uses[dl] != 2 || uses[dh] != 2 || isRoot[dl] || isRoot[dh] {
+			continue
+		}
+		lowLeaves, lowAll, lok := rawChainOf(dl, true)
+		highLeaves, highAll, hok := rawChainOf(dh, false)
+		if !lok || !hok || len(lowLeaves) != len(highLeaves) {
+			continue
+		}
+		paired := true
+		for j := range lowLeaves {
+			if lowLeaves[j].srcA != highLeaves[j].srcA || lowLeaves[j].srcB != highLeaves[j].srcB {
+				paired = false
+				break
+			}
+		}
+		if !paired {
+			continue
+		}
+		// Rebuild: a raw-dot chain over the common sources. Chain
+		// nodes land on the low chain's dot slots (ascending — each
+		// already follows its own byte sources in post-order); the
+		// final accumulation lands on the combine node so its
+		// consumers read the same index. The accumulation link is one
+		// VPADDD (1 cycle), so a single chain suffices — the a64
+		// twin's dual-chain latency split has nothing to win here.
+		k := len(lowLeaves)
+		// Chain nodes land on the low dots' slots in ascending index
+		// order, each carrying its own slot's sources (their indices
+		// precede the dot, so post-order holds at every link). The
+		// pairing above was positional; the chain's summation order is
+		// free (associative), so re-sorting the (slot, sources)
+		// triples together is exact.
+		type rawLeaf struct {
+			slot int
+			src  [2]simdfuse.Arg
+		}
+		rl := make([]rawLeaf, k)
+		for j, h := range lowLeaves {
+			rl[j] = rawLeaf{slot: h.dot, src: [2]simdfuse.Arg{h.srcA, h.srcB}}
+		}
+		for i := 1; i < k; i++ {
+			for j := i; j > 0 && rl[j].slot < rl[j-1].slot; j-- {
+				rl[j], rl[j-1] = rl[j-1], rl[j]
+			}
+		}
+		srcArgs := make([][2]simdfuse.Arg, k)
+		slots := make([]int, k)
+		for j, l := range rl {
+			srcArgs[j] = l.src
+			slots[j] = l.slot
+		}
+		for _, i := range lowAll {
+			nodes[i] = simdfuse.Node{Op: a64OpElided}
+		}
+		for _, i := range highAll {
+			nodes[i] = simdfuse.Node{Op: a64OpElided}
+		}
+		nodes[e] = simdfuse.Node{Op: a64OpElided}
+		nodes[o] = simdfuse.Node{Op: a64OpElided}
+		if k == 1 {
+			nodes[c] = simdfuse.Node{Op: x64OpRawDot, Args: []simdfuse.Arg{srcArgs[0][0], srcArgs[0][1]}}
+		} else {
+			prev := slots[0]
+			nodes[prev] = simdfuse.Node{Op: x64OpRawDot, Args: []simdfuse.Arg{srcArgs[0][0], srcArgs[0][1]}}
+			for j := 1; j < k-1; j++ {
+				nodes[slots[j]] = simdfuse.Node{Op: x64OpRawDotAcc, Args: []simdfuse.Arg{
+					{Kind: simdfuse.ArgNode, Index: prev}, srcArgs[j][0], srcArgs[j][1],
+				}}
+				prev = slots[j]
+			}
+			nodes[c] = simdfuse.Node{Op: x64OpRawDotAcc, Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: prev}, srcArgs[k-1][0], srcArgs[k-1][1],
+			}}
+		}
+		for _, i := range append(append([]int{}, lowAll...), highAll...) {
+			uses[i] = 0
+		}
+		rewrote = true
+	}
+	return rewrote
+}

--- a/internal/gcasm/simdsplice_fuse_crossdot_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_crossdot_x64_test.go
@@ -1,0 +1,188 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/simdfuse"
+)
+
+func TestX64CrossDotRewrite(t *testing.T) {
+	tree := crossChainTree(a64EvenSel, a64OddSel, simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2})
+	rt, rewrote := x64Dot8Rewrite(tree, false)
+	if !rewrote {
+		t.Fatal("cross-chain shape not rewritten")
+	}
+	ops := countOps(rt.Nodes)
+	if ops[x64OpRawDot] != 1 || ops[x64OpRawDotAcc] != 1 {
+		t.Fatalf("raw dot chain not built: %v", ops)
+	}
+	if ops["i8x16_shuffle"] != 0 || ops["i32x4_add"] != 0 ||
+		ops["i32x4_dot_i16x8_s"] != 0 || ops[x64OpBlockDot] != 0 {
+		t.Fatalf("combine not fully absorbed: %v", ops)
+	}
+	// The final accumulation must sit on the combine's slot (16), so
+	// consumers and the root are untouched.
+	if rt.Nodes[16].Op != x64OpRawDotAcc {
+		t.Fatalf("final accumulation not at the combine slot: %s", rt.Nodes[16].Op)
+	}
+	head := rt.Nodes[16].Args[0]
+	if head.Kind != simdfuse.ArgNode || rt.Nodes[head.Index].Op != x64OpRawDot {
+		t.Fatalf("chain head malformed: %+v", rt.Nodes[16].Args)
+	}
+	hArgs := rt.Nodes[head.Index].Args
+	if hArgs[0] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 0}) ||
+		hArgs[1] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 1}) {
+		t.Fatalf("head sources wrong: %+v", hArgs)
+	}
+	tArgs := rt.Nodes[16].Args
+	if tArgs[1] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2}) ||
+		tArgs[2] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 3}) {
+		t.Fatalf("tail sources wrong: %+v", tArgs)
+	}
+}
+
+func TestX64CrossDotRewritePortableSuppresses(t *testing.T) {
+	tree := crossChainTree(a64EvenSel, a64OddSel, simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2})
+	rt, rewrote := x64Dot8Rewrite(tree, true)
+	if rewrote {
+		t.Fatal("portable body must keep the literal lowering")
+	}
+	ops := countOps(rt.Nodes)
+	if ops[x64OpRawDot] != 0 || ops[x64OpRawDotAcc] != 0 {
+		t.Fatalf("portable body rewrote: %v", ops)
+	}
+}
+
+// A non-matching pattern (an arbitrary shuffle pair) stays literal.
+func TestX64CrossDotRewriteRejectsForeignShuffles(t *testing.T) {
+	tree := crossChainTree([2]uint64{0x0102030405060708, 0x090a0b0c0d0e0f00}, a64OddSel,
+		simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2})
+	rt, _ := x64Dot8Rewrite(tree, false)
+	ops := countOps(rt.Nodes)
+	if ops[x64OpRawDot] != 0 || ops[x64OpRawDotAcc] != 0 {
+		t.Fatalf("foreign shuffle pattern rewrote: %v", ops)
+	}
+}
+
+func TestX64RawDotEmitsCollapsedMadd(t *testing.T) {
+	tree := crossChainTree(a64EvenSel, a64OddSel, simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2})
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, tree, &ConstPool{}, fuseTestOffs, false, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	for _, want := range []string{
+		"VPMOVSXBW", "VPMADDWD Y3, Y2, Y2", "VPHADDD Y2, Y2, Y2",
+		"VEXTRACTI128 $1, Y2, X3", "VPUNPCKLQDQ X3, X2,", "VPADDD",
+		"// avx2 dot", "VZEROUPPER",
+	} {
+		if !strings.Contains(asm, want) {
+			t.Errorf("emitted asm missing %q:\n%s", want, asm)
+		}
+	}
+	// The absorbed shuffles and literal dots must be gone.
+	for _, gone := range []string{"PSHUFB", "PMADDWL"} {
+		if strings.Contains(asm, gone) {
+			t.Errorf("emitted asm still contains %q:\n%s", gone, asm)
+		}
+	}
+}
+
+// f16Tree: one f16x4_cvt over a pair input.
+func f16Tree() *simdfuse.Tree {
+	return &simdfuse.Tree{
+		Name:     "simd_p_fxf16",
+		NumPairs: 1,
+		Nodes: []simdfuse.Node{
+			{Op: "f16x4_cvt", Args: []simdfuse.Arg{{Kind: simdfuse.ArgPairIn, Index: 0}}},
+		},
+		Roots: []int{0},
+	}
+}
+
+func TestX64F16CvtFeatureBodyUsesF16C(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, f16Tree(), &ConstPool{}, fuseTestOffs, false, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	for _, want := range []string{"VPAND", "VPACKUSDW X1, X1, X1", "VCVTPH2PS X1,", "// avx2 dot"} {
+		if !strings.Contains(asm, want) {
+			t.Errorf("feature body missing %q:\n%s", want, asm)
+		}
+	}
+	if strings.Contains(asm, "PCMPGTL") || strings.Contains(asm, "MULPS") {
+		t.Errorf("feature body still carries the SSE2 bit trick:\n%s", asm)
+	}
+}
+
+func TestX64F16CvtPortableKeepsBitTrick(t *testing.T) {
+	var b strings.Builder
+	spliced, _, err := x64SpliceFused(&b, f16Tree(), &ConstPool{}, fuseTestOffs, true, 0)
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	if !spliced {
+		t.Fatal("not spliced")
+	}
+	asm := b.String()
+	if strings.Contains(asm, "VCVTPH2PS") {
+		t.Errorf("portable body used F16C:\n%s", asm)
+	}
+	if !strings.Contains(asm, "PCMPGTL") {
+		t.Errorf("portable body missing the SSE2 bit trick:\n%s", asm)
+	}
+}
+
+// TestX64CrossDotBodiesAssemble: the raw-dot and F16C sequences pass
+// the real assembler (linux/amd64), pool constants included.
+func TestX64CrossDotBodiesAssemble(t *testing.T) {
+	pool := &ConstPool{}
+	var body strings.Builder
+	body.WriteString("TEXT ·fusedProbe(SB), NOSPLIT, $0-0\n")
+	for i, tree := range []*simdfuse.Tree{
+		crossChainTree(a64EvenSel, a64OddSel, simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2}),
+		f16Tree(),
+	} {
+		var b strings.Builder
+		spliced, _, err := x64SpliceFused(&b, tree, pool, fuseTestOffs, false, 0)
+		if err != nil {
+			t.Fatalf("splice %d: %v", i, err)
+		}
+		if !spliced {
+			t.Fatalf("splice %d: not spliced", i)
+		}
+		body.WriteString(b.String())
+	}
+	body.WriteString("\tRET\n")
+	asm := "#include \"textflag.h\"\n\n" + body.String() + "\n" + pool.Emit()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "k_amd64.s"), []byte(asm), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSrc := "package main\n\nfunc fusedProbe()\nfunc main() { _ = fusedProbe }\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(goSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fcheck\n\ngo 1.25.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", os.DevNull, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "GOAMD64=v2")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fused bodies do not assemble: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_crossdot_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_crossdot_x64_test.go
@@ -17,31 +17,59 @@ func TestX64CrossDotRewrite(t *testing.T) {
 		t.Fatal("cross-chain shape not rewritten")
 	}
 	ops := countOps(rt.Nodes)
-	if ops[x64OpRawDot] != 1 || ops[x64OpRawDotAcc] != 1 {
-		t.Fatalf("raw dot chain not built: %v", ops)
+	// A fully-VEX tree takes the pair-domain wide chain with one
+	// fold on the combine slot.
+	if ops[x64OpRawDotWide] != 1 || ops[x64OpRawDotWideAcc] != 1 || ops[x64OpRawDotFold] != 1 {
+		t.Fatalf("wide raw dot chain not built: %v", ops)
 	}
 	if ops["i8x16_shuffle"] != 0 || ops["i32x4_add"] != 0 ||
 		ops["i32x4_dot_i16x8_s"] != 0 || ops[x64OpBlockDot] != 0 {
 		t.Fatalf("combine not fully absorbed: %v", ops)
 	}
-	// The final accumulation must sit on the combine's slot (16), so
-	// consumers and the root are untouched.
-	if rt.Nodes[16].Op != x64OpRawDotAcc {
-		t.Fatalf("final accumulation not at the combine slot: %s", rt.Nodes[16].Op)
+	// The fold must sit on the combine's slot (16), so consumers and
+	// the root are untouched.
+	if rt.Nodes[16].Op != x64OpRawDotFold {
+		t.Fatalf("fold not at the combine slot: %s", rt.Nodes[16].Op)
 	}
-	head := rt.Nodes[16].Args[0]
-	if head.Kind != simdfuse.ArgNode || rt.Nodes[head.Index].Op != x64OpRawDot {
-		t.Fatalf("chain head malformed: %+v", rt.Nodes[16].Args)
+	tail := rt.Nodes[16].Args[0]
+	if tail.Kind != simdfuse.ArgNode || rt.Nodes[tail.Index].Op != x64OpRawDotWideAcc {
+		t.Fatalf("chain tail malformed: %+v", rt.Nodes[16].Args)
+	}
+	tArgs := rt.Nodes[tail.Index].Args
+	if tArgs[1] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2}) ||
+		tArgs[2] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 3}) {
+		t.Fatalf("tail sources wrong: %+v", tArgs)
+	}
+	head := tArgs[0]
+	if head.Kind != simdfuse.ArgNode || rt.Nodes[head.Index].Op != x64OpRawDotWide {
+		t.Fatalf("chain head malformed: %+v", tArgs)
 	}
 	hArgs := rt.Nodes[head.Index].Args
 	if hArgs[0] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 0}) ||
 		hArgs[1] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 1}) {
 		t.Fatalf("head sources wrong: %+v", hArgs)
 	}
-	tArgs := rt.Nodes[16].Args
-	if tArgs[1] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2}) ||
-		tArgs[2] != (simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 3}) {
-		t.Fatalf("tail sources wrong: %+v", tArgs)
+}
+
+// A tree whose emission is not fully VEX (a store rides along) keeps
+// the self-contained per-leaf forms: no live ymm upper crosses a
+// possible mid-region VZEROUPPER.
+func TestX64CrossDotRewriteFallsBackPerLeaf(t *testing.T) {
+	tree := crossChainTree(a64EvenSel, a64OddSel, simdfuse.Arg{Kind: simdfuse.ArgPairIn, Index: 2})
+	tree.Nodes = append(tree.Nodes, simdfuse.Node{Op: "v128_store", Args: []simdfuse.Arg{
+		{Kind: simdfuse.ArgScalar, Index: 0}, {Kind: simdfuse.ArgConst}, {Kind: simdfuse.ArgNode, Index: 16},
+	}})
+	tree.Roots = []int{len(tree.Nodes) - 1}
+	rt, rewrote := x64Dot8Rewrite(tree, false)
+	if !rewrote {
+		t.Fatal("cross-chain shape not rewritten")
+	}
+	ops := countOps(rt.Nodes)
+	if ops[x64OpRawDotWide] != 0 || ops[x64OpRawDotWideAcc] != 0 || ops[x64OpRawDotFold] != 0 {
+		t.Fatalf("wide forms selected in a non-VEX tree: %v", ops)
+	}
+	if ops[x64OpRawDot] != 1 || ops[x64OpRawDotAcc] != 1 {
+		t.Fatalf("per-leaf chain not built: %v", ops)
 	}
 }
 
@@ -80,8 +108,8 @@ func TestX64RawDotEmitsCollapsedMadd(t *testing.T) {
 	}
 	asm := b.String()
 	for _, want := range []string{
-		"VPMOVSXBW", "VPMADDWD Y3, Y2, Y2", "VPHADDD Y2, Y2, Y2",
-		"VEXTRACTI128 $1, Y2, X3", "VPUNPCKLQDQ X3, X2,", "VPADDD",
+		"VPMOVSXBW", "VPMADDWD Y3, Y2,", "VPADDD Y",
+		"VPHADDD Y", "VEXTRACTI128 $1, Y2, X3", "VPUNPCKLQDQ X3, X2,",
 		"// avx2 dot", "VZEROUPPER",
 	} {
 		if !strings.Contains(asm, want) {

--- a/internal/gcasm/simdsplice_fuse_dot8_a64.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_a64.go
@@ -300,6 +300,40 @@ var (
 	a64OddSel  = [2]uint64{0x0f0e0d0c07060504, 0x1f1e1d1c17161514}
 )
 
+// crossSelKind classifies node i as an even/odd dword-select shuffle
+// of two node sources: its control vector must be a known even/odd
+// dword select — either the descriptor-constant form
+// (i8x16_shuffle_const, pattern in four ArgConst) or a pair argument
+// whose call-site value is a recorded constant. The patterns are
+// wasm-level constants, so both arch rewrites share the classifier.
+func crossSelKind(nodes []simdfuse.Node, constPairs map[int][2]uint64, i int) (x, y int, even, ok bool) {
+	n := &nodes[i]
+	var pat [2]uint64
+	switch {
+	case n.Op == "i8x16_shuffle_const" && len(n.Args) == 6 &&
+		n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode:
+		u32c := func(a simdfuse.Arg) uint64 { return uint64(uint32(a.Const)) }
+		pat = [2]uint64{u32c(n.Args[2]) | u32c(n.Args[3])<<32, u32c(n.Args[4]) | u32c(n.Args[5])<<32}
+	case n.Op == "i8x16_shuffle" && len(n.Args) == 3 &&
+		n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode &&
+		n.Args[2].Kind == simdfuse.ArgPairIn:
+		var isConst bool
+		pat, isConst = constPairs[n.Args[2].Index]
+		if !isConst {
+			return 0, 0, false, false
+		}
+	default:
+		return 0, 0, false, false
+	}
+	switch pat {
+	case a64EvenSel:
+		return n.Args[0].Index, n.Args[1].Index, true, true
+	case a64OddSel:
+		return n.Args[0].Index, n.Args[1].Index, false, true
+	}
+	return 0, 0, false, false
+}
+
 // a64CrossSdotRewrite upgrades the even/odd lane-combine of TWO
 // sadalp chains — one all-low, one all-high, over pairwise-identical
 // byte sources — to a single RAW SDOT chain.
@@ -326,37 +360,6 @@ func a64CrossSdotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[in
 				uses[a.Index]++
 			}
 		}
-	}
-	// selKind classifies a shuffle node: its control vector must be a
-	// known even/odd dword select — either the descriptor-constant
-	// form (i8x16_shuffle_const, pattern in four ArgConst) or a pair
-	// argument whose call-site value is a recorded constant.
-	selKind := func(i int) (x, y int, even, ok bool) {
-		n := &nodes[i]
-		var pat [2]uint64
-		switch {
-		case n.Op == "i8x16_shuffle_const" && len(n.Args) == 6 &&
-			n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode:
-			u32c := func(a simdfuse.Arg) uint64 { return uint64(uint32(a.Const)) }
-			pat = [2]uint64{u32c(n.Args[2]) | u32c(n.Args[3])<<32, u32c(n.Args[4]) | u32c(n.Args[5])<<32}
-		case n.Op == "i8x16_shuffle" && len(n.Args) == 3 &&
-			n.Args[0].Kind == simdfuse.ArgNode && n.Args[1].Kind == simdfuse.ArgNode &&
-			n.Args[2].Kind == simdfuse.ArgPairIn:
-			var isConst bool
-			pat, isConst = constPairs[n.Args[2].Index]
-			if !isConst {
-				return 0, 0, false, false
-			}
-		default:
-			return 0, 0, false, false
-		}
-		switch pat {
-		case a64EvenSel:
-			return n.Args[0].Index, n.Args[1].Index, true, true
-		case a64OddSel:
-			return n.Args[0].Index, n.Args[1].Index, false, true
-		}
-		return 0, 0, false, false
 	}
 	// chainOf collects a sadalp chain in leaf order: (head Dot8Low/High
 	// + Dot8Acc links over Dot8Mul products), or a bare head. Interior
@@ -404,8 +407,8 @@ func a64CrossSdotRewrite(nodes []simdfuse.Node, isRoot []bool, constPairs map[in
 			continue
 		}
 		e, o := n.Args[0].Index, n.Args[1].Index
-		ex, ey, eEven, eok := selKind(e)
-		ox, oy, oEven, ook := selKind(o)
+		ex, ey, eEven, eok := crossSelKind(nodes, constPairs, e)
+		ox, oy, oEven, ook := crossSelKind(nodes, constPairs, o)
 		if !eok || !ook || eEven == oEven || ex != ox || ey != oy {
 			continue
 		}

--- a/internal/gcasm/simdsplice_fuse_dot8_x64.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64.go
@@ -280,6 +280,13 @@ func x64Dot8Rewrite(tree *simdfuse.Tree, portable bool) (*simdfuse.Tree, bool) {
 		}
 		rewrote = true
 	}
+	// Cross-chain shapes (separate all-low/all-high chains joined by
+	// the even/odd shuffle combine — the interleaved repack kernels)
+	// are untouched by the pairing walk above; upgrade them to raw
+	// block-dot chains.
+	if x64CrossDotRewrite(nodes, isRoot, tree.ConstPairs) {
+		rewrote = true
+	}
 	if !rewrote {
 		return tree, false
 	}

--- a/internal/gcasm/simdsplice_fuse_dot8_x64.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64.go
@@ -283,9 +283,20 @@ func x64Dot8Rewrite(tree *simdfuse.Tree, portable bool) (*simdfuse.Tree, bool) {
 	// Cross-chain shapes (separate all-low/all-high chains joined by
 	// the even/odd shuffle combine — the interleaved repack kernels)
 	// are untouched by the pairing walk above; upgrade them to raw
-	// block-dot chains.
-	if x64CrossDotRewrite(nodes, isRoot, tree.ConstPairs) {
-		rewrote = true
+	// block-dot chains. Try the pair-domain wide form first — it
+	// keeps a live ymm upper between links, which is only sound in a
+	// fully-VEX region — and fall back to the self-contained per-leaf
+	// form otherwise.
+	snapshot := append([]simdfuse.Node(nil), nodes...)
+	if x64CrossDotRewrite(nodes, isRoot, tree.ConstPairs, true) {
+		if x64NodesVexClean(nodes) {
+			rewrote = true
+		} else {
+			copy(nodes, snapshot)
+			if x64CrossDotRewrite(nodes, isRoot, tree.ConstPairs, false) {
+				rewrote = true
+			}
+		}
 	}
 	if !rewrote {
 		return tree, false

--- a/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
+++ b/internal/gcasm/simdsplice_fuse_dot8_x64_test.go
@@ -415,3 +415,81 @@ func TestX64LoopHoistsRangeChecks(t *testing.T) {
 		t.Errorf("loop body lost the folded indexed load:\n%s", body)
 	}
 }
+
+// TestX64LoopHoistsChecksFloorForm: a memory64 do-while floor loop
+// (unit step) with loads addressed through a scalar-chain sum also
+// hoists its window checks — iters-1 = counter - thresh - 1, clamped
+// at zero — and every narrow load inside the body drops its check.
+func TestX64LoopHoistsChecksFloorForm(t *testing.T) {
+	tr := &simdfuse.Tree{
+		Name:       "simd_p_fxlfloor",
+		NumScalars: 3,
+		NeedsMem:   true,
+		NumPairs:   1,
+		Addr64:     true,
+		Nodes: []simdfuse.Node{
+			{Op: "scalar_i32_add", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgScalar, Index: 0},
+				{Kind: simdfuse.ArgScalar, Index: 1},
+			}},
+			{Op: "v128_load", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 0},
+				{Kind: simdfuse.ArgConst, Const: 8},
+			}},
+			{Op: "v128_load32_splat", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 0},
+				{Kind: simdfuse.ArgConst, Const: 4},
+			}},
+			{Op: "i32x4_add", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 1},
+				{Kind: simdfuse.ArgNode, Index: 2},
+			}},
+			{Op: "i32x4_add", Args: []simdfuse.Arg{
+				{Kind: simdfuse.ArgNode, Index: 3},
+				{Kind: simdfuse.ArgPairIn, Index: 0},
+			}},
+		},
+		Roots: []int{4},
+	}
+	loop := &simdfuse.Loop{
+		Tree:          tr,
+		CarriedPairs:  [][2]int{{0, 4}},
+		Bumps:         []simdfuse.LoopBump{{Scalar: 0, Delta: 136, DeltaScalar: -1}},
+		CounterScalar: 2,
+		Dec:           1,
+		PreTest:       false,
+		ExitGT:        true,
+		ExitThresh:    1,
+	}
+	var b strings.Builder
+	spliced, needsTrap, err := x64SpliceLoop(&b, loop, &ConstPool{}, fuseTestOffs, "7", false, 0)
+	if err != nil || !spliced {
+		t.Fatalf("spliced=%v err=%v", spliced, err)
+	}
+	if !needsTrap {
+		t.Error("hoisted check must still request the trap label")
+	}
+	asm := b.String()
+	loopStart := strings.Index(asm, "gcasmfxl7:")
+	if loopStart < 0 {
+		t.Fatalf("no loop label:\n%s", asm)
+	}
+	pre, body := asm[:loopStart], asm[loopStart:]
+	// iters-1 = counter - (thresh+1), clamped at zero, scaled by the
+	// bump, plus both chain terms and the widest end offset (8+16).
+	for _, want := range []string{"SUBQ $2, R12", "JGE gcasmfxh7_", "XORL R12, R12", "IMUL3Q $136, R12, R12", "ADDQ $24, R12"} {
+		if !strings.Contains(pre, want) {
+			t.Errorf("prologue missing %q:\n%s", want, pre)
+		}
+	}
+	// The body keeps no per-load bounds checks and uses folded
+	// indexed forms for both the vector load and the splat.
+	if strings.Contains(body, "JCS gcasmsimdoob") {
+		t.Errorf("loop body still bounds-checks:\n%s", body)
+	}
+	for _, want := range []string{"VMOVDQU 8(", "VMOVSS 4(", "VPSHUFD $0x00"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("loop body missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -390,8 +390,14 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 				// VCVTPH2PS (F16C, which the HasAVX2 gate requires).
 				// All VEX-128, so no ymm upper state is dirtied. The
 				// marker routes non-AVX2 hosts to the portable twin.
-				fmt.Fprintf(b, "\tVPAND ·%s(SB), X%d, X1\n", c4(0xFFFF), src)
-				b.WriteString("\tVPACKUSDW X1, X1, X1\n")
+				// A zero-extending 16x4 load already has empty upper
+				// lane halves, so its mask is dead weight.
+				if a := n.Args[0]; a.Kind == simdfuse.ArgNode && tree.Nodes[a.Index].Op == "v128_load16x4_u" {
+					fmt.Fprintf(b, "\tVPACKUSDW X%d, X%d, X1\n", src, src)
+				} else {
+					fmt.Fprintf(b, "\tVPAND ·%s(SB), X%d, X1\n", c4(0xFFFF), src)
+					b.WriteString("\tVPACKUSDW X1, X1, X1\n")
+				}
 				fmt.Fprintf(b, "\tVCVTPH2PS X1, X%d\n", dst)
 				b.WriteString("\t// avx2 dot\n")
 				loc[i] = fusedLoc{chained: willChain, pool: dst}
@@ -489,24 +495,29 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
-		} else if n.Op == x64OpRawDot || n.Op == x64OpRawDotAcc {
-			// Raw 16-byte 8-bit dot (see x64CrossDotRewrite): 8-lane
-			// madd across one ymm, then collapse to the four-byte
-			// grouping. Y2/Y3 (X2/X3) are scratch the pool never
-			// occupies; byte sources stage BEFORE either extend runs
-			// (X2 is Y2's own low half), and every source is read
-			// before dst is written, so dst may alias a source.
+		} else if n.Op == x64OpRawDot || n.Op == x64OpRawDotAcc ||
+			n.Op == x64OpRawDotWide || n.Op == x64OpRawDotWideAcc {
+			// Raw 16-byte 8-bit dots (see x64CrossDotRewrite). The
+			// self-contained forms collapse to the four-byte grouping
+			// in place; the wide forms leave the value in the 8-lane
+			// pair domain across a full ymm for x64OpRawDotFold.
+			// Y2/Y3 (X2/X3) are scratch the pool never occupies; byte
+			// sources stage BEFORE either extend runs (X2 is Y2's own
+			// low half), and every source is read before dst is
+			// written, so dst may alias a source.
+			isWide := n.Op == x64OpRawDotWide || n.Op == x64OpRawDotWideAcc
+			hasAcc := n.Op == x64OpRawDotAcc || n.Op == x64OpRawDotWideAcc
 			args := n.Args
-			accSrc := ""
-			if n.Op == x64OpRawDotAcc {
+			accReg := -1
+			if hasAcc {
 				a := args[0]
 				if a.Kind != simdfuse.ArgNode {
 					return nil, false, fmt.Errorf("fused splice %s: %s accumulator is not a node", tree.Name, n.Op)
 				}
 				if loc[a.Index].chained {
-					accSrc = "X0"
+					accReg = 0
 				} else {
-					accSrc = fmt.Sprintf("X%d", loc[a.Index].pool)
+					accReg = loc[a.Index].pool
 				}
 				args = args[1:]
 			}
@@ -539,20 +550,48 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			}
 			fmt.Fprintf(b, "\tVPMOVSXBW %s, Y2\n", ra)
 			fmt.Fprintf(b, "\tVPMOVSXBW %s, Y3\n", rb)
-			b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
-			b.WriteString("\tVPHADDD Y2, Y2, Y2\n")
-			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
-			if accSrc == "" {
-				fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
+			if isWide {
+				if hasAcc {
+					b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
+					fmt.Fprintf(b, "\tVPADDD Y%d, Y2, Y%d\n", accReg, dst)
+				} else {
+					fmt.Fprintf(b, "\tVPMADDWD Y3, Y2, Y%d\n", dst)
+				}
 			} else {
-				b.WriteString("\tVPUNPCKLQDQ X3, X2, X2\n")
-				fmt.Fprintf(b, "\tVPADDD %s, X2, X%d\n", accSrc, dst)
+				b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
+				b.WriteString("\tVPHADDD Y2, Y2, Y2\n")
+				b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
+				if !hasAcc {
+					fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
+				} else {
+					b.WriteString("\tVPUNPCKLQDQ X3, X2, X2\n")
+					fmt.Fprintf(b, "\tVPADDD X%d, X2, X%d\n", accReg, dst)
+				}
+				if !vexClean {
+					// See the block dot above: uppers must not stay
+					// dirty into legacy SSE code. (The wide forms are
+					// never selected outside fully-VEX trees.)
+					b.WriteString("\tVZEROUPPER\n")
+				}
 			}
-			if !vexClean {
-				// See the block dot above: uppers must not stay dirty
-				// into legacy SSE code.
-				b.WriteString("\tVZEROUPPER\n")
+			b.WriteString("\t// avx2 dot\n")
+			loc[i] = fusedLoc{chained: willChain, pool: dst}
+			continue
+		} else if n.Op == x64OpRawDotFold {
+			// Collapse the pair-domain chain value: lane j of the
+			// result is P2j + P2j+1 — the four-consecutive-byte
+			// grouping the consumers were proven to want.
+			a := n.Args[0]
+			if a.Kind != simdfuse.ArgNode {
+				return nil, false, fmt.Errorf("fused splice %s: %s input is not a node", tree.Name, n.Op)
 			}
+			v := 0
+			if !loc[a.Index].chained {
+				v = loc[a.Index].pool
+			}
+			fmt.Fprintf(b, "\tVPHADDD Y%d, Y%d, Y2\n", v, v)
+			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
+			fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
 			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
@@ -1530,9 +1569,15 @@ var x64VexOps = map[string]func(b *strings.Builder, srcs []string, dst int){
 // applies to legacy SSE only; VEX-128 ops are safe under dirty
 // uppers).
 func x64TreeVexClean(tree *simdfuse.Tree) bool {
-	for _, n := range tree.Nodes {
+	return x64NodesVexClean(tree.Nodes)
+}
+
+func x64NodesVexClean(nodes []simdfuse.Node) bool {
+	for _, n := range nodes {
 		if n.Op == a64OpElided || n.Op == x64OpBlockDot ||
-			n.Op == x64OpRawDot || n.Op == x64OpRawDotAcc || n.Op == "f32x4_splat" {
+			n.Op == x64OpRawDot || n.Op == x64OpRawDotAcc ||
+			n.Op == x64OpRawDotWide || n.Op == x64OpRawDotWideAcc ||
+			n.Op == x64OpRawDotFold || n.Op == "f32x4_splat" {
 			continue
 		}
 		if n.Op == "f16x4_cvt" {

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -920,9 +920,12 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 	if addrReg != "" {
 		// Chain-computed address: move the terminal into the address
 		// register first (see the arm64 twin). MOVL re-zero-extends
-		// the i32-wrapped chain result on wasm32.
+		// the i32-wrapped chain result on wasm32; at full width a
+		// chain already terminating in R12 needs no move at all.
 		if addr64 {
-			fmt.Fprintf(b, "\tMOVQ %s, R12\n", addrReg)
+			if addrReg != "R12" {
+				fmt.Fprintf(b, "\tMOVQ %s, R12\n", addrReg)
+			}
 		} else {
 			fmt.Fprintf(b, "\tMOVL %s, R12\n", addrReg)
 		}
@@ -1022,6 +1025,40 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 			return addOffErr
 		}
 		addOff(1)
+	case "v128_load32_splat_nc":
+		if d, ok := x64DeferOff(n.Args[1]); ok {
+			fmt.Fprintf(b, "\tVMOVSS %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+		} else {
+			addOff(1)
+			fmt.Fprintf(b, "\tVMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		}
+		fmt.Fprintf(b, "\tVPSHUFD $0x00, X%d, X%d\n", dst, dst)
+		return addOffErr
+	case "v128_load16x4_u_nc":
+		if d, ok := x64DeferOff(n.Args[1]); ok {
+			fmt.Fprintf(b, "\tVMOVQ %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+		} else {
+			addOff(1)
+			fmt.Fprintf(b, "\tVMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		}
+		fmt.Fprintf(b, "\tVPMOVZXWD X%d, X%d\n", dst, dst)
+		return addOffErr
+	case "v128_load32_zero_nc":
+		if d, ok := x64DeferOff(n.Args[1]); ok {
+			fmt.Fprintf(b, "\tVMOVSS %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+		} else {
+			addOff(1)
+			fmt.Fprintf(b, "\tVMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		}
+		return addOffErr
+	case "v128_load64_zero_nc":
+		if d, ok := x64DeferOff(n.Args[1]); ok {
+			fmt.Fprintf(b, "\tVMOVQ %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+		} else {
+			addOff(1)
+			fmt.Fprintf(b, "\tVMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		}
+		return addOffErr
 	case "v128_load_rng":
 		// start/end accumulate in R12 and are undone afterwards, so
 		// the address survives without a third register. The window is
@@ -1299,21 +1336,35 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 	// Pin m.M / memSize for the whole loop: every iteration's member
 	// accesses then skip the per-site Module loads.
 	offs = x64HoistMem(b, offs, tree, 1+tree.NumScalars+1+loop.NumDeltas+2*tree.NumPairs)
-	// Hoist the strided window checks out of the loop: a pretest loop
-	// with a power-of-two step runs exactly counter>>log2(Dec)
-	// iterations, so ONE check of
-	//   base + rlo + span + (iters-1)*delta
-	// against memSize covers every iteration's window and the loads
+	// Hoist the strided window checks out of the loop: when the
+	// iteration count is computable at entry, ONE check of
+	//   maxAddress = base + end + (iters-1)*delta
+	// against memSize covers every iteration's accesses and the loads
 	// inside the loop drop to single indexed instructions. Trapping at
 	// the loop head instead of the precise access is the same
 	// relaxation the windowed range check already makes. memory64
-	// trees only (all address terms add at full width there).
+	// trees only (all address terms add at full width there). Two loop
+	// forms qualify: the pretest power-of-two-step loop (iters =
+	// counter>>log2(Dec)) and the do-while floor loop with a unit step
+	// (iters = max(counter - thresh, 1) — the body runs at least
+	// once). Addresses may be a scalar argument, a scalar+const sum,
+	// or a scalar-chain ADD tree over those — the interleaved kernels
+	// derive every load address as bumpedBase + columnBase + const.
 	hoistedTrap := false
-	if tree.Addr64 && loop.PreTest && loop.Dec > 0 && loop.Dec&(loop.Dec-1) == 0 {
-		sh := 0
-		for d := loop.Dec; d > 1; d >>= 1 {
-			sh++
+	hoistForm := 0 // 1 = pretest pow2, 2 = do-while ExitGT unit-step
+	sh := 0
+	if tree.Addr64 && loop.Dec > 0 {
+		switch {
+		case loop.PreTest && loop.Dec&(loop.Dec-1) == 0:
+			hoistForm = 1
+			for d := loop.Dec; d > 1; d >>= 1 {
+				sh++
+			}
+		case !loop.PreTest && loop.ExitGT && loop.Dec == 1 && loop.ExitThresh >= 0:
+			hoistForm = 2
 		}
+	}
+	if hoistForm != 0 {
 		deltaOf := map[int]int64{}
 		dynamic := map[int]bool{}
 		for _, bump := range loop.Bumps {
@@ -1325,60 +1376,131 @@ func x64SpliceLoop(b *strings.Builder, loop *simdfuse.Loop, pool *ConstPool, off
 		}
 		nodes := append([]simdfuse.Node(nil), tree.Nodes...)
 		ctrReg := x64FusedArgRegs[1+loop.CounterScalar]
-		checkedSpans := map[string]bool{}
-		rewrote := false
-		for i := range nodes {
-			n := &nodes[i]
-			if n.Op != "v128_load_rng" || len(n.Args) != 4 {
-				continue
+		// resolveAffine flattens a load address into scalar-argument
+		// terms plus a constant: ArgScalar/ArgSum directly, or a
+		// scalar-chain add tree over those.
+		var resolveAffine func(a simdfuse.Arg, depth int) ([]int, int64, bool)
+		resolveAffine = func(a simdfuse.Arg, depth int) ([]int, int64, bool) {
+			if depth > 6 {
+				return nil, 0, false
 			}
-			a := n.Args[0]
-			if a.Kind != simdfuse.ArgScalar && a.Kind != simdfuse.ArgSum {
-				continue
-			}
-			if dynamic[a.Index] {
-				continue
-			}
-			rlo, span := n.Args[2], n.Args[3]
-			if rlo.Kind != simdfuse.ArgConst || span.Kind != simdfuse.ArgConst || rlo.Const < 0 {
-				continue
-			}
-			d := deltaOf[a.Index]
-			if d < 0 || d > 1<<20 {
-				continue
-			}
-			base := int64(0)
-			if a.Kind == simdfuse.ArgSum {
-				base = int64(a.Const)
-			}
-			end := base + int64(rlo.Const) + int64(uint32(span.Const))
-			key := fmt.Sprintf("%d/%d/%d", a.Index, end, d)
-			if !checkedSpans[key] {
-				checkedSpans[key] = true
-				skip := fmt.Sprintf("gcasmfxh%s_%d", site, i)
-				// A 32-bit counter arrives with undefined upper bits;
-				// MOVL zero-extends before the shift.
-				ctrMov := "MOVL"
-				if loop.CounterWide {
-					ctrMov = "MOVQ"
+			switch a.Kind {
+			case simdfuse.ArgScalar:
+				return []int{a.Index}, 0, true
+			case simdfuse.ArgSum:
+				return []int{a.Index}, int64(a.Const), true
+			case simdfuse.ArgConst:
+				return nil, int64(a.Const), true
+			case simdfuse.ArgNode:
+				nd := &nodes[a.Index]
+				if nd.Op != "scalar_i32_add" || len(nd.Args) != 2 {
+					return nil, 0, false
 				}
-				fmt.Fprintf(b, "\t%s %s, R12\n", ctrMov, ctrReg)
+				t1, c1, ok1 := resolveAffine(nd.Args[0], depth+1)
+				if !ok1 {
+					return nil, 0, false
+				}
+				t2, c2, ok2 := resolveAffine(nd.Args[1], depth+1)
+				if !ok2 {
+					return nil, 0, false
+				}
+				return append(append([]int{}, t1...), t2...), c1 + c2, true
+			}
+			return nil, 0, false
+		}
+		// emitIters leaves (iters-1) in R12. Form 1 branches to after
+		// the check when the loop runs zero times; form 2 always runs
+		// at least once and clamps (counter - thresh - 1) at zero.
+		ctrMov := "MOVL"
+		if loop.CounterWide {
+			ctrMov = "MOVQ"
+		}
+		emitIters := func(lbl string) (post string) {
+			fmt.Fprintf(b, "\t%s %s, R12\n", ctrMov, ctrReg)
+			if hoistForm == 1 {
 				if sh > 0 {
 					fmt.Fprintf(b, "\tSHRQ $%d, R12\n", sh)
 				}
 				b.WriteString("\tTESTQ R12, R12\n")
-				fmt.Fprintf(b, "\tJZ %s\n", skip)
+				fmt.Fprintf(b, "\tJZ %s\n", lbl)
 				b.WriteString("\tSUBQ $1, R12\n")
+				return lbl
+			}
+			fmt.Fprintf(b, "\tSUBQ $%d, R12\n", int64(loop.ExitThresh)+1)
+			fmt.Fprintf(b, "\tJGE %s\n", lbl)
+			b.WriteString("\tXORL R12, R12\n")
+			fmt.Fprintf(b, "%s:\n", lbl)
+			return ""
+		}
+		checkedSpans := map[string]bool{}
+		rewrote := false
+		for i := range nodes {
+			n := &nodes[i]
+			var width int64
+			var ncOp string
+			switch n.Op {
+			case "v128_load_rng":
+				ncOp = "v128_load_nc"
+			case "v128_load":
+				width, ncOp = 16, "v128_load_nc"
+			case "v128_load32_splat":
+				width, ncOp = 4, "v128_load32_splat_nc"
+			case "v128_load16x4_u":
+				width, ncOp = 8, "v128_load16x4_u_nc"
+			case "v128_load32_zero":
+				width, ncOp = 4, "v128_load32_zero_nc"
+			case "v128_load64_zero":
+				width, ncOp = 8, "v128_load64_zero_nc"
+			default:
+				continue
+			}
+			terms, base, aok := resolveAffine(n.Args[0], 0)
+			if !aok {
+				continue
+			}
+			var d int64
+			bad := false
+			for _, tm := range terms {
+				if dynamic[tm] {
+					bad = true
+				}
+				d += deltaOf[tm]
+			}
+			if bad || d < 0 || d > 1<<20 {
+				continue
+			}
+			var end int64
+			if n.Op == "v128_load_rng" {
+				rlo, span := n.Args[2], n.Args[3]
+				if rlo.Kind != simdfuse.ArgConst || span.Kind != simdfuse.ArgConst || rlo.Const < 0 {
+					continue
+				}
+				end = base + int64(rlo.Const) + int64(uint32(span.Const))
+			} else {
+				off := n.Args[1]
+				if off.Kind != simdfuse.ArgConst || off.Const < 0 {
+					continue
+				}
+				end = base + int64(off.Const) + width
+			}
+			key := fmt.Sprintf("%v/%d/%d", terms, end, d)
+			if !checkedSpans[key] {
+				checkedSpans[key] = true
+				post := emitIters(fmt.Sprintf("gcasmfxh%s_%d", site, i))
 				if d != 0 {
 					fmt.Fprintf(b, "\tIMUL3Q $%d, R12, R12\n", d)
 				}
-				fmt.Fprintf(b, "\tADDQ %s, R12\n", x64FusedArgRegs[1+a.Index])
+				for _, tm := range terms {
+					fmt.Fprintf(b, "\tADDQ %s, R12\n", x64FusedArgRegs[1+tm])
+				}
 				fmt.Fprintf(b, "\tADDQ $%d, R12\n", end)
 				x64MemSizeCheck(b, offs)
-				fmt.Fprintf(b, "%s:\n", skip)
+				if post != "" {
+					fmt.Fprintf(b, "%s:\n", post)
+				}
 				hoistedTrap = true
 			}
-			n.Op = "v128_load_nc"
+			n.Op = ncOp
 			n.Args = n.Args[:2]
 			rewrote = true
 		}

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -559,12 +559,10 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 				}
 			} else {
 				b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
-				b.WriteString("\tVPHADDD Y2, Y2, Y2\n")
-				b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
 				if !hasAcc {
-					fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
+					x64PairFold(b, 2, dst)
 				} else {
-					b.WriteString("\tVPUNPCKLQDQ X3, X2, X2\n")
+					x64PairFold(b, 2, 2)
 					fmt.Fprintf(b, "\tVPADDD X%d, X2, X%d\n", accReg, dst)
 				}
 				if !vexClean {
@@ -589,9 +587,7 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 			if !loc[a.Index].chained {
 				v = loc[a.Index].pool
 			}
-			fmt.Fprintf(b, "\tVPHADDD Y%d, Y%d, Y2\n", v, v)
-			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
-			fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
+			x64PairFold(b, v, dst)
 			b.WriteString("\t// avx2 dot\n")
 			loc[i] = fusedLoc{chained: willChain, pool: dst}
 			continue
@@ -1025,38 +1021,25 @@ func x64FusedLoad(b *strings.Builder, n simdfuse.Node, scalarReg func(simdfuse.A
 			return addOffErr
 		}
 		addOff(1)
-	case "v128_load32_splat_nc":
-		if d, ok := x64DeferOff(n.Args[1]); ok {
-			fmt.Fprintf(b, "\tVMOVSS %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
-		} else {
-			addOff(1)
-			fmt.Fprintf(b, "\tVMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+	case "v128_load32_splat_nc", "v128_load16x4_u_nc", "v128_load32_zero_nc", "v128_load64_zero_nc":
+		// Unchecked narrow loads (window check hoisted at the loop
+		// head): a 4-byte VMOVSS or 8-byte VMOVQ, then the op's own
+		// widen where it has one.
+		mov := "VMOVSS"
+		if n.Op == "v128_load16x4_u_nc" || n.Op == "v128_load64_zero_nc" {
+			mov = "VMOVQ"
 		}
-		fmt.Fprintf(b, "\tVPSHUFD $0x00, X%d, X%d\n", dst, dst)
-		return addOffErr
-	case "v128_load16x4_u_nc":
 		if d, ok := x64DeferOff(n.Args[1]); ok {
-			fmt.Fprintf(b, "\tVMOVQ %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
+			fmt.Fprintf(b, "\t%s %s(%s)(R12*1), X%d\n", mov, d, x64MemBase(b, offs), dst)
 		} else {
 			addOff(1)
-			fmt.Fprintf(b, "\tVMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+			fmt.Fprintf(b, "\t%s (%s)(R12*1), X%d\n", mov, x64MemBase(b, offs), dst)
 		}
-		fmt.Fprintf(b, "\tVPMOVZXWD X%d, X%d\n", dst, dst)
-		return addOffErr
-	case "v128_load32_zero_nc":
-		if d, ok := x64DeferOff(n.Args[1]); ok {
-			fmt.Fprintf(b, "\tVMOVSS %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
-		} else {
-			addOff(1)
-			fmt.Fprintf(b, "\tVMOVSS (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
-		}
-		return addOffErr
-	case "v128_load64_zero_nc":
-		if d, ok := x64DeferOff(n.Args[1]); ok {
-			fmt.Fprintf(b, "\tVMOVQ %s(%s)(R12*1), X%d\n", d, x64MemBase(b, offs), dst)
-		} else {
-			addOff(1)
-			fmt.Fprintf(b, "\tVMOVQ (%s)(R12*1), X%d\n", x64MemBase(b, offs), dst)
+		switch n.Op {
+		case "v128_load32_splat_nc":
+			fmt.Fprintf(b, "\tVPSHUFD $0x00, X%d, X%d\n", dst, dst)
+		case "v128_load16x4_u_nc":
+			fmt.Fprintf(b, "\tVPMOVZXWD X%d, X%d\n", dst, dst)
 		}
 		return addOffErr
 	case "v128_load_rng":
@@ -1723,6 +1706,15 @@ func x64NodesVexClean(nodes []simdfuse.Node) bool {
 		return false
 	}
 	return true
+}
+
+// x64PairFold collapses an 8-lane VPMADDWD pair-domain ymm value to
+// the four-consecutive-byte i32x4 grouping: lane j of the result is
+// P2j + P2j+1. Y2/X3 are scratch; dst may equal src.
+func x64PairFold(b *strings.Builder, src, dst int) {
+	fmt.Fprintf(b, "\tVPHADDD Y%d, Y%d, Y2\n", src, src)
+	b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
+	fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
 }
 
 // x64VexArgsOK reports whether every argument is a register-resident

--- a/internal/gcasm/simdsplice_fuse_x64.go
+++ b/internal/gcasm/simdsplice_fuse_x64.go
@@ -381,6 +381,22 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 				}
 				return pool.addBlob(blob)
 			}
+			if !portable {
+				// Feature body: hardware conversion, the x64 mirror of
+				// the arm64 xtn+fcvtl pair. Mask each lane to its low
+				// 16 bits (the conversion reads nothing else), pack the
+				// four u32 lanes into four contiguous u16s (exact — the
+				// masked values fit unsaturated), and convert with
+				// VCVTPH2PS (F16C, which the HasAVX2 gate requires).
+				// All VEX-128, so no ymm upper state is dirtied. The
+				// marker routes non-AVX2 hosts to the portable twin.
+				fmt.Fprintf(b, "\tVPAND ·%s(SB), X%d, X1\n", c4(0xFFFF), src)
+				b.WriteString("\tVPACKUSDW X1, X1, X1\n")
+				fmt.Fprintf(b, "\tVCVTPH2PS X1, X%d\n", dst)
+				b.WriteString("\t// avx2 dot\n")
+				loc[i] = fusedLoc{chained: willChain, pool: dst}
+				continue
+			}
 			fmt.Fprintf(b, "\tMOVOU X%d, X3\n", src)
 			b.WriteString("\tPSLLL $16, X3\n")
 			fmt.Fprintf(b, "\tPAND \u00b7%s(SB), X3\n", c4(0x80000000))
@@ -468,6 +484,73 @@ func x64SpliceFusedCore(b *strings.Builder, tree *simdfuse.Tree, pool *ConstPool
 				// dependency that serializes the loop (measured 30x on
 				// Granite Rapids). A fully VEX region defers this to
 				// one clear at the exit instead.
+				b.WriteString("\tVZEROUPPER\n")
+			}
+			b.WriteString("\t// avx2 dot\n")
+			loc[i] = fusedLoc{chained: willChain, pool: dst}
+			continue
+		} else if n.Op == x64OpRawDot || n.Op == x64OpRawDotAcc {
+			// Raw 16-byte 8-bit dot (see x64CrossDotRewrite): 8-lane
+			// madd across one ymm, then collapse to the four-byte
+			// grouping. Y2/Y3 (X2/X3) are scratch the pool never
+			// occupies; byte sources stage BEFORE either extend runs
+			// (X2 is Y2's own low half), and every source is read
+			// before dst is written, so dst may alias a source.
+			args := n.Args
+			accSrc := ""
+			if n.Op == x64OpRawDotAcc {
+				a := args[0]
+				if a.Kind != simdfuse.ArgNode {
+					return nil, false, fmt.Errorf("fused splice %s: %s accumulator is not a node", tree.Name, n.Op)
+				}
+				if loc[a.Index].chained {
+					accSrc = "X0"
+				} else {
+					accSrc = fmt.Sprintf("X%d", loc[a.Index].pool)
+				}
+				args = args[1:]
+			}
+			rawSrc := func(a simdfuse.Arg, stage int) (string, error) {
+				switch a.Kind {
+				case simdfuse.ArgNode:
+					if loc[a.Index].chained {
+						return "X0", nil
+					}
+					return fmt.Sprintf("X%d", loc[a.Index].pool), nil
+				case simdfuse.ArgPairIn:
+					if cr, isCarried := carried[a.Index]; isCarried {
+						return fmt.Sprintf("X%d", cr), nil
+					}
+					lo, hi := pairRegs(a)
+					fmt.Fprintf(b, "\tMOVQ %s, X%d\n", lo, stage)
+					fmt.Fprintf(b, "\tPINSRQ $1, %s, X%d\n", hi, stage)
+					return fmt.Sprintf("X%d", stage), nil
+				default:
+					return "", fmt.Errorf("fused splice %s: malformed %s args", tree.Name, n.Op)
+				}
+			}
+			ra, err := rawSrc(args[0], 2)
+			if err != nil {
+				return nil, false, err
+			}
+			rb, err := rawSrc(args[1], 3)
+			if err != nil {
+				return nil, false, err
+			}
+			fmt.Fprintf(b, "\tVPMOVSXBW %s, Y2\n", ra)
+			fmt.Fprintf(b, "\tVPMOVSXBW %s, Y3\n", rb)
+			b.WriteString("\tVPMADDWD Y3, Y2, Y2\n")
+			b.WriteString("\tVPHADDD Y2, Y2, Y2\n")
+			b.WriteString("\tVEXTRACTI128 $1, Y2, X3\n")
+			if accSrc == "" {
+				fmt.Fprintf(b, "\tVPUNPCKLQDQ X3, X2, X%d\n", dst)
+			} else {
+				b.WriteString("\tVPUNPCKLQDQ X3, X2, X2\n")
+				fmt.Fprintf(b, "\tVPADDD %s, X2, X%d\n", accSrc, dst)
+			}
+			if !vexClean {
+				// See the block dot above: uppers must not stay dirty
+				// into legacy SSE code.
 				b.WriteString("\tVZEROUPPER\n")
 			}
 			b.WriteString("\t// avx2 dot\n")
@@ -1448,13 +1531,20 @@ var x64VexOps = map[string]func(b *strings.Builder, srcs []string, dst int){
 // uppers).
 func x64TreeVexClean(tree *simdfuse.Tree) bool {
 	for _, n := range tree.Nodes {
-		if n.Op == a64OpElided || n.Op == x64OpBlockDot || n.Op == "f32x4_splat" {
+		if n.Op == a64OpElided || n.Op == x64OpBlockDot ||
+			n.Op == x64OpRawDot || n.Op == x64OpRawDotAcc || n.Op == "f32x4_splat" {
+			continue
+		}
+		if n.Op == "f16x4_cvt" {
+			// VEX-128 VCVTPH2PS sequence in feature bodies — and the
+			// caller only consults this in feature bodies (usedAVX
+			// and vexClean are both !portable-gated).
 			continue
 		}
 		if n.Class() != simdfuse.ClassV128 {
 			continue // scalar chains emit VEX FP ops
 		}
-		if simdfuse.IsStore(n.Op) || n.Op == "v128_load32_lane" || n.Op == "f16x4_cvt" {
+		if simdfuse.IsStore(n.Op) || n.Op == "v128_load32_lane" {
 			return false
 		}
 		if _, isMem := fusedMemOpsA64[n.Op]; isMem {

--- a/internal/gcasm/simdsplice_mem_a64.go
+++ b/internal/gcasm/simdsplice_mem_a64.go
@@ -32,6 +32,12 @@ type Config struct {
 	// gate it and validate with token-level equivalence instead of
 	// the byte-equality probe.
 	FastMath bool
+	// DisableRepackGemm opts out of the repack GEMM retarget: the
+	// wholesale replacement of an exported dbg_gemm_q8_0_4x4 body
+	// with the native 4x4 tile kernel (see Build). The retarget is
+	// already FastMath-gated; this switch exists for A/B comparison
+	// and fault isolation of that one replacement.
+	DisableRepackGemm bool
 	// FuseLoopUnroll is the in-splice unroll factor: how many
 	// iteration steps a fused loop's fast lane emits per branch.
 	// 0 or 1 means no in-splice unrolling; 2..8 unroll.

--- a/internal/lower/inline.go
+++ b/internal/lower/inline.go
@@ -2,6 +2,7 @@ package lower
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/goccy/wasm2go/internal/ssa"
@@ -63,7 +64,13 @@ type fnInlineInfo struct {
 	bodyBytes int
 	leaf      bool // no call / call_indirect anywhere in the body
 	hasTry    bool
-	sites     int // static `call <idx>` sites referencing this function
+	// noInline pins the function out-of-line regardless of size: it
+	// is a stable export the downstream gcasm backend retargets by
+	// name (the repack dbg_ kernels). Inlining it into every caller
+	// would leave the exported body dead and the retarget landing on
+	// unreachable code.
+	noInline bool
+	sites    int // static `call <idx>` sites referencing this function
 	// innerCalls lists the direct callees inside the body (dedup'd);
 	// hasIndirect marks a call_indirect. A non-leaf body may still
 	// inline when every inner call is direct and non-throwing: the
@@ -94,6 +101,20 @@ func analyzeModuleForInline(mod *wasm.Module) *inlineAnalysis {
 	for i := range mod.Functions {
 		idx := mod.NumImportedFuncs + uint32(i)
 		a.fns[idx] = &fnInlineInfo{bodyBytes: len(mod.Functions[i].Body), leaf: true}
+	}
+	// Exported retarget anchors: pin them out-of-line so the gcasm
+	// backend's by-name kernel retarget lands on a live body. The
+	// engine names these dbg_* by convention.
+	// Only the batched GEMM is pinned: the GEMV runs at nrows=1 in
+	// the decode hot path, where its per-call overhead outweighs the
+	// tile benefit, so it stays inlinable. The GEMM tile earns its
+	// keep only when a caller batches four or more rows.
+	for _, e := range mod.Exports {
+		if e.Kind == wasm.ExportFunc && strings.HasPrefix(e.Name, "dbg_gemm_") {
+			if info, ok := a.fns[e.Index]; ok {
+				info.noInline = true
+			}
+		}
 	}
 	for i := range mod.Functions {
 		idx := mod.NumImportedFuncs + uint32(i)
@@ -188,7 +209,7 @@ func (ls *lowerState) shouldInline(funcIdx uint32, ft wasm.FuncType) bool {
 		return false
 	}
 	info, ok := ls.inlineInfo.fns[funcIdx]
-	if !ok || info.hasTry {
+	if !ok || info.hasTry || info.noInline {
 		return false
 	}
 	// A non-leaf body may inline when every inner call is direct,

--- a/internal/lower/inline_noinline_test.go
+++ b/internal/lower/inline_noinline_test.go
@@ -1,0 +1,28 @@
+package lower
+
+import (
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// A dbg_-exported function is pinned out-of-line so the gcasm
+// retarget lands on a live body, even when it is small enough to
+// inline; an ordinary small leaf is still inlinable.
+func TestExportedRetargetAnchorNotInlined(t *testing.T) {
+	body := []byte{0x0b} // just `end`: a tiny leaf body
+	mod := &wasm.Module{
+		Functions: []wasm.Function{{Body: body}, {Body: body}},
+		Exports: []wasm.Export{
+			{Name: "dbg_gemm_q8_0_4x4", Kind: wasm.ExportFunc, Index: 0},
+			{Name: "dbg_gemv_q8_0_4x4", Kind: wasm.ExportFunc, Index: 1},
+		},
+	}
+	a := analyzeModuleForInline(mod)
+	if !a.fns[0].noInline {
+		t.Error("dbg_-exported function must be pinned noInline")
+	}
+	if a.fns[1].noInline {
+		t.Error("gemv (nrows=1 decode kernel) must stay inlinable")
+	}
+}

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -135,11 +135,12 @@ func Translate(w io.Writer, m *Module, opts Options) (Result, error) {
 		}
 	}
 	gcasmFiles, gstats, err := gcasm.Build(m, mainBuf.Bytes(), treeIn, opts.OutputImportPath, res.FusedSimd, res.FusedLoops, res.Outlined, synthSigs, nrc2, gcasm.Config{
-		FastMath:         opts.FastMath,
-		FuseLoopUnroll:   opts.FuseLoopUnroll,
-		DirectAsm:        directAsm,
-		DirectAsmGlobals: res.DirectAsmGlobals,
-		DirectAsmExc:     directAsmExc,
+		FastMath:          opts.FastMath,
+		DisableRepackGemm: opts.DisableRepackGemm,
+		FuseLoopUnroll:    opts.FuseLoopUnroll,
+		DirectAsm:         directAsm,
+		DirectAsmGlobals:  res.DirectAsmGlobals,
+		DirectAsmExc:      directAsmExc,
 	})
 	if err != nil {
 		return res, fmt.Errorf("gcasm backend: %w", err)


### PR DESCRIPTION
## Why

The llamawasm2go v0.3.0 rebundle moved mul_mat onto ggml's interleaved q8_0x4 repack gemv/gemm. Those kernels keep two i32x4_add chains per block (all extend_low half dots in one, all extend_high in the other) and combine them with even/odd dword-select shuffles — a shape the amd64 (low, high) pairing walk never matches, so amd64 fell back to literal SSE pair ops while arm64's cross-chain SDOT rewrite kept firing. Measured on the go-llama native-gap bench (same runner, single thread, qwen2.5-0.5b q8_0): amd64 tg 11.8 vs native 33.1 (36%), pp 12.9 vs 88.0 (15%); arm64 sits at 68%/28%.

## What

- **x64CrossDotRewrite** — the amd64 twin of a64CrossSdotRewrite, matching the combine on the raw node forms and rebuilding it as a chain of synthetic raw block dots. Emission: one ymm VPMOVSXBW×2 + VPMADDWD per 16-byte leaf, collapsed to the four-consecutive-byte grouping with VPHADDD + VEXTRACTI128 + VPUNPCKLQDQ, VPADDD accumulation. Exact for **all** inputs (VPMADDWD widens into i32; no saturation anywhere — deliberately not the VPSIGNB/VPMADDUBSW route, which wraps on -128), and i32 add regrouping is associative, so bit-identical to the literal lowering. Feature-body only; portable twins keep SSE via the existing dual-body dispatch.
- **f16x4_cvt** feature bodies now emit mask + VPACKUSDW + VCVTPH2PS (3 ops, F16C — already required by the HasAVX2 gate) instead of the 15-op SSE2 bit trick; the x64 mirror of arm64's xtn+fcvtl. The software conversion was among the hottest instructions in the amd64 pp profile.

## Testing

Rewrite/emission/portable-suppression unit tests mirror the a64 cross-sdot tests; a real-assembler acceptance test builds the emitted bodies for linux/amd64. `make lint` clean, gcasm+codegen suites green. Bundle-level validation (verify suites + greedy gate + same-runner bench vs native) runs through the llama-wasm rebundle next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)