### PR TITLE
gcasm: fix cross-chunk symbol gaps in the direct-call path

### DIFF
--- a/internal/asmgen/asmgen.go
+++ b/internal/asmgen/asmgen.go
@@ -111,16 +111,20 @@ type FuncOptions struct {
 	// slot-only mode (no register homes, no m-cache, no loop-carry
 	// coalesce) because splice bodies clobber registers freely.
 	Splicer SimdSplicer
-	// CalleeSymbol, when non-nil, resolves a direct-call target to a
-	// locally CALLable bare asm symbol (no ·/(SB) decoration; possibly
-	// a host-emitted forward wrapper). Calls resolved this way are
-	// exempt from ForbidCalls — the host guarantees the symbol links
-	// in the package the body lands in. ok=false falls back to the
-	// FuncSymbol spelling and the ForbidCalls consequence.
+	// CalleeSymbol, when non-nil, resolves a direct-call target to
+	// the plan 9 symbol operand to CALL, without the "(SB)" suffix:
+	// a package-local "·name" (possibly a host-emitted forward
+	// wrapper) or a spelled cross-package "pkg·name" reference. The
+	// operand is emitted verbatim — goAsmSymbol is NOT applied, so
+	// the host controls the exact spelling. Calls resolved this way
+	// are exempt from ForbidCalls — the host guarantees the symbol
+	// links in the package the body lands in. ok=false falls back to
+	// the FuncSymbol spelling and the ForbidCalls consequence.
 	CalleeSymbol func(funcIdx uint32) (string, bool)
 	// MemHelperSymbol likewise resolves the memory-op helper family
 	// (memorySize / memoryGrow / memoryCopy / memoryFill and their 64
-	// variants) to a locally CALLable bare symbol.
+	// variants) to a CALLable symbol operand (same shape as
+	// CalleeSymbol: no "(SB)" suffix, emitted verbatim).
 	MemHelperSymbol func(name string) (string, bool)
 	// PackedParams, when non-nil, marks the packed outlined-boundary
 	// form: the Go-side signature carries only the module pointer and
@@ -2305,7 +2309,7 @@ func planFunc(f *ssa.Func, opts FuncOptions, sig wasm.FuncType, callArgBias int,
 						z, ok1 := opts.MemHelperSymbol("wasm_trap_div_zero")
 						ovf, ok2 := opts.MemHelperSymbol("wasm_trap_int_overflow")
 						if ok1 && ok2 {
-							p.trapDivZero, p.trapIntOvf = "·"+z, "·"+ovf
+							p.trapDivZero, p.trapIntOvf = z, ovf
 							break
 						}
 						p.divRemInline = false
@@ -2351,24 +2355,32 @@ func planFunc(f *ssa.Func, opts FuncOptions, sig wasm.FuncType, callArgBias int,
 				if err != nil {
 					return nil, fmt.Errorf("OpCallDirect v%d: callee %d frame: %w", v.ID, calleeIdx, err)
 				}
-				var bareName string
+				symbol := ""
 				resolved := false
 				if opts.CalleeSymbol != nil {
-					bareName, resolved = opts.CalleeSymbol(calleeIdx)
+					var operand string
+					if operand, resolved = opts.CalleeSymbol(calleeIdx); resolved {
+						// The resolver hands back the exact operand
+						// (local "·name" or spelled cross-package
+						// "pkg·name") — use it verbatim; goAsmSymbol
+						// would mis-split a spelled name (its dots
+						// are U+00B7, not ASCII ".").
+						symbol = operand + "(SB)"
+					}
 				}
 				if !resolved {
 					// Unresolved callees count against ForbidCalls.
 					p.noteNonSimdCall(v)
+					bareName := fmt.Sprintf("Fn%d", calleeIdx)
 					if opts.FuncSymbol != nil {
 						bareName = opts.FuncSymbol(calleeIdx)
-					} else {
-						bareName = fmt.Sprintf("Fn%d", calleeIdx)
 					}
+					symbol = goAsmSymbol(bareName)
 				}
 				p.directs[v.ID] = &directCall{
 					sig:    csig,
 					frame:  cframe,
-					symbol: goAsmSymbol(bareName),
+					symbol: symbol,
 				}
 				if cframe.argSize > maxCallee {
 					maxCallee = cframe.argSize
@@ -2494,18 +2506,15 @@ func planFunc(f *ssa.Func, opts FuncOptions, sig wasm.FuncType, callArgBias int,
 				if err != nil {
 					return nil, fmt.Errorf("%v v%d: frame: %w", v.Op, v.ID, err)
 				}
-				// OpMem* lowerings always CALL the same-package
-				// helper symbol — `·memorySize(SB)` etc. In
-				// multi-package mode the caller is responsible for
-				// emitting a chunk-local trampoline that uses
-				// //go:linkname to bridge to the canonical
-				// implementation living in base. Plan9 asm cannot
-				// CALL across packages on user code, so the indirect
-				// hop is mandatory.
+				// OpMem* lowerings CALL the operand the resolver
+				// hands back — `·memorySize(SB)` same-package, or in
+				// multi-package mode the chunk-local //go:linkname
+				// trampoline the host registers to bridge to the
+				// canonical implementation living in base.
 				sym := ""
 				if opts.MemHelperSymbol != nil {
-					if bare, ok := opts.MemHelperSymbol(helperName); ok {
-						sym = fmt.Sprintf("·%s(SB)", bare)
+					if operand, ok := opts.MemHelperSymbol(helperName); ok {
+						sym = operand + "(SB)"
 					}
 				}
 				if sym == "" {
@@ -3458,10 +3467,10 @@ func wrapperSymbol(helperPfx, name string) string {
 // embed a "/" or "." inside a symbol operand — the U+00B7 /
 // U+2215 substitution we apply here. Any other punctuation that
 // Go module paths permit ("-", "+", "~", ...) has no plan 9
-// counterpart, which is why the asm-CALL optimization in
-// asm_bundle.go is gated behind isPlan9AsmSafe and falls back to
-// the per-chunk Go-body wrapper for hyphenated host paths
-// (see asm_bundle.go's comment on buildAsmFilesMultiChunk).
+// counterpart, which is why the cross-package asm-CALL shapes in
+// internal/codegen and internal/gcasm are gated behind
+// Plan9AsmPathSafe (plan9path.go) and fall back to per-chunk
+// Go-body wrappers for hyphenated host paths.
 //
 // The split between package and symbol uses the LAST dot, which
 // is the only dot that can legitimately separate path from symbol

--- a/internal/asmgen/plan9path.go
+++ b/internal/asmgen/plan9path.go
@@ -1,0 +1,49 @@
+package asmgen
+
+// Plan9AsmPathSafe reports whether an import path can be embedded in
+// a plan 9 asm symbol operand (via the U+00B7 / U+2215 spelling that
+// goAsmSymbol applies — see its doc comment for the lexer mechanics).
+//
+// The asm lexer (src/cmd/asm/internal/lex/tokenizer.go: isIdentRune)
+// accepts letters, "_", U+00B7 and U+2215 as identifier runes, plus
+// digits AFTER the first rune, and nothing else. Two consequences:
+//
+//   - "." and "/" are the only ASCII punctuation an operand can
+//     carry (through the Unicode substitution); anything else Go
+//     module paths permit ("-", "+", "~", " ", ...) has no plan 9
+//     counterpart and is unrepresentable — there is no escape
+//     syntax.
+//
+//   - A spelled path lexes as ONE identifier starting at the path's
+//     first byte, so a digit-leading host ("4d63.com/...",
+//     "0xacab.org/...") is unrepresentable too: position 0 of the
+//     identifier would be a digit and the token lexes as a number.
+//
+// The empty path is rejected so callers treat it as unsafe.
+//
+// This single function is the contract both halves of a generated
+// bundle consult: internal/codegen keys the decl-only vs
+// wrapper-pair linkname alias shape off it, and internal/gcasm keys
+// the direct-CALL vs gcasmFwd forwarding shape plus the
+// gcasmABI0Keep anchor off it. Keeping one copy is what guarantees
+// the two decisions can never disagree.
+func Plan9AsmPathSafe(path string) bool {
+	if path == "" {
+		return false
+	}
+	if c := path[0]; !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_') {
+		return false
+	}
+	for i := 1; i < len(path); i++ {
+		c := path[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_' || c == '.' || c == '/':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/asmgen/plan9path.go
+++ b/internal/asmgen/plan9path.go
@@ -31,7 +31,11 @@ func Plan9AsmPathSafe(path string) bool {
 	if path == "" {
 		return false
 	}
-	if c := path[0]; !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_') {
+	switch c := path[0]; {
+	case c >= 'a' && c <= 'z':
+	case c >= 'A' && c <= 'Z':
+	case c == '_':
+	default:
 		return false
 	}
 	for i := 1; i < len(path); i++ {

--- a/internal/asmgen/plan9path_test.go
+++ b/internal/asmgen/plan9path_test.go
@@ -1,0 +1,60 @@
+package asmgen
+
+import "testing"
+
+// TestPlan9AsmPathSafe pins the shared safety predicate that decides
+// whether an import path can be embedded verbatim into a plan 9 asm
+// symbol operand (mapping "/" → "∕" and "." → "·") or whether the
+// generators must fall back to per-chunk Go-body wrappers because
+// some byte of the path has no plan 9 identifier substitute.
+func TestPlan9AsmPathSafe(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Single-name stdlib-style paths: safe.
+		{"runtime", true},
+		{"syscall", true},
+		// Nested paths with letters / digits / underscores: safe.
+		{"internal/runtime/atomic", true},
+		{"a/b/c", true},
+		{"foo_bar/baz", true},
+		{"_x/y", true},
+		{"gentest/pkg", true},
+		// Domain-style paths: dots are remapped to U+00B7, still safe.
+		{"github.com/foo/bar", true},
+		{"github.com/goccy/wasm2go/internal", true},
+		{"x.y.z/pkg", true},
+		{"example.org/x_y/v2", true},
+		// Digits are identifier runes only AFTER the first rune: a
+		// digit-leading host would put a digit at position 0 of the
+		// spelled operand, which the asm lexer scans as a number, not
+		// an identifier. Real Go module hosts like this exist.
+		{"4d63.com/mymod/pkg", false},
+		{"0xacab.org/x", false},
+		// ...while a digit anywhere later in the path is fine.
+		{"h4d63.com/mymod/pkg", true},
+		{"example.org/0user/pkg", true},
+		// Hyphen has no identifier-rune substitute — unsafe. This is
+		// what makes any module path containing a "-" fall back to
+		// the per-chunk Go-body wrappers.
+		{"github.com/example/foo-bar", false},
+		{"github.com/goccy/some-hyphen/pkg", false},
+		{"a-b", false},
+		// Other punctuation that can legally appear in module paths
+		// but breaks plan 9 asm identifier scanning.
+		{"a+b", false},
+		{"host.tld/a+b", false},
+		{"a~b", false},
+		{"foo bar", false},
+		{"host.tld/sp ace", false},
+		// Empty path: treated as unsafe so the caller skips the
+		// optimization rather than emitting "·" alone.
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := Plan9AsmPathSafe(c.path); got != c.want {
+			t.Errorf("Plan9AsmPathSafe(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/internal/codegen/asm_bundle.go
+++ b/internal/codegen/asm_bundle.go
@@ -14,48 +14,6 @@ import (
 	"strings"
 )
 
-// isPlan9AsmSafe reports whether path can be embedded into a plan 9
-// asm symbol operand by mapping "/" → U+2215 ("∕") and "." →
-// U+00B7 ("·"). The plan 9 asm lexer is the source of truth:
-//
-//   - src/cmd/asm/internal/lex/tokenizer.go: isIdentRune accepts
-//     unicode.IsLetter, digits (after the first character), "_",
-//     U+00B7, and U+2215 — and nothing else.
-//
-//   - src/cmd/asm/internal/lex/lex.go: lex.Make post-processes
-//     identifier tokens with `strings.ReplaceAll`, mapping U+00B7
-//     back to "." and U+2215 back to "/" before the name is
-//     handed to the symbol-lookup pass. So the only ASCII
-//     punctuation that survives a round-trip through the scanner
-//     into a symbol operand is "." and "/" — every other character
-//     ("-", "+", "~", " ", ...) has no plan 9 substitute and is
-//     simply unrepresentable in an asm CALL operand. There is no
-//     escape syntax: macros must themselves be alphanumeric
-//     identifiers (input.go: macroName) and string literals are
-//     immediate-only ("string constant must be an immediate").
-//
-// Any byte outside [A-Za-z0-9_./] therefore forces a fall back to
-// the per-chunk Go-body trampoline so the asm CALL stays a local
-// ·FnN(SB) reference. Empty path is rejected so the caller treats
-// it as unsafe.
-func isPlan9AsmSafe(path string) bool {
-	if path == "" {
-		return false
-	}
-	for i := 0; i < len(path); i++ {
-		c := path[i]
-		switch {
-		case c >= 'a' && c <= 'z':
-		case c >= 'A' && c <= 'Z':
-		case c >= '0' && c <= '9':
-		case c == '_' || c == '.' || c == '/':
-		default:
-			return false
-		}
-	}
-	return true
-}
-
 // wasmFuncBodyName matches the identifiers codegen uses for wasm
 // function bodies — `Fn<N>` in multi-package mode, `fn<N>` in
 // single-package mode. Anything else (export wrappers, helpers,

--- a/internal/codegen/cg_helpers_unit_test.go
+++ b/internal/codegen/cg_helpers_unit_test.go
@@ -347,47 +347,6 @@ func TestFloatInitExpr(t *testing.T) {
 	}
 }
 
-// TestIsPlan9AsmSafe pins the per-byte safety predicate that decides
-// whether the asm CALL syntax can embed a Go import path verbatim
-// (mapping "/" → "∕" and "." → "·") or whether we have to fall back
-// to the per-chunk Go-body trampoline because some byte in the path
-// has no plan 9 identifier substitute.
-func TestIsPlan9AsmSafe(t *testing.T) {
-	cases := []struct {
-		path string
-		want bool
-	}{
-		// Single-name stdlib-style paths: safe.
-		{"runtime", true},
-		{"syscall", true},
-		// Nested paths with letters / digits / underscores: safe.
-		{"internal/runtime/atomic", true},
-		{"a/b/c", true},
-		{"foo_bar/baz", true},
-		// Domain-style paths: dots are remapped to U+00B7, still safe.
-		{"github.com/foo/bar", true},
-		{"x.y.z/pkg", true},
-		// Hyphen has no identifier-rune substitute — unsafe. This is
-		// what makes any module path containing a "-" fall back to
-		// the per-chunk Go-body trampoline.
-		{"github.com/example/foo-bar", false},
-		{"a-b", false},
-		// Other punctuation that can legally appear in module paths
-		// but breaks plan 9 asm identifier scanning.
-		{"a+b", false},
-		{"a~b", false},
-		{"foo bar", false},
-		// Empty path: treated as unsafe so the caller skips the
-		// optimization rather than emitting "·" alone.
-		{"", false},
-	}
-	for _, c := range cases {
-		if got := isPlan9AsmSafe(c.path); got != c.want {
-			t.Errorf("isPlan9AsmSafe(%q) = %v, want %v", c.path, got, c.want)
-		}
-	}
-}
-
 // TestPlanLinknamePackagesPublic exercises the package-public chunk
 // planner against an arbitrary parsed module. The behavioural
 // guarantees we assert are minimal and stable across any future

--- a/internal/codegen/translate_linkname.go
+++ b/internal/codegen/translate_linkname.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/goccy/wasm2go/internal/asmgen"
 	"github.com/goccy/wasm2go/internal/wasm"
 )
 
@@ -417,7 +418,7 @@ func (t *translator) emitChunkAliasFiles(pkgName string, callerChunk int, dir st
 	// wrapper-pair shape forces the Go compiler to emit the local
 	// ABI0 wrapper that asm `CALL ·FnN(SB)` resolves through.
 	asmKind := linknameForwardWrapperPair
-	if isPlan9AsmSafe(t.opts.OutputImportPath) {
+	if asmgen.Plan9AsmPathSafe(t.opts.OutputImportPath) {
 		asmKind = linknameForwardDeclOnly
 	}
 	asmForwards := t.emitWasmFnForwards(callerChunk, asmKind)

--- a/internal/gcasm/asmsym.go
+++ b/internal/gcasm/asmsym.go
@@ -2,37 +2,17 @@ package gcasm
 
 import "strings"
 
-// plan9AsmPathSafe reports whether an import path can be embedded in a
-// plan 9 asm symbol operand. The asm lexer accepts letters, digits,
-// "_", U+00B7 and U+2215 as identifier runes and maps the latter two
-// back to "." and "/" (src/cmd/asm/internal/lex), so "." and "/" are
-// the only ASCII punctuation an operand can carry — anything else
-// ("-", "+", "~", ...) is unrepresentable and forces the Go-wrapper
-// forwarding path. This mirrors codegen.isPlan9AsmSafe; the two
-// packages cannot share it without an import cycle.
-func plan9AsmPathSafe(path string) bool {
-	if path == "" {
-		return false
-	}
-	for i := 0; i < len(path); i++ {
-		c := path[i]
-		switch {
-		case c >= 'a' && c <= 'z':
-		case c >= 'A' && c <= 'Z':
-		case c >= '0' && c <= '9':
-		case c == '_' || c == '.' || c == '/':
-		default:
-			return false
-		}
-	}
-	return true
-}
+// Whether an import path can be embedded in a plan 9 asm symbol
+// operand at all is decided by asmgen.Plan9AsmPathSafe — the single
+// shared predicate this package's direct-CALL / gcasmABI0Keep gates
+// and codegen's linkname alias shape both consult, so the two halves
+// of a bundle can never disagree.
 
 // asmSpellPath renders an import path as a plan 9 asm identifier
 // prefix: "." becomes U+00B7 ("·") and "/" becomes U+2215 ("∕"),
 // which the asm lexer folds back to the ASCII forms, so the linker
 // sees the canonical dotted path. Only meaningful for paths
-// plan9AsmPathSafe accepts.
+// asmgen.Plan9AsmPathSafe accepts.
 func asmSpellPath(path string) string {
 	path = strings.ReplaceAll(path, ".", "·")
 	return strings.ReplaceAll(path, "/", "∕")

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/goccy/wasm2go/internal/asmgen"
 	"github.com/goccy/wasm2go/internal/simdfuse"
 	"github.com/goccy/wasm2go/internal/wasm"
 )
@@ -645,6 +646,11 @@ func buildPkg(
 	stdlibUsed := map[string]bool{}
 
 	fallbackNames := map[string]bool{}
+	// textNames records every captured fn that emitted a TEXT body
+	// (transformed, gated-split, or direct-asm). Together with
+	// fallbackNames it must cover the whole capture — the invariant
+	// the post-loop check below enforces.
+	textNames := map[string]bool{}
 	pool := &ConstPool{}
 	types := &TypeTable{}
 	jt := &JTTable{}
@@ -695,7 +701,7 @@ func buildPkg(
 			// A path plan 9 cannot spell (e.g. a hyphenated host repo)
 			// or a callee outside the capture keeps the historical
 			// Go-wrapper hop.
-			if fnOwner[cname] == cpkg && plan9AsmPathSafe(cpkg) {
+			if fnOwner[cname] == cpkg && asmgen.Plan9AsmPathSafe(cpkg) {
 				return params, hasRes, res, asmSpellPath(cpkg) + "·" + cname, true
 			}
 			wrap := "gcasmFwd" + cname
@@ -784,6 +790,7 @@ func buildPkg(
 				asmB.WriteString(dab)
 				asmB.WriteString("\n")
 				stats.DirectAsm++
+				textNames[name] = true
 				declFns.WriteString("func " + name + declSig(rel, name, declParams, hasRes, res, synth) + "\n")
 				continue
 			}
@@ -925,6 +932,7 @@ func buildPkg(
 					mirrorVar, featureRef, mirrorVar, featureRef)
 			}
 			fmt.Fprintf(&declFns, "func %s%s\nfunc %s%s\nfunc %s%s\n", name, sig, featSym, sig, portSym, sig)
+			textNames[name] = true
 			continue
 		}
 		asmB.WriteString(body)
@@ -933,6 +941,7 @@ func buildPkg(
 			stats.JumpTables++
 		}
 		stats.Transformed++
+		textNames[name] = true
 		declFns.WriteString("func " + name + sig + "\n")
 	}
 	stats.SimdSpliced += splices.Spliced
@@ -943,6 +952,20 @@ func buildPkg(
 	for _, n := range outlinedNames {
 		if !seenSynth[n] {
 			return nil, fmt.Errorf("outlined %s: not present in the %s capture", n, arch.name)
+		}
+	}
+	// Every captured fn must leave the loop above either with a TEXT
+	// body or registered as a pure-Go fallback. A name that slips
+	// both sets has no symbol in this package at all, and — worse —
+	// other chunks may already have spelled a direct CALL against it
+	// (see calleeSig), a hole that would otherwise surface only as a
+	// link error in the consumer build. Each degrade path added to
+	// the loop must keep this invariant; the check catches the one
+	// that forgets.
+	for _, f := range pfns {
+		name := f.Name[strings.LastIndex(f.Name, ".")+1:]
+		if !textNames[name] && !fallbackNames[name] {
+			return nil, fmt.Errorf("%s: dropped by the %s build: neither transformed to asm nor registered as a pure-Go fallback", name, arch.name)
 		}
 	}
 
@@ -960,7 +983,7 @@ func buildPkg(
 	// wrappers for every cross-chunk call, so no direct reference to a
 	// fallback fn is ever made and the anchor would be pure dead
 	// weight — skip it there.
-	if len(fallbackNames) > 0 && plan9AsmPathSafe(importPath) {
+	if len(fallbackNames) > 0 && asmgen.Plan9AsmPathSafe(importPath) {
 		var names []string
 		for n := range fallbackNames {
 			names = append(names, n)

--- a/internal/gcasm/crosschunk_test.go
+++ b/internal/gcasm/crosschunk_test.go
@@ -10,23 +10,6 @@ import (
 	"github.com/goccy/wasm2go/internal/wasm"
 )
 
-func TestPlan9AsmPathSafe(t *testing.T) {
-	for path, want := range map[string]bool{
-		"":                                  false,
-		"gentest/pkg":                       true,
-		"github.com/goccy/llamawasm2go/p1":  true,
-		"github.com/goccy/some-hyphen/pkg":  false,
-		"example.org/x_y/v2":                true,
-		"host.tld/a+b":                      false,
-		"host.tld/sp ace":                   false,
-		"github.com/goccy/wasm2go/internal": true,
-	} {
-		if got := plan9AsmPathSafe(path); got != want {
-			t.Errorf("plan9AsmPathSafe(%q) = %v, want %v", path, got, want)
-		}
-	}
-}
-
 func TestAsmSpellPath(t *testing.T) {
 	got := asmSpellPath("github.com/goccy/llamawasm2go/p1")
 	want := "github·com∕goccy∕llamawasm2go∕p1"
@@ -102,9 +85,19 @@ func TestCrossChunkDirectCalls(t *testing.T) {
 }
 
 // TestCrossChunkWrapperFallback: an import path plan 9 asm cannot
-// spell (a hyphen) keeps the historical Go-wrapper forwarding shape.
+// spell keeps the historical Go-wrapper forwarding shape. Both
+// unspellable classes are covered: a hyphenated host path, and a
+// digit-leading host path (the asm lexer accepts digits only after
+// the first identifier rune, so "4d63·com∕..." would lex as a
+// number, not a symbol).
 func TestCrossChunkWrapperFallback(t *testing.T) {
-	files := buildMultiChunk(t, "cg_crosscall", "github.com/gen-test/pkg")
+	for _, importPath := range []string{"github.com/gen-test/pkg", "4d63.com/gentest/pkg"} {
+		t.Run(importPath, func(t *testing.T) { assertWrapperFallback(t, importPath) })
+	}
+}
+
+func assertWrapperFallback(t *testing.T, importPath string) {
+	files := buildMultiChunk(t, "cg_crosscall", importPath)
 	var spelled, wrappers, anchors int
 	for name, data := range files {
 		if strings.HasSuffix(name, ".s") {
@@ -125,6 +118,78 @@ func TestCrossChunkWrapperFallback(t *testing.T) {
 	// anchor would be pure dead weight — it must not be emitted.
 	if anchors != 0 {
 		t.Errorf("%d gcasmABI0Keep anchors emitted for an unspellable path; none should be (no direct calls)", anchors)
+	}
+}
+
+// TestCrossChunkDirectAsmCallSymbols: a function retained for
+// direct-asm emission whose body makes cross-chunk calls must emit
+// the same CALL operand shapes the listing transform does — a
+// spelled remote symbol on a spellable path, never a
+// current-package-qualified mangling of it ("CALL ·github·com∕...")
+// that could not link.
+func TestCrossChunkDirectAsmCallSymbols(t *testing.T) {
+	defer codegen.SetMultiPackageThreshold(64)()
+	bin := testfixture.Wasm(t, "cg_crosscall_directasm")
+	mod, err := wasm.Parse(bytes.NewReader(bin))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const importPath = "github.com/gentest/pkg"
+	var buf bytes.Buffer
+	// Fn2 ($mid) calls Fn0/Fn1 across chunks; Fn4 (the export) also
+	// calls the fallback fn Fn3 ($wide), covering the anchor-resolved
+	// shape from a direct-asm body too.
+	res, err := codegen.Translate(&buf, mod, codegen.Options{
+		Package: "pkg", OutputImportPath: importPath,
+		DirectAsmFuncs: []string{"Fn2", "Fn4"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.DirectAsmSSA) == 0 {
+		t.Fatal("translator retained no direct-asm SSA; the direct-asm path is not exercised")
+	}
+	directAsm := map[string]DirectAsmFn{}
+	for name, df := range res.DirectAsmSSA {
+		directAsm[name] = DirectAsmFn{Fn: df.Fn, Sig: df.Sig, Packed: df.Packed, PackedParams: df.PackedParams}
+	}
+	treeIn := map[string][]byte{}
+	for name, data := range res.Sidecars {
+		treeIn[name] = data
+	}
+	for name, data := range res.Files {
+		treeIn[name] = data
+	}
+	files, stats, err := Build(mod, buf.Bytes(), treeIn, importPath, nil, nil, nil, nil, nil,
+		Config{DirectAsm: directAsm, DirectAsmGlobals: res.DirectAsmGlobals})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.DirectAsm == 0 {
+		t.Fatal("no direct-asm body emitted; the direct-asm path is not exercised")
+	}
+	var directBodies, spelledInDirect int
+	for name, data := range files {
+		if !strings.HasSuffix(name, ".s") {
+			continue
+		}
+		s := string(data)
+		// A spelled remote symbol re-wrapped as current-package-local
+		// can never link; it must not appear anywhere in the bundle.
+		if strings.Contains(s, "·github·com") {
+			t.Errorf("%s: current-package-mangled spelled symbol (CALL ·github·com...) emitted", name)
+		}
+		if !strings.Contains(s, "// direct-asm: ") {
+			continue
+		}
+		directBodies++
+		spelledInDirect += strings.Count(s, "CALL github·com∕gentest∕pkg")
+	}
+	if directBodies == 0 {
+		t.Fatal("no .s file carries a direct-asm body marker")
+	}
+	if spelledInDirect == 0 {
+		t.Error("no spelled cross-chunk CALL emitted from a direct-asm body")
 	}
 }
 

--- a/internal/gcasm/directasm.go
+++ b/internal/gcasm/directasm.go
@@ -71,17 +71,19 @@ func emitDirectAsmBody(mod *wasm.Module, name string, df DirectAsmFn, archName s
 		opts.HelperPrefix = "base"
 	}
 	// Direct-call and memory-op callees resolve through the same
-	// machinery the listing transform uses; resolution registers the
-	// chunk-local forward wrapper as a side effect, so the returned
-	// symbol always links in this package.
+	// machinery the listing transform uses. calleeSig returns the
+	// exact CALL operand — a local "·name", a chunk-local forward
+	// wrapper it registers as a side effect, or a spelled remote
+	// "pkg·FnN" reference — and asmgen emits it verbatim, so every
+	// shape links from this package.
 	opts.CalleeSymbol = func(idx uint32) (string, bool) {
 		for _, bare := range []string{fmt.Sprintf("Fn%d", idx), fmt.Sprintf("fn%d", idx)} {
 			owner, ok := fnOwner[bare]
 			if !ok {
 				continue
 			}
-			if _, _, _, localSym, ok2 := calleeSig(owner + "." + bare); ok2 {
-				return strings.TrimPrefix(localSym, "·"), true
+			if _, _, _, sym, ok2 := calleeSig(owner + "." + bare); ok2 {
+				return sym, true
 			}
 		}
 		return "", false
@@ -91,8 +93,8 @@ func emitDirectAsmBody(mod *wasm.Module, name string, df DirectAsmFn, archName s
 		if rel != "" {
 			qualified = importPath + "/base." + strings.ToUpper(helper[:1]) + helper[1:]
 		}
-		if _, _, _, localSym, ok := calleeSig(qualified); ok {
-			return strings.TrimPrefix(localSym, "·"), true
+		if _, _, _, sym, ok := calleeSig(qualified); ok {
+			return sym, true
 		}
 		return "", false
 	}

--- a/testdata/cg_crosscall_directasm.wat
+++ b/testdata/cg_crosscall_directasm.wat
@@ -1,0 +1,81 @@
+(module
+  ;; Cross-chunk direct calls made from direct-asm-retained bodies.
+  ;; Unlike cg_crosscall.wat, every op here lowers to native
+  ;; instructions (no rotl/rotr/div, which become helper CALLs the
+  ;; direct-asm emitter's ForbidCalls refuses), so the retained
+  ;; functions actually emit via internal/asmgen and their
+  ;; cross-chunk CALL operands are exercised. Bodies are padded past
+  ;; the tiny multi-package chunk budgets the tests use, so each
+  ;; function lands in its own chunk package.
+
+  ;; leafA: a long dependent i64 chain of native-lowering ops.
+  (func $leafA (param $a i64) (param $b i64) (result i64)
+    (local $x i64)
+    (local.set $x (i64.add (local.get $a) (local.get $b)))
+    (local.set $x (i64.mul (local.get $x) (i64.const 31)))
+    (local.set $x (i64.xor (local.get $x) (i64.const 0x9e3779b97f4a7c15)))
+    (local.set $x (i64.add (local.get $x) (i64.shr_u (local.get $x) (i64.const 7))))
+    (local.set $x (i64.mul (local.get $x) (i64.const 0x100000001b3)))
+    (local.set $x (i64.xor (local.get $x) (i64.shl (local.get $x) (i64.const 13))))
+    (local.set $x (i64.add (local.get $x) (i64.const 12345)))
+    (local.set $x (i64.sub (local.get $x) (i64.shl (local.get $a) (i64.const 17))))
+    (local.set $x (i64.xor (local.get $x) (i64.shr_u (local.get $b) (i64.const 9))))
+    (local.set $x (i64.mul (local.get $x) (i64.const 7)))
+    (i64.add (local.get $x) (i64.shr_s (local.get $x) (i64.const 3))))
+
+  ;; leafB: a different long chain.
+  (func $leafB (param $a i64) (result i64)
+    (local $y i64)
+    (local.set $y (i64.mul (local.get $a) (i64.const 0x5851f42d4c957f2d)))
+    (local.set $y (i64.add (local.get $y) (i64.const 0x14057b7ef767814f)))
+    (local.set $y (i64.xor (local.get $y) (i64.shr_u (local.get $y) (i64.const 33))))
+    (local.set $y (i64.mul (local.get $y) (i64.const 0xff51afd7ed558ccd)))
+    (local.set $y (i64.xor (local.get $y) (i64.shr_u (local.get $y) (i64.const 29))))
+    (local.set $y (i64.add (local.get $y) (i64.shl (local.get $a) (i64.const 5))))
+    (local.set $y (i64.sub (local.get $y) (i64.const 999)))
+    (local.set $y (i64.or (local.get $y) (i64.const 1)))
+    (i64.mul (local.get $y) (i64.const 3)))
+
+  ;; mid combines both leaves; retained for direct-asm, so its two
+  ;; cross-chunk calls come out of the asmgen emitter.
+  (func $mid (param $a i64) (param $b i64) (result i64)
+    (local $z i64)
+    (local.set $z (i64.add
+      (call $leafA (local.get $a) (local.get $b))
+      (call $leafB (local.get $a))))
+    (local.set $z (i64.xor (local.get $z) (i64.shr_u (local.get $z) (i64.const 11))))
+    (local.set $z (i64.mul (local.get $z) (i64.const 5)))
+    (local.set $z (i64.add (local.get $z) (i64.shr_u (local.get $b) (i64.const 21))))
+    (local.set $z (i64.sub (local.get $z) (i64.shl (local.get $a) (i64.const 2))))
+    (local.set $z (i64.xor (local.get $z) (i64.const 0x0f0f0f0f0f0f0f0f)))
+    (i64.add (local.get $z) (i64.const 42)))
+
+  ;; wide: enough i64 params to overflow the register ABI, so this
+  ;; function keeps its pure Go body (sig fallback) while its callers
+  ;; are transformed — a direct-asm caller's CALL then resolves
+  ;; against the ABI0 wrapper the gcasmABI0Keep anchor forces out.
+  (func $wide
+      (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64)
+      (result i64)
+    (i64.add (local.get 0)
+    (i64.add (local.get 1)
+    (i64.add (local.get 2)
+    (i64.add (local.get 3)
+    (i64.add (local.get 4)
+    (i64.add (local.get 5)
+    (i64.add (local.get 6)
+    (i64.add (local.get 7)
+    (i64.add (local.get 8)
+    (i64.add (local.get 9)
+    (i64.add (local.get 10) (local.get 11)))))))))))))
+
+  (func (export "crosscall_da") (param $a i64) (param $b i64) (result i64)
+    (i64.add
+      (i64.add
+        (call $mid (local.get $a) (local.get $b))
+        (call $leafB (local.get $b)))
+      (call $wide
+        (local.get $a) (local.get $b) (local.get $a) (local.get $b)
+        (local.get $a) (local.get $b) (local.get $a) (local.get $b)
+        (local.get $a) (local.get $b) (local.get $a) (local.get $b))))
+)


### PR DESCRIPTION
Follow-up fixes for gaps found while reviewing #61 (direct cross-chunk asm calls).

## Bug 1: direct-asm bodies mangled the new spelled cross-chunk symbols

The direct-asm resolvers in `internal/gcasm/directasm.go` did `strings.TrimPrefix(localSym, "·")` on `calleeSig`'s result and handed the remainder to asmgen, whose `goAsmSymbol` re-derives the operand by splitting at the last ASCII `.`. Since #61, `calleeSig` returns spelled remote symbols (`github·com∕...∕p2·Fn0`) whose dots are U+00B7 — no ASCII `.` to split on — so `goAsmSymbol` re-wrapped the whole thing as a current-package reference (`CALL ·github·com∕...(SB)`). That symbol resolves to `<callerChunkPkg>.github.com/.../Fn0`, which never exists: any function retained for direct-asm emission (`--direct-asm`) that makes a resolved cross-chunk call produced an undefined symbol at consumer link time. This was a regression from the pre-#61 wrapper path and had no test coverage (the #61 tests pass `Config{}` with no `DirectAsm`).

Fix: the `CalleeSymbol` / `MemHelperSymbol` contract now carries the exact plan 9 operand (local `·name` or spelled `pkg·name`, without the `(SB)` suffix) and asmgen emits it verbatim; the gcasm adapters pass `calleeSig`'s result through unchanged.

The new `cg_crosscall_directasm.wat` fixture keeps every op native (no `rotl`/`rotr`, which lower to helper CALLs that the direct-asm emitter's `ForbidCalls` refuses) so the retained functions actually emit via asmgen. Its regression test fails against the pre-fix code with the mangled spelling in the emitted bundle on both arches:

```
--- FAIL: TestCrossChunkDirectAsmCallSymbols
    crosschunk_test.go:180: p3/amd64.s: current-package-mangled spelled symbol (CALL ·github·com...) emitted
    crosschunk_test.go:180: p3/arm64.s: current-package-mangled spelled symbol (CALL ·github·com...) emitted
```

## Bug 2: digit-leading import paths passed the spellability predicate

The plan 9 asm lexer accepts digits as identifier runes only **after** the first rune, but `plan9AsmPathSafe` / `isPlan9AsmSafe` accepted a digit at position 0. A consumer module on a digit-leading host (real ones exist: `4d63.com`, `0xacab.org`) would get `CALL 4d63·com∕...(SB)`, which lexes as a number and fails to assemble. The predicate now requires a letter or `_` first, and the wrapper-fallback test covers a digit-leading path alongside the hyphenated one.

## Consolidation: one predicate instead of two copies

The predicate existed byte-for-byte in both `internal/codegen` and `internal/gcasm` under a comment claiming "the two packages cannot share it without an import cycle" — `go list -deps` shows no such cycle (neither package imports the other; both can import `internal/asmgen`). It now lives once as `asmgen.Plan9AsmPathSafe`, next to `goAsmSymbol`, so codegen's linkname-alias-shape decision and gcasm's direct-CALL / `gcasmABI0Keep` anchor gates consult the same function and can never disagree (relevant for bug 2, which would otherwise have had to be fixed in two places in lockstep).

## Hardening: Build-time coverage check

The invariant "every captured fn either emits a TEXT body or registers as a pure-Go fallback" was held only by convention spread across the emission loop's growing set of degrade paths (`errUnsupportedDuff`, `errUnsupportedJumpTable`, `errSimdPairUnspliced`, direct-asm fallback). A path that forgets `fallbackNames` would surface only as a link error in the consumer repo — no Build-time diagnostic, and other chunks may already have spelled a direct CALL against the dropped fn. `buildPkg` now checks the invariant after the loop and returns a Build error naming the dropped fn.

## Verification

Commands run in this branch's worktree, all exit 0:

- `go build ./...`
- `go test ./... -count=1` (full wasm2go module suite, including the ~139s gcasm and ~168s codegen suites)
- Red/green check: with `internal/asmgen/asmgen.go` and `internal/gcasm/directasm.go` restored to the #61 merge commit, `go test ./internal/gcasm -run TestCrossChunkDirectAsmCallSymbols` fails as shown above; with the fix it passes.

Not run: the external consumer e2e chain (wasmify plugin → `googlesql-wasm` buf generate → `go-googlesql` build → `googlesqlite-wasm2go` tests). No claim is made about it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
