### PR TITLE
gcasm: widen the repack GEMM tiles (amd64 i16 prepass, arm64 SMMLA 8x4) and gate SMMLA on FEAT_I8MM

### DIFF
--- a/internal/codegen/helpers/cpufeat_arm64_darwin.go
+++ b/internal/codegen/helpers/cpufeat_arm64_darwin.go
@@ -9,7 +9,19 @@ import "syscall"
 // portable twin body runs when it is false.
 var CPUDotProd = detectDotProd()
 
+// CPUI8MM reports FEAT_I8MM (SMMLA/UMMLA); see the linux twin for
+// why it is detected apart from CPUDotProd.
+var CPUI8MM = detectI8MM()
+
 func detectDotProd() bool {
-	v, err := syscall.SysctlUint32("hw.optional.arm.FEAT_DotProd")
+	return sysctlFeature("hw.optional.arm.FEAT_DotProd")
+}
+
+func detectI8MM() bool {
+	return sysctlFeature("hw.optional.arm.FEAT_I8MM")
+}
+
+func sysctlFeature(name string) bool {
+	v, err := syscall.SysctlUint32(name)
 	return err == nil && v != 0
 }

--- a/internal/codegen/helpers/cpufeat_arm64_linux.go
+++ b/internal/codegen/helpers/cpufeat_arm64_linux.go
@@ -12,16 +12,33 @@ import (
 // portable twin body runs when it is false.
 var CPUDotProd = detectDotProd()
 
+// CPUI8MM reports FEAT_I8MM (the SMMLA/UMMLA int8 matrix
+// instructions). The tile kernels branch on it at entry and fall
+// back to their dotprod bodies when it is false — FEAT_DotProd
+// without FEAT_I8MM is common (Neoverse N1, Cortex-A76..X1, Apple
+// M1), so the two are detected separately.
+var CPUI8MM = detectI8MM()
+
 func detectDotProd() bool {
-	// AT_HWCAP (16), HWCAP_ASIMDDP (bit 20), from the auxiliary
-	// vector: unswappable 8-byte key/value pairs.
+	// AT_HWCAP (16), HWCAP_ASIMDDP (bit 20).
+	return auxvBit(16, 20)
+}
+
+func detectI8MM() bool {
+	// AT_HWCAP2 (26), HWCAP2_I8MM (bit 13).
+	return auxvBit(26, 13)
+}
+
+// auxvBit reports bit `bit` of the auxiliary-vector entry `key`:
+// unswappable 8-byte key/value pairs.
+func auxvBit(key uint64, bit uint) bool {
 	auxv, err := os.ReadFile("/proc/self/auxv")
 	if err != nil {
 		return false
 	}
 	for i := 0; i+16 <= len(auxv); i += 16 {
-		if binary.LittleEndian.Uint64(auxv[i:]) == 16 {
-			return binary.LittleEndian.Uint64(auxv[i+8:])&(1<<20) != 0
+		if binary.LittleEndian.Uint64(auxv[i:]) == key {
+			return binary.LittleEndian.Uint64(auxv[i+8:])&(1<<bit) != 0
 		}
 	}
 	return false

--- a/internal/codegen/helpers/cpufeat_arm64_other.go
+++ b/internal/codegen/helpers/cpufeat_arm64_other.go
@@ -2,6 +2,7 @@
 
 package helpers
 
-// CPUDotProd: no detection story on this OS — run the portable
-// bodies.
+// CPUDotProd / CPUI8MM: no detection story on this OS — run the
+// portable bodies.
 var CPUDotProd = false
+var CPUI8MM = false

--- a/internal/codegen/simd_fuse_f16gather.go
+++ b/internal/codegen/simd_fuse_f16gather.go
@@ -530,17 +530,35 @@ func (fb *fusedTreeBuilder) compactDeadNodes(roots []int) []int {
 			mark(i)
 		}
 	}
+	// Rebuild in index order, except that a node's operands are placed
+	// before the node: a rewrite that appends a fresh operand node at
+	// the end of the list (the gather's collapsed 8-byte load) would
+	// otherwise leave a forward reference, and the pure twin body
+	// emits nodes in list order. Hoisting a dependency to just before
+	// its first consumer keeps every other relative order intact — the
+	// load lands where the chain's last lane load used to be.
 	remap := make([]int, n)
+	for i := range remap {
+		remap[i] = -1
+	}
 	var newNodes []simdfuse.Node
 	newNodeVals := fb.nodeVals[:0:0]
-	for i := 0; i < n; i++ {
-		if !live[i] {
-			remap[i] = -1
-			continue
+	var place func(i int)
+	place = func(i int) {
+		if remap[i] >= 0 || !live[i] {
+			return
+		}
+		for _, a := range fb.nodes[i].Args {
+			if a.Kind == simdfuse.ArgNode && remap[a.Index] < 0 {
+				place(a.Index)
+			}
 		}
 		remap[i] = len(newNodes)
 		newNodes = append(newNodes, fb.nodes[i])
 		newNodeVals = append(newNodeVals, fb.nodeVals[i])
+	}
+	for i := 0; i < n; i++ {
+		place(i)
 	}
 	for i := range newNodes {
 		for ai := range newNodes[i].Args {

--- a/internal/codegen/simd_fuse_f16gather_test.go
+++ b/internal/codegen/simd_fuse_f16gather_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/goccy/wasm2go/internal/simdfuse"
+	"github.com/goccy/wasm2go/internal/ssa"
 )
 
 func mustExpr(t *testing.T, src string) ast.Expr {
@@ -129,5 +130,36 @@ func TestWordOperandIdent(t *testing.T) {
 	}
 	if _, ok := wordOperandIdent(mustExpr(t, "v1+v2")); ok {
 		t.Fatal("binary expr accepted as word operand")
+	}
+}
+
+// compactDeadNodes must leave no forward references: the gather
+// rewrite appends its collapsed load after the f16x4_cvt that consumes
+// it, and the pure twin body emits nodes in list order.
+func TestCompactDeadNodesHoistsForwardOperands(t *testing.T) {
+	fb := &fusedTreeBuilder{}
+	fb.nodes = []simdfuse.Node{
+		{Op: "f16x4_cvt", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 3}}},
+		{Op: "f32x4_mul", Args: []simdfuse.Arg{{Kind: simdfuse.ArgNode, Index: 0}, {Kind: simdfuse.ArgPairIn, Index: 0}}},
+		{Op: "v128_load32_zero", Args: []simdfuse.Arg{{Kind: simdfuse.ArgConst, Const: 64}, {Kind: simdfuse.ArgConst, Const: 0}}}, // dead
+		{Op: "v128_load16x4_u", Args: []simdfuse.Arg{{Kind: simdfuse.ArgConst, Const: 128}, {Kind: simdfuse.ArgConst, Const: 0}}},
+	}
+	fb.nodeVals = make([]*ssa.Value, len(fb.nodes))
+	roots := fb.compactDeadNodes([]int{1})
+	if len(fb.nodes) != 3 {
+		t.Fatalf("live nodes = %d, want 3 (dead load32_zero dropped): %+v", len(fb.nodes), fb.nodes)
+	}
+	for i, nd := range fb.nodes {
+		for _, a := range nd.Args {
+			if a.Kind == simdfuse.ArgNode && a.Index >= i {
+				t.Fatalf("node %d %s references node %d at or after itself: %+v", i, nd.Op, a.Index, fb.nodes)
+			}
+		}
+	}
+	if fb.nodes[0].Op != "v128_load16x4_u" || fb.nodes[1].Op != "f16x4_cvt" || fb.nodes[2].Op != "f32x4_mul" {
+		t.Fatalf("order = %s %s %s, want load, cvt, mul", fb.nodes[0].Op, fb.nodes[1].Op, fb.nodes[2].Op)
+	}
+	if len(roots) != 1 || roots[0] != 2 {
+		t.Fatalf("roots = %v, want [2]", roots)
 	}
 }

--- a/internal/gcasm/a64exec_test.go
+++ b/internal/gcasm/a64exec_test.go
@@ -30,7 +30,9 @@ func runArm64Gate(t *testing.T, dir, pkg, runName, diag string) {
 	}
 	cmd := exec.Command(bin, "-test.run", runName, "-test.v")
 	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		t.Fatalf("arm64 execution failed: %v\n%s\n--- asm ---\n%s", err, out, diag)
 	}
+	t.Logf("arm64 execution:\n%s", out)
 }

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -103,7 +103,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	pure := PureFilter(all)
 
 	repackGemmFn := repackGemmExport(mod, cfg)
-	simdGemmFn := simdGemmF32Export(mod, cfg)
+	kernelRetargets := kernelRetargetExports(mod, cfg)
 
 	// Capture tree.
 	dir, err := os.MkdirTemp("", "gcasm-capture-*")
@@ -288,7 +288,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 			if len(pfns) == 0 {
 				continue
 			}
-			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, repackGemmFn, simdGemmFn, cfg)
+			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, repackGemmFn, kernelRetargets, cfg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("gcasm bundle %s/%s: %w", pkgOrRoot(rel), spec.name, err)
 			}
@@ -713,7 +713,7 @@ func buildPkg(
 	synth map[string]SynthSig,
 	nrc2 *Nrc2Spec,
 	repackGemmFn string,
-	simdGemmFn string,
+	kernelRetargets map[string]kernelRetarget,
 	cfg Config,
 ) (map[string][]byte, error) {
 	directSSA := cfg.DirectAsm
@@ -935,13 +935,15 @@ func buildPkg(
 		// symbol on a baseline CPU would fault. (Outlined extraction
 		// bodies historically never contained gated instructions, so
 		// including them here is a no-op for them.)
-		// The f32 GEMM retarget rides the same twin split even though
-		// its transformed body has no gated instruction: the native
-		// kernel becomes the feature body (the amd64 one needs AVX2)
-		// and the transformed body stays as the baseline twin.
-		retargetSimdGemm := simdGemmFn != "" && name == simdGemmFn && (arch.name == "arm64" || arch.name == "amd64") &&
+		// The by-export kernel retargets (f32 GEMM, vector exp) ride
+		// the same twin split even though their transformed bodies
+		// have no gated instruction: the native kernel becomes the
+		// feature body (the amd64 ones need AVX2) and the transformed
+		// body stays as the baseline twin.
+		kr, retargetKernel := kernelRetargets[name]
+		retargetKernel = retargetKernel && (arch.name == "arm64" || arch.name == "amd64") &&
 			modOffs != nil && modOffs.Cfg.FastMath && arch.gatedMarker != "" && !strings.Contains(body, arch.jtMarker)
-		if retargetSimdGemm || (arch.gatedMarker != "" &&
+		if retargetKernel || (arch.gatedMarker != "" &&
 			strings.Contains(body, arch.gatedMarker) && !strings.Contains(body, arch.jtMarker)) {
 			// Feature-gated body: the feature symbol keeps this body, a
 			// baseline twin is transformed with PortableSIMD, and a
@@ -1020,20 +1022,19 @@ func buildPkg(
 			// f32 GEMM (flash attention's tiled QK^T / PV): the feature
 			// body is replaced wholesale by a register-tiled kernel
 			// that reproduces the wasm arithmetic exactly.
-			if retargetSimdGemm {
+			if retargetKernel {
 				trapSym := "wasm_trap_simd_oob"
 				if rel != "" && rel != "base" {
 					trapSym = "gcasmFwdH_base_Wasm_trap_simd_oob"
 				}
 				wide := mod.Memory64()
-				_, wantArgs := simdGemmF32Args(wide)
-				if m[1] != fmt.Sprint(wantArgs) {
-					return nil, fmt.Errorf("transform %s: f32 GEMM retarget expects a %d-byte argument frame, transformed body has %s", f.Name, wantArgs, m[1])
+				if want := kr.argBytes(wide); m[1] != fmt.Sprint(want) {
+					return nil, fmt.Errorf("transform %s: %s retarget expects a %d-byte argument frame, transformed body has %s", f.Name, kr.export, want, m[1])
 				}
 				if arch.name == "amd64" {
-					featBody = x64SimdGemmF32Kernel(featSym, trapSym, modOffs, wide)
+					featBody = kr.x64(featSym, trapSym, modOffs, pool, wide)
 				} else {
-					featBody = a64SimdGemmF32Kernel(featSym, trapSym, modOffs, wide)
+					featBody = kr.a64(featSym, trapSym, modOffs, pool, wide)
 				}
 			}
 			if nrc2 != nil && name == nrc2.VecDot && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -935,8 +935,14 @@ func buildPkg(
 		// symbol on a baseline CPU would fault. (Outlined extraction
 		// bodies historically never contained gated instructions, so
 		// including them here is a no-op for them.)
-		if arch.gatedMarker != "" &&
-			strings.Contains(body, arch.gatedMarker) && !strings.Contains(body, arch.jtMarker) {
+		// The f32 GEMM retarget rides the same twin split even though
+		// its transformed body has no gated instruction: the native
+		// kernel becomes the feature body (the amd64 one needs AVX2)
+		// and the transformed body stays as the baseline twin.
+		retargetSimdGemm := simdGemmFn != "" && name == simdGemmFn && (arch.name == "arm64" || arch.name == "amd64") &&
+			modOffs != nil && modOffs.Cfg.FastMath && arch.gatedMarker != "" && !strings.Contains(body, arch.jtMarker)
+		if retargetSimdGemm || (arch.gatedMarker != "" &&
+			strings.Contains(body, arch.gatedMarker) && !strings.Contains(body, arch.jtMarker)) {
 			// Feature-gated body: the feature symbol keeps this body, a
 			// baseline twin is transformed with PortableSIMD, and a
 			// NOSPLIT tail-jump stub under the original name dispatches
@@ -1014,7 +1020,7 @@ func buildPkg(
 			// f32 GEMM (flash attention's tiled QK^T / PV): the feature
 			// body is replaced wholesale by a register-tiled kernel
 			// that reproduces the wasm arithmetic exactly.
-			if simdGemmFn != "" && name == simdGemmFn && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {
+			if retargetSimdGemm {
 				trapSym := "wasm_trap_simd_oob"
 				if rel != "" && rel != "base" {
 					trapSym = "gcasmFwdH_base_Wasm_trap_simd_oob"

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -103,6 +103,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 	pure := PureFilter(all)
 
 	repackGemmFn := repackGemmExport(mod, cfg)
+	simdGemmFn := simdGemmF32Export(mod, cfg)
 
 	// Capture tree.
 	dir, err := os.MkdirTemp("", "gcasm-capture-*")
@@ -287,7 +288,7 @@ func Build(mod *wasm.Module, mainSrc []byte, resFiles map[string][]byte, importP
 			if len(pfns) == 0 {
 				continue
 			}
-			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, repackGemmFn, cfg)
+			files, err := buildPkg(mod, importPath, rel, pfns, ac.dm, pkgSigs, fnKinds, isFallbackSig, fnOwnerByArch[spec.name], pure, archStats, spec, modOffs, fused, fusedLoops, outlined[rel], synth, nrc2, repackGemmFn, simdGemmFn, cfg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("gcasm bundle %s/%s: %w", pkgOrRoot(rel), spec.name, err)
 			}
@@ -712,6 +713,7 @@ func buildPkg(
 	synth map[string]SynthSig,
 	nrc2 *Nrc2Spec,
 	repackGemmFn string,
+	simdGemmFn string,
 	cfg Config,
 ) (map[string][]byte, error) {
 	directSSA := cfg.DirectAsm
@@ -1007,6 +1009,25 @@ func buildPkg(
 						}
 						fmt.Fprintf(&declFns, "// gcasmCPUI8MM mirrors %s for the SMMLA tile kernels'\n// entry branches (asm reads package-local data only).\nvar gcasmCPUI8MM = %s\n\n", i8mmRef, i8mmRef)
 					}
+				}
+			}
+			// f32 GEMM (flash attention's tiled QK^T / PV): the feature
+			// body is replaced wholesale by a register-tiled kernel
+			// that reproduces the wasm arithmetic exactly.
+			if simdGemmFn != "" && name == simdGemmFn && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {
+				trapSym := "wasm_trap_simd_oob"
+				if rel != "" && rel != "base" {
+					trapSym = "gcasmFwdH_base_Wasm_trap_simd_oob"
+				}
+				wide := mod.Memory64()
+				_, wantArgs := simdGemmF32Args(wide)
+				if m[1] != fmt.Sprint(wantArgs) {
+					return nil, fmt.Errorf("transform %s: f32 GEMM retarget expects a %d-byte argument frame, transformed body has %s", f.Name, wantArgs, m[1])
+				}
+				if arch.name == "amd64" {
+					featBody = x64SimdGemmF32Kernel(featSym, trapSym, modOffs, wide)
+				} else {
+					featBody = a64SimdGemmF32Kernel(featSym, trapSym, modOffs, wide)
 				}
 			}
 			if nrc2 != nil && name == nrc2.VecDot && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {

--- a/internal/gcasm/bundle.go
+++ b/internal/gcasm/bundle.go
@@ -633,6 +633,36 @@ func x64DispatchStub(sym, featSym, portSym, mirrorVar, argBytes string) string {
 		"\tJMP ·" + portSym + "(SB)\n"
 }
 
+// a64I8MMDispatchStub is the frameless entry of an arm64 SMMLA tile
+// kernel: it reads the package-local FEAT_I8MM mirror and tail-jumps
+// to the tile kernel when set, else to the bit-exact Go companion.
+// Both targets take the same ABI0 argument frame, and a $0 stub is
+// the only place a tail jump is legal — a kernel with a frame cannot
+// hand off without unwinding it first.
+func a64I8MMDispatchStub(sym, kernelSym, fallbackSym, mirrorVar string, argBytes int) string {
+	return "TEXT ·" + sym + "(SB), NOSPLIT, $0-" + strconv.Itoa(argBytes) + "\n" +
+		"\tMOVBU ·" + mirrorVar + "(SB), R27\n" +
+		"\tCBZ R27, 2(PC)\n" +
+		"\tJMP ·" + kernelSym + "(SB)\n" +
+		"\tJMP ·" + fallbackSym + "(SB)\n"
+}
+
+// nrc2ArgBytes / nrc2ArgType describe the vec_dot companion's ABI0
+// argument frame at the module's pointer width (see a64Nrc2Kernel).
+func nrc2ArgBytes(wide bool) int {
+	if wide {
+		return 64
+	}
+	return 36
+}
+
+func nrc2ArgType(wide bool) string {
+	if wide {
+		return "int64"
+	}
+	return "int32"
+}
+
 // a64DispatchStub is the arm64 feature-dispatch stub: read the mirror
 // bool, tail-jump to the portable twin when it is clear. Same frame,
 // same FP layout — the targets see the original caller's arguments.
@@ -969,6 +999,14 @@ func buildPkg(
 					}
 				} else {
 					featBody = a64RepackGemmKernel(featSym, trapSym, modOffs, wide)
+					if !mirrorVars["gcasmCPUI8MM"] {
+						mirrorVars["gcasmCPUI8MM"] = true
+						i8mmRef := "CPUI8MM"
+						if rel != "" && rel != "base" {
+							i8mmRef = "base." + i8mmRef
+						}
+						fmt.Fprintf(&declFns, "// gcasmCPUI8MM mirrors %s for the SMMLA tile kernels'\n// entry branches (asm reads package-local data only).\nvar gcasmCPUI8MM = %s\n\n", i8mmRef, i8mmRef)
+					}
 				}
 			}
 			if nrc2 != nil && name == nrc2.VecDot && (arch.name == "arm64" || arch.name == "amd64") && modOffs != nil && modOffs.Cfg.FastMath {
@@ -997,7 +1035,24 @@ func buildPkg(
 						fmt.Fprintf(&declFns, "// gcasmHasAVX512VNNI mirrors %s for the tile kernel's\n// entry branch (asm reads package-local data only).\nvar gcasmHasAVX512VNNI = %s\n\n", vnniRef, vnniRef)
 					}
 				} else {
-					asmB.WriteString(a64Nrc2Kernel(fastSym, trapSym, modOffs, wide))
+					// The SMMLA tile needs FEAT_I8MM, which the dotprod
+					// gate that selected this feature body does not
+					// imply: fastSym is a frameless stub that sends
+					// CPUs without I8MM back to the bit-exact Go
+					// companion and the rest to the tile kernel.
+					smmlaSym := fastSym + "smmla"
+					asmB.WriteString(a64I8MMDispatchStub(fastSym, smmlaSym, nrc2.Companion, "gcasmCPUI8MM", nrc2ArgBytes(wide)))
+					asmB.WriteString("\n")
+					asmB.WriteString(a64Nrc2Kernel(smmlaSym, trapSym, modOffs, wide))
+					if !mirrorVars["gcasmCPUI8MM"] {
+						mirrorVars["gcasmCPUI8MM"] = true
+						i8mmRef := "CPUI8MM"
+						if rel != "" && rel != "base" {
+							i8mmRef = "base." + i8mmRef
+						}
+						fmt.Fprintf(&declFns, "// gcasmCPUI8MM mirrors %s for the SMMLA tile kernels'\n// entry stubs (asm reads package-local data only).\nvar gcasmCPUI8MM = %s\n\n", i8mmRef, i8mmRef)
+					}
+					fmt.Fprintf(&declFns, "func %s(m %s, l0 int32, l1 %s, l2 %s, l3 %s, l4 %s, l5 %s, l6 %s)\n", smmlaSym, moduleTypeName(rel), nrc2ArgType(wide), nrc2ArgType(wide), nrc2ArgType(wide), nrc2ArgType(wide), nrc2ArgType(wide), nrc2ArgType(wide))
 				}
 				asmB.WriteString("\n")
 				argType := "int32"

--- a/internal/gcasm/repackgemm_a64.go
+++ b/internal/gcasm/repackgemm_a64.go
@@ -5,25 +5,52 @@ import (
 	"strings"
 )
 
-// a64RepackGemmKernel emits the q8_0x4 repack GEMM under sym: the
-// 4-rows x 4-columns tile the native q8_0_4x4 dotprod path computes,
-// replacing the engine's four sequential gemv-shaped passes. The wasm
-// activation block (block_q8_0x4) already interleaves the four rows'
-// 4-byte groups contiguously, so each 16-byte weight group pairs with
-// ONE 16-byte activation load and four BY-ELEMENT SDOTs:
+// a64RepackGemmChunkBlocks / a64RepackGemmScratch / a64RepackGemmFrame
+// size the SMMLA nest's stack scratch, the arm64 twin of the amd64
+// constants: per block, the two activation row groups' four 8-column
+// pairs zipped into SMMLA A operands = 4 x 64 bytes.
+const (
+	a64RepackGemmChunkBlocks = 256
+	a64RepackGemmScratch     = a64RepackGemmChunkBlocks * 256
+	a64RepackGemmFrame       = 64 + a64RepackGemmScratch
+)
+
+// a64RepackGemmKernel emits the q8_0x4 repack GEMM under sym.
+//
+// Two nests share the prologue and the bounds contract:
+//
+// SMMLA nest (FEAT_I8MM, package mirror gcasmCPUI8MM): an 8-rows x
+// 4-columns tile over two activation row groups at once, so every
+// weight byte streamed from memory feeds 1024 MACs (the native
+// q8_0_4x8 gemm's shape; the 4x4 SDOT tile below feeds 512). The
+// weights stay in their 4x4 interleave: two consecutive 16-byte
+// groups zip (zip1/zip2 .4s) into the two 2-columns x 8-k SMMLA B
+// operands, shared by all eight rows. The activations are zipped the
+// same way ONCE per chunk into the stack scratch, so the block loop
+// loads its A operands ready-made. Eight 2x2 i32 tiles accumulate
+// per block; each converts and scales by drow[r]*dcol[c] built from
+// the two f16 quads (dup .2d of the column pair, zip of the row pair)
+// and adds into eight f32 tiles that unzip (zip1/zip2 .2d) to rows at
+// store time. Row groups beyond the last pair, and every CPU without
+// I8MM, run the SDOT nest.
+//
+// SDOT nest: the 4-rows x 4-columns tile the native q8_0_4x4 dotprod
+// path computes. The wasm activation block (block_q8_0x4) already
+// interleaves the four rows' 4-byte groups contiguously, so each
+// 16-byte weight group pairs with ONE 16-byte activation load and
+// four BY-ELEMENT SDOTs:
 //
 //	sdot vAcc_r.4s, vWeights.16b, vActs.4b[r]
 //
-// — one instruction per (weight group, row), the native kernel's own
-// shape. Per block the four per-row i32x4 column sums convert once,
-// scale by d_col[4]*d_row (FMUL by element + vector FMLA), and
-// accumulate into four f32x4 row accumulators that store once per
-// column group. Integer arithmetic is exact, and the f32 tail keeps
-// the wasm gemm's own multiply/multiply/add sequence and rounding —
-// the same sequence the fused GEMV loops execute — so the batched
-// and single-row paths stay as close as the wasm semantics themselves
-// (prompt batch-size invariance depends on it). FastMath-gated only
-// because the retarget replaces the verified wasm lowering wholesale.
+// Both nests keep the wasm gemm's own per-element arithmetic on every
+// output: exact i32 column sum -> f32 -> x (dcol * drow) -> + running
+// sum, in block order (the same sequence the fused GEMV loops
+// execute, so the batched and single-row paths stay as close as the
+// wasm semantics themselves — prompt batch-size invariance depends on
+// it). Larger K than the scratch holds runs as chunks that accumulate
+// into the output rows in place, in the same block order. FastMath-
+// gated only because the retarget replaces the verified wasm lowering
+// wholesale.
 //
 // C signature (see llama-wasm's arch/wasm/repack.cpp):
 //
@@ -39,7 +66,8 @@ import (
 // l3+32, l4+40, l5(nr)+48, l6(nc)+52.
 //
 // Requires FEAT_DotProd; callers gate the retarget on the dotprod
-// feature dispatch that guards the SDOT bodies.
+// feature dispatch that guards the SDOT bodies. FEAT_I8MM is checked
+// here, at entry.
 // repackGemmArgs returns the ABI0 stack offsets of the GEMM's l1..l6
 // arguments and the frame's argument-byte count for the module's
 // pointer width (see the layout comment above). Shared by the a64 and
@@ -71,6 +99,25 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 		enc := 0x4F80E000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
 		word(enc, fmt.Sprintf("sdot v%d.4s, v%d.16b, v%d.4b[%d]", d, n, m, idx))
 	}
+	// SMMLA: d.4s (2x2) += n (2 rows x 8 i8) · m (2 rows x 8 i8)^T.
+	smmla := func(d, n, m int) {
+		word(0x4E80A400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("smmla v%d.4s, v%d.16b, v%d.16b", d, n, m))
+	}
+	zip1S := func(d, n, m int) {
+		word(0x4E803800|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("zip1 v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+	zip2S := func(d, n, m int) {
+		word(0x4E807800|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("zip2 v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+	zip1D := func(d, n, m int) {
+		word(0x4EC03800|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("zip1 v%d.2d, v%d.2d, v%d.2d", d, n, m))
+	}
+	zip2D := func(d, n, m int) {
+		word(0x4EC07800|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("zip2 v%d.2d, v%d.2d, v%d.2d", d, n, m))
+	}
+	dupD := func(d, n, idx int) {
+		word(0x4E080400|uint32(idx)<<20|uint32(n)<<5|uint32(d), fmt.Sprintf("dup v%d.2d, v%d.d[%d]", d, n, idx))
+	}
 	fcvtl := func(d, n int) { word(0x0E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl v%d.4s, v%d.4h", d, n)) }
 	scvtf := func(d, n int) { word(0x4E21D800|uint32(n)<<5|uint32(d), fmt.Sprintf("scvtf v%d.4s, v%d.4s", d, n)) }
 	fmulLane := func(d, n, m, idx int) {
@@ -97,8 +144,8 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 		w("\t%s\t%s+%d(FP), R%d", mv, name, argOff[name], reg)
 	}
 
-	w("// %s: q8_0x4 repack GEMM, 4x4 tile via by-element SDOT.", sym)
-	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("// %s: q8_0x4 repack GEMM, 8x4 tile via SMMLA / 4x4 tile via by-element SDOT.", sym)
+	w("TEXT ·%s(SB), $%d-%d", sym, a64RepackGemmFrame, argBytes)
 	w("\tNO_LOCAL_POINTERS")
 	w("\tMOVD\tm+0(FP), R0")
 	w("\tMOVD\t%d(R0), R21", offs.MemSize)
@@ -145,10 +192,164 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	w("\tADD\tR20, R2, R11") // s row base (host)
 	w("\tADD\tR20, R4, R22") // vx base (host)
 	w("\tLSL\t$2, R3, R23")  // 4*bs bytes: s row-group stride
+	w("\tMOVBU\t·gcasmCPUI8MM(SB), R26")
+	w("\tCBZ\tR26, gemmsdot")
+
+	// ---- SMMLA nest: row-group pairs.
+	//
+	// R9 chunk byte offset | R24 blocks left | R25 chunk blocks
+	// R19 scratch cursor | R17 ap (group a) | R27 ap (group b)
+	// v0..v7 i32 2x2 tiles (index 2*rowpair+colpair, row pairs
+	// 01a 23a 01b 23b) | v24..v31 f32 tiles | v16..v23 operands.
+	w("gemmm:")
+	w("\tCMPW\t$2, R6")
+	w("\tBLO\tgemmsdot") // 0 or 1 row groups left
+	w("\tMOVD\t$0, R9")
+	w("\tMOVW\tR1, R24")
+	w("gemmmchunk:")
+	w("\tMOVW\t$%d, R25", a64RepackGemmChunkBlocks)
+	w("\tCMPW\tR25, R24")
+	w("\tCSELW\tLO, R24, R25, R25")
+	// Zip this tile's activation chunk: per block and 8-column pair,
+	// A01/A23 of row group a then of row group b (4 x 16 bytes).
+	w("\tADD\tR10, R9, R17")
+	w("\tADD\tR17, R8, R27")
+	w("\tMOVD\t$gemmscratch-%d(SP), R19", a64RepackGemmScratch)
+	w("\tMOVW\tR25, R15")
+	w("\tCBZW\tR15, gemmmx0")
+	w("gemmmpre:")
+	for p := 0; p < 4; p++ {
+		ldurQ(16, 17, 8+32*p)
+		ldurQ(17, 17, 24+32*p)
+		zip1S(18, 16, 17)
+		zip2S(19, 16, 17)
+		sturQ(18, 19, 64*p)
+		sturQ(19, 19, 64*p+16)
+		ldurQ(16, 27, 8+32*p)
+		ldurQ(17, 27, 24+32*p)
+		zip1S(20, 16, 17)
+		zip2S(21, 16, 17)
+		sturQ(20, 19, 64*p+32)
+		sturQ(21, 19, 64*p+48)
+	}
+	w("\tADD\t$136, R17, R17")
+	w("\tADD\t$136, R27, R27")
+	w("\tADD\t$256, R19, R19")
+	w("\tSUBW\t$1, R15, R15")
+	w("\tCBNZW\tR15, gemmmpre")
+	w("gemmmx0:")
+	w("\tADD\tR22, R9, R13") // b column-group cursor at the chunk offset
+	w("\tMOVD\tR11, R14")    // s column cursor
+	w("\tMOVW\tR7, R12")     // x counter
+	w("gemmmx:")
+	// f32 tiles: zero on the first chunk, else the rows' running
+	// sums re-zipped into 2x2 form.
+	w("\tCBNZ\tR9, gemmmxload")
+	for i := 24; i < 32; i++ {
+		movi0(i)
+	}
+	w("\tB\tgemmmxgo")
+	w("gemmmxload:")
+	w("\tMOVD\tR14, R26")
+	for rp := 0; rp < 4; rp++ {
+		ldurQ(16, 26, 0)
+		w("\tADD\tR3, R26, R26")
+		ldurQ(17, 26, 0)
+		w("\tADD\tR3, R26, R26")
+		zip1D(24+2*rp, 16, 17)
+		zip2D(25+2*rp, 16, 17)
+	}
+	w("gemmmxgo:")
+	w("\tMOVD\tR13, R16")
+	w("\tADD\tR10, R9, R17")
+	w("\tADD\tR17, R8, R27")
+	w("\tMOVD\t$gemmscratch-%d(SP), R19", a64RepackGemmScratch)
+	w("\tMOVW\tR25, R15")
+	w("\tCBZW\tR15, gemmmstore")
+	w("gemmmblk:")
+	for i := 0; i < 8; i++ {
+		movi0(i)
+	}
+	for p := 0; p < 4; p++ {
+		ldurQ(16, 16, 8+32*p)
+		ldurQ(17, 16, 24+32*p)
+		zip1S(18, 16, 17) // B01: columns 0,1 x 8 k
+		zip2S(19, 16, 17) // B23
+		ldurQ(20, 19, 64*p)
+		ldurQ(21, 19, 64*p+16)
+		ldurQ(22, 19, 64*p+32)
+		ldurQ(23, 19, 64*p+48)
+		smmla(0, 20, 18)
+		smmla(1, 20, 19)
+		smmla(2, 21, 18)
+		smmla(3, 21, 19)
+		smmla(4, 22, 18)
+		smmla(5, 22, 19)
+		smmla(6, 23, 18)
+		smmla(7, 23, 19)
+	}
+	// Scales. dcol -> [dc0 dc1 dc0 dc1] / [dc2 dc3 dc2 dc3]; each
+	// row group's drow -> [dr0 dr0 dr1 dr1] / [dr2 dr2 dr3 dr3].
+	ldurD(16, 16, 0)
+	fcvtl(16, 16)
+	dupD(18, 16, 0)
+	dupD(19, 16, 1)
+	ldurD(17, 17, 0)
+	fcvtl(17, 17)
+	zip1S(20, 17, 17)
+	zip2S(21, 17, 17)
+	ldurD(17, 27, 0)
+	fcvtl(17, 17)
+	zip1S(22, 17, 17)
+	zip2S(23, 17, 17)
+	// tile(rp, cp): f32 += f32(i32) * (drow_rp * dcol_cp)
+	for i := 0; i < 8; i++ {
+		rp, cp := i/2, i%2
+		fmulV(16, 18+cp, 20+rp)
+		scvtf(i, i)
+		fmulV(i, i, 16)
+		faddV(24+i, 24+i, i)
+	}
+	w("\tADD\t$136, R16, R16")
+	w("\tADD\t$136, R17, R17")
+	w("\tADD\t$136, R27, R27")
+	w("\tADD\t$256, R19, R19")
+	w("\tSUBW\t$1, R15, R15")
+	w("\tCBNZW\tR15, gemmmblk")
+	w("gemmmstore:")
+	// Rows 2rp / 2rp+1 = the low / high halves of tiles (rp,01),(rp,23).
+	w("\tMOVD\tR14, R26")
+	for rp := 0; rp < 4; rp++ {
+		zip1D(16, 24+2*rp, 25+2*rp)
+		zip2D(17, 24+2*rp, 25+2*rp)
+		sturQ(16, 26, 0)
+		w("\tADD\tR3, R26, R26")
+		sturQ(17, 26, 0)
+		w("\tADD\tR3, R26, R26")
+	}
+	w("\tADD\tR8, R13, R13")
+	w("\tADD\t$16, R14, R14")
+	w("\tSUBW\t$1, R12, R12")
+	w("\tCBNZW\tR12, gemmmx")
+	// Next chunk of this tile, if any.
+	w("\tSUBW\tR25, R24, R24")
+	w("\tMOVD\t$136, R26")
+	w("\tMUL\tR25, R26, R26")
+	w("\tADD\tR26, R9, R9")
+	w("\tCBNZW\tR24, gemmmchunk")
+	// Next row-group pair.
+	w("\tADD\tR8<<1, R10, R10")
+	w("\tADD\tR23<<1, R11, R11")
+	w("\tSUBW\t$2, R6, R6")
+	w("\tB\tgemmm")
+
+	// ---- SDOT nest: remaining row groups (all of them without I8MM).
+	w("gemmsdot:")
+	w("\tCBZW\tR6, gemmdone")
 	w("gemmy:")
 	w("\tMOVD\tR22, R13") // b column-group cursor
 	w("\tMOVD\tR11, R14") // s column cursor
-	w("\tMOVD\tR7, R12")  // x counter
+	w("\tMOVW\tR7, R12")  // x counter
 	w("gemmx:")
 	movi0(28)
 	movi0(29)
@@ -156,7 +357,7 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	movi0(31)
 	w("\tMOVD\tR13, R16") // bp
 	w("\tMOVD\tR10, R17") // ap
-	w("\tMOVD\tR1, R15")  // block counter
+	w("\tMOVW\tR1, R15")  // block counter
 	w("\tCBZW\tR15, gemmstore")
 	w("gemmblk:")
 	movi0(24)

--- a/internal/gcasm/repackgemm_a64.go
+++ b/internal/gcasm/repackgemm_a64.go
@@ -42,15 +42,15 @@ const (
 //
 //	sdot vAcc_r.4s, vWeights.16b, vActs.4b[r]
 //
-// Both nests keep the wasm gemm's own per-element arithmetic on every
-// output: exact i32 column sum -> f32 -> x (dcol * drow) -> + running
-// sum, in block order (the same sequence the fused GEMV loops
-// execute, so the batched and single-row paths stay as close as the
-// wasm semantics themselves — prompt batch-size invariance depends on
-// it). Larger K than the scratch holds runs as chunks that accumulate
-// into the output rows in place, in the same block order. FastMath-
-// gated only because the retarget replaces the verified wasm lowering
-// wholesale.
+// The SDOT nest keeps the wasm gemm's own per-element arithmetic on
+// every output: exact i32 column sum -> f32 -> x (dcol * drow) -> +
+// running sum, in block order. The SMMLA nest keeps the exact i32 sums
+// and the block order but fuses the row scale into the accumulate
+// ((f32(sum) * dcol) * drow with one rounding), the native-style
+// rounding the FastMath gate admits; the block tail was 36% of the
+// kernel's time and the fused form is three ops per tile. Larger K than
+// the scratch holds runs as chunks that accumulate into the output
+// rows in place, in the same block order.
 //
 // C signature (see llama-wasm's arch/wasm/repack.cpp):
 //
@@ -126,6 +126,9 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	}
 	fmulV := func(d, n, m int) {
 		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+	fmlaV := func(d, n, m int) {
+		word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
 	faddV := func(d, n, m int) {
 		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
@@ -302,13 +305,16 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	fcvtl(17, 17)
 	zip1S(22, 17, 17)
 	zip2S(23, 17, 17)
-	// tile(rp, cp): f32 += f32(i32) * (drow_rp * dcol_cp)
+	// tile(rp, cp): f32 += (f32(i32) * dcol_cp) * drow_rp — the column
+	// scale by multiply, the row scale fused into the accumulate
+	// (one rounding; fast-math, as the f32 GEMM). This block tail was
+	// 36% of the kernel's time measured with it removed, so it pays
+	// to keep it at three ops per tile.
 	for i := 0; i < 8; i++ {
 		rp, cp := i/2, i%2
-		fmulV(16, 18+cp, 20+rp)
 		scvtf(i, i)
-		fmulV(i, i, 16)
-		faddV(24+i, 24+i, i)
+		fmulV(i, i, 18+cp)
+		fmlaV(24+i, i, 20+rp)
 	}
 	w("\tADD\t$136, R16, R16")
 	w("\tADD\t$136, R17, R17")

--- a/internal/gcasm/repackgemm_a64.go
+++ b/internal/gcasm/repackgemm_a64.go
@@ -42,15 +42,14 @@ const (
 //
 //	sdot vAcc_r.4s, vWeights.16b, vActs.4b[r]
 //
-// The SDOT nest keeps the wasm gemm's own per-element arithmetic on
-// every output: exact i32 column sum -> f32 -> x (dcol * drow) -> +
-// running sum, in block order. The SMMLA nest keeps the exact i32 sums
-// and the block order but fuses the row scale into the accumulate
-// ((f32(sum) * dcol) * drow with one rounding), the native-style
-// rounding the FastMath gate admits; the block tail was 36% of the
-// kernel's time and the fused form is three ops per tile. Larger K than
-// the scratch holds runs as chunks that accumulate into the output
-// rows in place, in the same block order.
+// Both nests keep the exact i32 sums and the block order and fuse the
+// row scale into the accumulate ((f32(sum) * dcol) * drow, one
+// rounding), the native-style rounding the FastMath gate admits — and
+// the same sequence in both, so a row's result does not depend on the
+// nest it fell into. (The SMMLA block tail was 36% of the kernel's time;
+// the fused form is three ops per tile.) Larger K than the scratch
+// holds runs as chunks that accumulate into the output rows in place,
+// in the same block order.
 //
 // C signature (see llama-wasm's arch/wasm/repack.cpp):
 //
@@ -120,18 +119,15 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	}
 	fcvtl := func(d, n int) { word(0x0E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl v%d.4s, v%d.4h", d, n)) }
 	scvtf := func(d, n int) { word(0x4E21D800|uint32(n)<<5|uint32(d), fmt.Sprintf("scvtf v%d.4s, v%d.4s", d, n)) }
-	fmulLane := func(d, n, m, idx int) {
-		enc := 0x4F809000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
-		word(enc, fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
-	}
 	fmulV := func(d, n, m int) {
 		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
 	fmlaV := func(d, n, m int) {
 		word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
-	faddV := func(d, n, m int) {
-		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	fmlaLane := func(d, n, m, idx int) {
+		enc := 0x4F801000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
+		word(enc, fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
 	}
 
 	argOff, argBytes := repackGemmArgs(wide)
@@ -379,27 +375,19 @@ func a64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 		sdotLane(27, 0, 1, 3)
 	}
 	// Scales: column d[4] and row d[4] (f16 -> f32), then per row
-	// sumv_r += f32(acc_r) * (dcol * drow[r]).
+	// sumv_r += (f32(acc_r) * dcol) * drow[r] with the row scale fused
+	// — the SAME sequence and rounding as the SMMLA nest's tail, so a
+	// row's result does not depend on whether it fell into a pair or
+	// into this tail group.
 	ldurD(2, 16, 0)
 	fcvtl(2, 2)
 	ldurD(3, 17, 0)
 	fcvtl(3, 3)
-	scvtf(24, 24)
-	scvtf(25, 25)
-	scvtf(26, 26)
-	scvtf(27, 27)
-	fmulLane(4, 2, 3, 0)
-	fmulV(5, 24, 4)
-	faddV(28, 28, 5)
-	fmulLane(4, 2, 3, 1)
-	fmulV(5, 25, 4)
-	faddV(29, 29, 5)
-	fmulLane(4, 2, 3, 2)
-	fmulV(5, 26, 4)
-	faddV(30, 30, 5)
-	fmulLane(4, 2, 3, 3)
-	fmulV(5, 27, 4)
-	faddV(31, 31, 5)
+	for r := 0; r < 4; r++ {
+		scvtf(24+r, 24+r)
+		fmulV(24+r, 24+r, 2)
+		fmlaLane(28+r, 24+r, 3, r)
+	}
 	w("\tADD\t$136, R16, R16")
 	w("\tADD\t$136, R17, R17")
 	w("\tSUBW\t$1, R15, R15")

--- a/internal/gcasm/repackgemm_bench_test.go
+++ b/internal/gcasm/repackgemm_bench_test.go
@@ -1,0 +1,74 @@
+package gcasm
+
+import (
+	"os"
+	"testing"
+)
+
+// TestEmitRepackGemmBench writes a standalone benchmark package for
+// the arm64 repack GEMM kernel into GCASM_BENCH_DIR (skipped when the
+// variable is unset): `go test -bench . ` there reports GMAC/s on the
+// host, the measurement that steers kernel work (asm-first).
+func TestEmitRepackGemmBench(t *testing.T) {
+	dir := os.Getenv("GCASM_BENCH_DIR")
+	if dir == "" {
+		t.Skip("GCASM_BENCH_DIR unset")
+	}
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	kernel := a64RepackGemmKernel("GemmKernel", "trapstub", offs, true)
+	a64GemvFourGroups = os.Getenv("GCASM_BENCH_GEMV1") == ""
+	gemv := a64RepackGemvKernel("GemvKernel", "trapstub", offs, true)
+	a64GemvFourGroups = true
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGemmRunTree(t, dir, "arm64", kernel+"\n"+gemv,
+		"\nfunc GemmKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc GemvKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\nvar gcasmCPUI8MM = true\n",
+		`package gemmrun
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// qwen2.5-0.5b down-projection shape: K=4864 (nb=152), 512 rows, 896 columns.
+func benchProblem(nRows, nCols, k int) (*mockModule, []byte, int, int, int) {
+	nb := k / 32
+	vxOff := 8192
+	vyOff := vxOff + (nCols/4)*nb*136 + 64
+	sOff := vyOff + (nRows/4+1)*nb*136 + 64
+	mem := make([]byte, sOff+nRows*nCols*4+4096)
+	memSize := uint64(len(mem))
+	return &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}, mem, sOff, vxOff, vyOff
+}
+
+func BenchmarkGemm512x896xK4864(b *testing.B) {
+	m, _, sOff, vxOff, vyOff := benchProblem(512, 896, 4864)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GemmKernel(m, 4864, int64(sOff), 896, int64(vxOff), int64(vyOff), 512, 896)
+	}
+	b.ReportMetric(float64(512)*896*4864*float64(b.N)/b.Elapsed().Seconds()/1e9, "GMAC/s")
+}
+
+func BenchmarkGemm512x4864xK896(b *testing.B) {
+	m, _, sOff, vxOff, vyOff := benchProblem(512, 4864, 896)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GemmKernel(m, 896, int64(sOff), 4864, int64(vxOff), int64(vyOff), 512, 4864)
+	}
+	b.ReportMetric(float64(512)*4864*896*float64(b.N)/b.Elapsed().Seconds()/1e9, "GMAC/s")
+}
+
+// 38912 columns x K=896: 37 MB of weights, streamed from DRAM like decode.
+func BenchmarkGemv38912xK896(b *testing.B) {
+	m, _, sOff, vxOff, vyOff := benchProblem(4, 38912, 896)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GemvKernel(m, 896, int64(sOff), 38912, int64(vxOff), int64(vyOff), 1, 38912)
+	}
+	b.ReportMetric(float64(38912)*896*float64(b.N)/b.Elapsed().Seconds()/1e9, "GMAC/s")
+	b.ReportMetric(float64(38912/4*28*136)*float64(b.N)/b.Elapsed().Seconds()/1e9, "GB/s")
+}
+`)
+}

--- a/internal/gcasm/repackgemm_test.go
+++ b/internal/gcasm/repackgemm_test.go
@@ -35,6 +35,8 @@ func TestRepackGemmKernelShape(t *testing.T) {
 	offs := &ModuleOffsets{M: 8, MemSize: 0}
 	a := a64RepackGemmKernel("Fn9dotprod", "trapstub", offs, true)
 	for _, want := range []string{
+		"smmla v7.4s, v23.16b, v19.16b", "zip1 v18.4s, v16.4s, v17.4s",
+		"dup v19.2d, v16.d[1]", "gcasmCPUI8MM", "gemmmpre:", "gemmmchunk:",
 		"sdot v24.4s, v0.16b, v1.4b[0]",
 		"sdot v27.4s, v0.16b, v1.4b[3]",
 		"fmul v4.4s, v2.4s, v3.s[3]",
@@ -50,6 +52,7 @@ func TestRepackGemmKernelShape(t *testing.T) {
 	x := x64RepackGemmKernel("Fn9avx2", "trapstub", offs, pool, true)
 	for _, want := range []string{
 		"VPDPBUSD", "VPMADDWD", "VPHADDD", "VCVTPH2PS", "VADDPS",
+		"VPBROADCASTQ", "VPERM2I128", "VPERMPS", "gemmpre:", "gemmchunk:",
 		"gcasmHasAVX512VNNI", "vgemmblk:", "gemmblk:", "VZEROUPPER",
 	} {
 		if !strings.Contains(x, want) {
@@ -66,9 +69,26 @@ const repackGemmRunSrc = `package gemmrun
 
 import (
 	"math"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"testing"
 	"unsafe"
 )
+
+// hostHasI8MM reports FEAT_I8MM on the executing arm64 host.
+func hostHasI8MM() bool {
+	switch runtime.GOOS {
+	case "linux":
+		data, err := os.ReadFile("/proc/cpuinfo")
+		return err == nil && strings.Contains(string(data), " i8mm")
+	case "darwin":
+		out, err := exec.Command("sysctl", "-n", "hw.optional.arm.FEAT_I8MM").Output()
+		return err == nil && strings.TrimSpace(string(out)) == "1"
+	}
+	return false
+}
 
 type mockModule struct {
 	memSizePtr *uint64
@@ -100,13 +120,12 @@ func f16val(h uint16) float64 {
 }
 
 const (
-	n  = 64 // nb = 2
-	nr = 8
+	nr = 12 // three row groups: one SMMLA pair + the SDOT tail group
 	nc = 8
 	bs = 10 // output row stride in floats (> nc to catch stride bugs)
 )
 
-func buildProblem(mem []byte, sOff, vxOff, vyOff int) {
+func buildProblem(mem []byte, n, sOff, vxOff, vyOff int) {
 	nb := n / 32
 	rng := uint32(0x12345)
 	nextI8 := func() int8 {
@@ -131,7 +150,7 @@ func buildProblem(mem []byte, sOff, vxOff, vyOff int) {
 	_ = sOff
 }
 
-func reference(mem []byte, vxOff, vyOff int) [nr][nc]float64 {
+func reference(mem []byte, n, vxOff, vyOff int) [nr][nc]float64 {
 	nb := n / 32
 	var out [nr][nc]float64
 	for y := 0; y < nr/4; y++ {
@@ -160,14 +179,21 @@ func reference(mem []byte, vxOff, vyOff int) [nr][nc]float64 {
 	return out
 }
 
-func runOne(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)) {
-	mem := make([]byte, 1<<16)
-	sOff, vxOff, vyOff := 256, 8192, 32768
-	buildProblem(mem, sOff, vxOff, vyOff)
+// runOne exercises the kernel on an n-column problem: n = 64 is the
+// two-block shape, n = 32*300 spans more blocks than the amd64
+// nest's per-chunk scratch holds, so it covers the chunk boundary and
+// the accumulate-into-s reload path.
+func runOne(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32), n int) {
+	nb := n / 32
+	sOff := 256
+	vxOff := 8192
+	vyOff := vxOff + (nc/4)*nb*136 + 64
+	mem := make([]byte, vyOff+(nr/4)*nb*136+4096)
+	buildProblem(mem, n, sOff, vxOff, vyOff)
 	memSize := uint64(len(mem))
 	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
-	kernel(m, n, int64(sOff), int64(bs), int64(vxOff), int64(vyOff), nr, nc)
-	want := reference(mem, vxOff, vyOff)
+	kernel(m, int32(n), int64(sOff), int64(bs), int64(vxOff), int64(vyOff), nr, nc)
+	want := reference(mem, n, vxOff, vyOff)
 	for r := 0; r < nr; r++ {
 		for c := 0; c < nc; c++ {
 			bits := uint32(mem[sOff+(r*bs+c)*4]) | uint32(mem[sOff+(r*bs+c)*4+1])<<8 |
@@ -210,12 +236,27 @@ func TestA64RepackGemmKernelGate(t *testing.T) {
 	kernel := a64RepackGemmKernel("GemmKernel", "trapstub", offs, true)
 	dir := t.TempDir()
 	writeGemmRunTree(t, dir, "arm64", kernel,
-		"\nfunc GemmKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\n",
+		"\nfunc GemmKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\nvar gcasmCPUI8MM bool\n",
 		`package gemmrun
 
 import "testing"
 
-func TestGemmA64(t *testing.T) { runOne(t, GemmKernel) }
+// The SDOT nest alone, then the SMMLA nest (row-group pairs with the
+// SDOT tail for the odd group) when the host has FEAT_I8MM.
+func TestGemmA64(t *testing.T) {
+	gcasmCPUI8MM = false
+	runOne(t, GemmKernel, 64)
+	runOne(t, GemmKernel, 32*300)
+}
+
+func TestGemmA64SMMLA(t *testing.T) {
+	if !hostHasI8MM() {
+		t.Skip("host has no FEAT_I8MM")
+	}
+	gcasmCPUI8MM = true
+	runOne(t, GemmKernel, 64)
+	runOne(t, GemmKernel, 32*300)
+}
 `)
 	runArm64Gate(t, dir, ".", "TestGemmA64", kernel)
 }
@@ -258,12 +299,14 @@ import "testing"
 
 func TestGemmX64(t *testing.T) {
 	gcasmHasAVX512VNNI = false
-	runOne(t, GemmKernel)
+	runOne(t, GemmKernel, 64)
+	runOne(t, GemmKernel, 32*300)
 }
 
 func TestGemmX64VNNI(t *testing.T) {
 	gcasmHasAVX512VNNI = true
-	runOne(t, GemmKernel)
+	runOne(t, GemmKernel, 64)
+	runOne(t, GemmKernel, 32*300)
 }
 `)
 	bin := filepath.Join(dir, "gemmrun.test")

--- a/internal/gcasm/repackgemm_test.go
+++ b/internal/gcasm/repackgemm_test.go
@@ -39,8 +39,8 @@ func TestRepackGemmKernelShape(t *testing.T) {
 		"dup v19.2d, v16.d[1]", "gcasmCPUI8MM", "gemmmpre:", "gemmmchunk:",
 		"sdot v24.4s, v0.16b, v1.4b[0]",
 		"sdot v27.4s, v0.16b, v1.4b[3]",
-		"fmul v4.4s, v2.4s, v3.s[3]",
-		"fadd v31.4s, v31.4s, v5.4s",
+		"fmul v27.4s, v27.4s, v2.4s",
+		"fmla v31.4s, v27.4s, v3.s[3]",
 		"fcvtl v2.4s, v2.4h",
 		"gemmblk:", "gemmoob:",
 	} {

--- a/internal/gcasm/repackgemm_x64.go
+++ b/internal/gcasm/repackgemm_x64.go
@@ -5,6 +5,23 @@ import (
 	"strings"
 )
 
+// x64RepackGemmChunkBlocks is the number of q8_0 blocks (32 columns
+// each, so 8192 columns of K) whose activation row group the AVX2
+// nest widens into its stack scratch at a time. Larger K runs as a
+// sequence of chunks that accumulate into the output rows in place,
+// in the same block order as a single pass — the f32 sums are
+// identical, only a register-to-memory round trip is added.
+const x64RepackGemmChunkBlocks = 256
+
+// x64RepackGemmScratch is the AVX2 nest's stack scratch: per block,
+// the 8 activation groups sign-extended to i16 (16 lanes = 4 rows x
+// 4 columns) = 8 x 32 bytes.
+const x64RepackGemmScratch = x64RepackGemmChunkBlocks * 256
+
+// x64RepackGemmFrame is the kernel frame: the widened-activation
+// scratch behind 64 bytes of loop bookkeeping.
+const x64RepackGemmFrame = 64 + x64RepackGemmScratch
+
 // x64RepackGemmKernel emits the q8_0x4 repack GEMM under sym for
 // amd64 — the 4x4 tile the a64 twin computes with by-element SDOT,
 // with an entry branch to a VNNI loop on CPUs reporting AVX-512 VNNI
@@ -12,22 +29,35 @@ import (
 // bounds-check contract and the fast-math gating; the memory layouts
 // and the ABI0 argument frame are identical.
 //
-// AVX2 nest, per 16-byte weight group: the group sign-extends ONCE
-// across a ymm and each row's broadcast 4-byte activation group
-// multiplies into that row's pair-domain ymm accumulator
-// (VPMADDWD + VPADDD); the four accumulators collapse to per-column
-// i32x4 sums once per block. VNNI nest: VPDPBUSD with the exact +128
-// bias identity — the per-row byte sums the identity needs
-// accumulate in ONE extra VPDPBUSD per group (ones · activation
-// block = all four rows' group sums, one lane each).
+// AVX2 nest. The activation row group is widened ONCE per chunk into
+// the stack scratch (a 16-byte group of four 4-byte row quads becomes
+// 32 bytes of i16), so the block loop's per-(group, row) work is a
+// pure-load VPBROADCASTQ of the row's four i16 plus VPMADDWD and
+// VPADDD into that row's pair-domain ymm accumulator — no in-loop
+// shuffles or sign extensions besides the one VPMOVSXBW per weight
+// group that all four rows share. Per block the four pair-domain
+// accumulators collapse with two VPHADDD, two VPERM2I128 and two
+// unpacks into [row0|row2] and [row1|row3] column vectors, which
+// convert and scale as ymm pairs into two f32 accumulators. The
+// per-block arithmetic on each output element is the wasm kernel's
+// own: exact i32 column sum -> f32 -> x (dcol * drow) -> + running
+// sum, in block order.
+//
+// VNNI nest: VPDPBUSD with the exact +128 bias identity — the per-row
+// byte sums the identity needs accumulate in ONE extra VPDPBUSD per
+// group (ones · activation block = all four rows' group sums, one
+// lane each); each row's quad arrives by VPBROADCASTD straight from
+// memory.
 //
 // Register file after the prologue (memSize/M die once the entry
 // checks pass and every pointer is host-absolute):
 //
-//	CX vx base | SI a-row cursor | BX s-row cursor | R8 nb
-//	R9 xtotal | R10 y ctr | R11 nc4 | R14 bs bytes | R15 4*bs
-//	DX b-col cursor | DI s-col cursor | R13 x ctr
-//	R12 bp | AX ap | 0(SP) block ctr
+//	CX vx base | SI a-row-group cursor | BX s-row-group cursor
+//	R8 nb | R9 xtotal | R10 y ctr | R14 bs bytes | R15 4*bs
+//	DX b-col cursor | DI s-col cursor | R13 x ctr (VNNI: R11 nc4)
+//	R12 bp | AX ap | R11 scratch cursor (AVX2)
+//	0(SP) block ctr | 8(SP) blocks left | 16(SP) chunk byte offset
+//	24(SP) nc4 | 32(SP) chunk blocks | 64(SP).. scratch
 func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
 	var b strings.Builder
 	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
@@ -41,6 +71,19 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 	}
 	biasSym := c16(0x80)
 	onesSym := c16(0x01)
+	// VPERMPS index vectors: lanes [0 0 0 0 2 2 2 2] / [1 1 1 1 3 3 3 3]
+	// broadcast the row scales of the [row0|row2] and [row1|row3]
+	// accumulator halves.
+	idxSym := func(lo, hi byte) string {
+		blob := make([]byte, 32)
+		for i := 0; i < 4; i++ {
+			blob[4*i] = lo
+			blob[16+4*i] = hi
+		}
+		return pool.addBlob(blob)
+	}
+	idx02Sym := idxSym(0, 2)
+	idx13Sym := idxSym(1, 3)
 
 	argOff, argBytes := repackGemmArgs(wide)
 	movArg := "MOVL"
@@ -60,7 +103,7 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 	}
 
 	w("// %s: q8_0x4 repack GEMM, 4x4 tile via AVX2 / VNNI.", sym)
-	w("TEXT ·%s(SB), $8-%d", sym, argBytes)
+	w("TEXT ·%s(SB), $%d-%d", sym, x64RepackGemmFrame, argBytes)
 	w("\tNO_LOCAL_POINTERS")
 	w("\tMOVQ\tm+0(FP), AX")
 	w("\tMOVQ\t%d(AX), R15", offs.MemSize)
@@ -107,109 +150,206 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 	w("\tMOVQ\tDX, R14")
 	w("\tMOVQ\tDX, R15")
 	w("\tSHLQ\t$2, R15")
-	fmt.Fprintf(&b, "\tVMOVDQU ·%s(SB), X14\n", onesSym)
+	w("\tMOVL\tR11, 24(SP)")
 	w("\tCMPB\t·gcasmHasAVX512VNNI(SB), $0")
 	w("\tJNE\tvgemmy")
 
-	// nest emits one complete y/x/block loop nest under the label
-	// prefix; the AVX2 and VNNI bodies differ only in the per-block
-	// integer tile.
-	nest := func(p string, vnni bool) {
-		w("%sy:", p)
-		w("\tMOVQ\tCX, DX")
-		w("\tMOVQ\tBX, DI")
-		w("\tMOVQ\tR11, R13")
-		w("%sx:", p)
-		w("\tVPXOR\tX8, X8, X8")
-		w("\tVPXOR\tX9, X9, X9")
-		w("\tVPXOR\tX10, X10, X10")
-		w("\tVPXOR\tX11, X11, X11")
-		w("\tMOVQ\tDX, R12")
-		w("\tMOVQ\tSI, AX")
-		w("\tMOVL\tR8, 0(SP)")
-		w("\tTESTL\tR8, R8")
-		w("\tJZ\t%sstore", p)
-		w("%sblk:", p)
-		if vnni {
-			w("\tVPXOR\tX0, X0, X0")
-			w("\tVPXOR\tX1, X1, X1")
-			w("\tVPXOR\tX2, X2, X2")
-			w("\tVPXOR\tX3, X3, X3")
-			w("\tVPXOR\tX7, X7, X7")
-			for k := 0; k < 8; k++ {
-				w("\tVMOVDQU\t%d(R12), X4", 8+16*k)
-				fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
-				w("\tVMOVDQU\t%d(AX), X5", 8+16*k)
-				w("\tVPDPBUSD\tX5, X14, X7") // rowsum += group sums
-				for row := 0; row < 4; row++ {
-					w("\tVPSHUFD\t$%#02x, X5, X6", row*0x55)
-					w("\tVPDPBUSD\tX6, X4, X%d", row)
-				}
-			}
-			// acc_row -= 128 * rowsum[row].
-			for row := 0; row < 4; row++ {
-				w("\tVPSHUFD\t$%#02x, X7, X6", row*0x55)
-				w("\tVPSLLD\t$7, X6, X6")
-				w("\tVPSUBD\tX6, X%d, X%d", row, row)
-			}
-		} else {
-			w("\tVPXOR\tY0, Y0, Y0")
-			w("\tVPXOR\tY1, Y1, Y1")
-			w("\tVPXOR\tY2, Y2, Y2")
-			w("\tVPXOR\tY3, Y3, Y3")
-			for k := 0; k < 8; k++ {
-				w("\tVPMOVSXBW\t%d(R12), Y4", 8+16*k)
-				w("\tVMOVDQU\t%d(AX), X5", 8+16*k)
-				for row := 0; row < 4; row++ {
-					w("\tVPSHUFD\t$%#02x, X5, X6", row*0x55)
-					w("\tVPMOVSXBW\tX6, Y6")
-					w("\tVPMADDWD\tY4, Y6, Y6")
-					w("\tVPADDD\tY6, Y%d, Y%d", row, row)
-				}
-			}
-			// Collapse pair-domain ymm to the per-column grouping.
-			for row := 0; row < 4; row++ {
-				w("\tVPHADDD\tY%d, Y%d, Y%d", row, row, row)
-				w("\tVEXTRACTI128\t$1, Y%d, X6", row)
-				w("\tVPUNPCKLQDQ\tX6, X%d, X%d", row, row)
-			}
-		}
-		// Scales: sumv_row += f32(acc_row) * (dcol * drow[row]).
-		w("\tVMOVQ\t(R12), X6")
-		w("\tVCVTPH2PS\tX6, X12")
-		w("\tVMOVQ\t(AX), X6")
-		w("\tVCVTPH2PS\tX6, X13")
-		for row := 0; row < 4; row++ {
-			w("\tVCVTDQ2PS\tX%d, X%d", row, row)
-			w("\tVPSHUFD\t$%#02x, X13, X7", row*0x55)
-			w("\tVMULPS\tX12, X7, X7")
-			w("\tVMULPS\tX%d, X7, X7", row)
-			w("\tVADDPS\tX7, X%d, X%d", 8+row, 8+row)
-		}
-		w("\tADDQ\t$136, R12")
-		w("\tADDQ\t$136, AX")
-		w("\tDECL\t0(SP)")
-		w("\tJNZ\t%sblk", p)
-		w("%sstore:", p)
-		w("\tVMOVUPS\tX8, (DI)")
-		w("\tLEAQ\t(DI)(R14*1), R12")
-		w("\tVMOVUPS\tX9, (R12)")
-		w("\tADDQ\tR14, R12")
-		w("\tVMOVUPS\tX10, (R12)")
-		w("\tADDQ\tR14, R12")
-		w("\tVMOVUPS\tX11, (R12)")
-		w("\tADDQ\tR9, DX")
-		w("\tADDQ\t$16, DI")
-		w("\tSUBL\t$1, R13")
-		w("\tJNZ\t%sx", p)
-		w("\tADDQ\tR9, SI")
-		w("\tADDQ\tR15, BX")
-		w("\tSUBL\t$1, R10")
-		w("\tJNZ\t%sy", p)
-		w("\tJMP\tgemmdone")
+	// ---- AVX2 nest: chunked, widened activations in the scratch.
+	fmt.Fprintf(&b, "\tVMOVDQU ·%s(SB), Y14\n", idx02Sym)
+	fmt.Fprintf(&b, "\tVMOVDQU ·%s(SB), Y15\n", idx13Sym)
+	w("gemmy:")
+	w("\tMOVQ\t$0, 16(SP)")
+	w("\tMOVL\tR8, 8(SP)")
+	w("gemmchunk:")
+	// cnt = min(blocks left, chunk)
+	w("\tMOVL\t8(SP), R13")
+	w("\tMOVL\t$%d, AX", x64RepackGemmChunkBlocks)
+	w("\tCMPL\tR13, AX")
+	w("\tCMOVLGT\tAX, R13")
+	w("\tMOVL\tR13, 32(SP)")
+	// Widen this row group's chunk: 16 bytes [r0 r1 r2 r3] x 4 i8
+	// -> 32 bytes of i16 per group, 8 groups per block.
+	w("\tMOVQ\tSI, AX")
+	w("\tADDQ\t16(SP), AX")
+	w("\tLEAQ\t64(SP), R11")
+	w("\tTESTL\tR13, R13")
+	w("\tJZ\tgemmxinit")
+	w("gemmpre:")
+	for k := 0; k < 8; k++ {
+		w("\tVPMOVSXBW\t%d(AX), Y4", 8+16*k)
+		w("\tVMOVDQU\tY4, %d(R11)", 32*k)
 	}
-	nest("gemm", false)
-	nest("vgemm", true)
+	w("\tADDQ\t$136, AX")
+	w("\tADDQ\t$256, R11")
+	w("\tDECL\tR13")
+	w("\tJNZ\tgemmpre")
+	w("gemmxinit:")
+	w("\tMOVQ\tCX, DX")
+	w("\tADDQ\t16(SP), DX")
+	w("\tMOVQ\tBX, DI")
+	w("\tMOVL\t24(SP), R13")
+	w("gemmx:")
+	// f32 accumulators [row0|row2] / [row1|row3]: zero on the first
+	// chunk, else the rows' running sums from s.
+	w("\tCMPQ\t16(SP), $0")
+	w("\tJNE\tgemmxload")
+	w("\tVPXOR\tY8, Y8, Y8")
+	w("\tVPXOR\tY9, Y9, Y9")
+	w("\tJMP\tgemmxgo")
+	w("gemmxload:")
+	w("\tLEAQ\t(DI)(R14*2), R12")
+	w("\tVMOVUPS\t(DI), X8")
+	w("\tVINSERTF128\t$1, (R12), Y8, Y8")
+	w("\tVMOVUPS\t(DI)(R14*1), X9")
+	w("\tVINSERTF128\t$1, (R12)(R14*1), Y9, Y9")
+	w("gemmxgo:")
+	w("\tMOVQ\tDX, R12")
+	w("\tMOVQ\tSI, AX")
+	w("\tADDQ\t16(SP), AX")
+	w("\tMOVL\t32(SP), R11")
+	w("\tMOVL\tR11, 0(SP)")
+	w("\tLEAQ\t64(SP), R11")
+	w("\tCMPL\t0(SP), $0")
+	w("\tJZ\tgemmstore")
+	w("gemmblk:")
+	w("\tVPXOR\tY0, Y0, Y0")
+	w("\tVPXOR\tY1, Y1, Y1")
+	w("\tVPXOR\tY2, Y2, Y2")
+	w("\tVPXOR\tY3, Y3, Y3")
+	for k := 0; k < 8; k++ {
+		w("\tVPMOVSXBW\t%d(R12), Y4", 8+16*k)
+		for row := 0; row < 4; row++ {
+			w("\tVPBROADCASTQ\t%d(R11), Y5", 32*k+8*row)
+			w("\tVPMADDWD\tY4, Y5, Y5")
+			w("\tVPADDD\tY5, Y%d, Y%d", row, row)
+		}
+	}
+	// Collapse the pair domain: T01 = [r0c0 r0c1 r1c0 r1c1 | r0c2
+	// r0c3 r1c2 r1c3], T23 likewise; the lane swap + unpacks yield
+	// [row0 | row2] and [row1 | row3].
+	w("\tVPHADDD\tY1, Y0, Y10")
+	w("\tVPHADDD\tY3, Y2, Y11")
+	w("\tVPERM2I128\t$0x20, Y11, Y10, Y4")
+	w("\tVPERM2I128\t$0x31, Y11, Y10, Y5")
+	w("\tVPUNPCKLQDQ\tY5, Y4, Y10")
+	w("\tVPUNPCKHQDQ\tY5, Y4, Y11")
+	// Scales: dcol[4] in both halves; drow broadcast per half.
+	w("\tVMOVQ\t(R12), X6")
+	w("\tVCVTPH2PS\tX6, X12")
+	w("\tVINSERTF128\t$1, X12, Y12, Y12")
+	w("\tVMOVQ\t(AX), X6")
+	w("\tVCVTPH2PS\tX6, X13")
+	w("\tVPERMPS\tY13, Y14, Y4")
+	w("\tVMULPS\tY12, Y4, Y4")
+	w("\tVPERMPS\tY13, Y15, Y5")
+	w("\tVMULPS\tY12, Y5, Y5")
+	w("\tVCVTDQ2PS\tY10, Y10")
+	w("\tVMULPS\tY4, Y10, Y10")
+	w("\tVADDPS\tY10, Y8, Y8")
+	w("\tVCVTDQ2PS\tY11, Y11")
+	w("\tVMULPS\tY5, Y11, Y11")
+	w("\tVADDPS\tY11, Y9, Y9")
+	w("\tADDQ\t$136, R12")
+	w("\tADDQ\t$136, AX")
+	w("\tADDQ\t$256, R11")
+	w("\tDECL\t0(SP)")
+	w("\tJNZ\tgemmblk")
+	w("gemmstore:")
+	w("\tLEAQ\t(DI)(R14*2), R12")
+	w("\tVMOVUPS\tX8, (DI)")
+	w("\tVMOVUPS\tX9, (DI)(R14*1)")
+	w("\tVEXTRACTF128\t$1, Y8, X6")
+	w("\tVMOVUPS\tX6, (R12)")
+	w("\tVEXTRACTF128\t$1, Y9, X6")
+	w("\tVMOVUPS\tX6, (R12)(R14*1)")
+	w("\tADDQ\tR9, DX")
+	w("\tADDQ\t$16, DI")
+	w("\tSUBL\t$1, R13")
+	w("\tJNZ\tgemmx")
+	// Next chunk of this row group, if any.
+	w("\tMOVL\t32(SP), R13")
+	w("\tSUBL\tR13, 8(SP)")
+	w("\tIMUL3Q\t$136, R13, R13")
+	w("\tADDQ\tR13, 16(SP)")
+	w("\tCMPL\t8(SP), $0")
+	w("\tJNE\tgemmchunk")
+	w("\tADDQ\tR9, SI")
+	w("\tADDQ\tR15, BX")
+	w("\tSUBL\t$1, R10")
+	w("\tJNZ\tgemmy")
+	w("\tJMP\tgemmdone")
+
+	// ---- VNNI nest.
+	fmt.Fprintf(&b, "vgemmy:\n\tVMOVDQU ·%s(SB), X14\n", onesSym)
+	w("\tMOVL\t24(SP), R11")
+	w("vgemmyy:")
+	w("\tMOVQ\tCX, DX")
+	w("\tMOVQ\tBX, DI")
+	w("\tMOVQ\tR11, R13")
+	w("vgemmx:")
+	w("\tVPXOR\tX8, X8, X8")
+	w("\tVPXOR\tX9, X9, X9")
+	w("\tVPXOR\tX10, X10, X10")
+	w("\tVPXOR\tX11, X11, X11")
+	w("\tMOVQ\tDX, R12")
+	w("\tMOVQ\tSI, AX")
+	w("\tMOVL\tR8, 0(SP)")
+	w("\tTESTL\tR8, R8")
+	w("\tJZ\tvgemmstore")
+	w("vgemmblk:")
+	w("\tVPXOR\tX0, X0, X0")
+	w("\tVPXOR\tX1, X1, X1")
+	w("\tVPXOR\tX2, X2, X2")
+	w("\tVPXOR\tX3, X3, X3")
+	w("\tVPXOR\tX7, X7, X7")
+	for k := 0; k < 8; k++ {
+		w("\tVMOVDQU\t%d(R12), X4", 8+16*k)
+		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
+		w("\tVMOVDQU\t%d(AX), X5", 8+16*k)
+		w("\tVPDPBUSD\tX5, X14, X7") // rowsum += group sums
+		for row := 0; row < 4; row++ {
+			w("\tVPBROADCASTD\t%d(AX), X6", 8+16*k+4*row)
+			w("\tVPDPBUSD\tX6, X4, X%d", row)
+		}
+	}
+	// acc_row -= 128 * rowsum[row].
+	for row := 0; row < 4; row++ {
+		w("\tVPSHUFD\t$%#02x, X7, X6", row*0x55)
+		w("\tVPSLLD\t$7, X6, X6")
+		w("\tVPSUBD\tX6, X%d, X%d", row, row)
+	}
+	// Scales: sumv_row += f32(acc_row) * (dcol * drow[row]).
+	w("\tVMOVQ\t(R12), X6")
+	w("\tVCVTPH2PS\tX6, X12")
+	w("\tVMOVQ\t(AX), X6")
+	w("\tVCVTPH2PS\tX6, X13")
+	for row := 0; row < 4; row++ {
+		w("\tVCVTDQ2PS\tX%d, X%d", row, row)
+		w("\tVPSHUFD\t$%#02x, X13, X7", row*0x55)
+		w("\tVMULPS\tX12, X7, X7")
+		w("\tVMULPS\tX%d, X7, X7", row)
+		w("\tVADDPS\tX7, X%d, X%d", 8+row, 8+row)
+	}
+	w("\tADDQ\t$136, R12")
+	w("\tADDQ\t$136, AX")
+	w("\tDECL\t0(SP)")
+	w("\tJNZ\tvgemmblk")
+	w("vgemmstore:")
+	w("\tVMOVUPS\tX8, (DI)")
+	w("\tLEAQ\t(DI)(R14*1), R12")
+	w("\tVMOVUPS\tX9, (R12)")
+	w("\tADDQ\tR14, R12")
+	w("\tVMOVUPS\tX10, (R12)")
+	w("\tADDQ\tR14, R12")
+	w("\tVMOVUPS\tX11, (R12)")
+	w("\tADDQ\tR9, DX")
+	w("\tADDQ\t$16, DI")
+	w("\tSUBL\t$1, R13")
+	w("\tJNZ\tvgemmx")
+	w("\tADDQ\tR9, SI")
+	w("\tADDQ\tR15, BX")
+	w("\tSUBL\t$1, R10")
+	w("\tJNZ\tvgemmyy")
 	w("gemmdone:")
 	w("\tVZEROUPPER")
 	w("\tRET")

--- a/internal/gcasm/repackgemm_x64.go
+++ b/internal/gcasm/repackgemm_x64.go
@@ -43,11 +43,13 @@ const x64RepackGemmFrame = 64 + x64RepackGemmScratch
 // own: exact i32 column sum -> f32 -> x (dcol * drow) -> + running
 // sum, in block order.
 //
-// VNNI nest: VPDPBUSD with the exact +128 bias identity — the per-row
-// byte sums the identity needs accumulate in ONE extra VPDPBUSD per
-// group (ones · activation block = all four rows' group sums, one
-// lane each); each row's quad arrives by VPBROADCASTD straight from
-// memory.
+// VNNI nest: the same chunk/prepass structure at 256-bit width. The
+// prepass stores, per group pair and row, the 8 bytes [quad_k,
+// quad_k+1] xor 0x80 (u8); the weight pair is VPERMD'd to per-column
+// pairs (s8) and ONE VPDPBUSD per row covers 8 columns x 4 k; the
+// +128 activation bias is undone with a weight column sum shared by
+// the four rows (one VPDPBUSD(ones, weights) per pair, one subtract
+// per row per block), then the AVX2 collapse applies unchanged.
 //
 // Register file after the prologue (memSize/M die once the entry
 // checks pass and every pointer is host-absolute):
@@ -84,6 +86,15 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 	}
 	idx02Sym := idxSym(0, 2)
 	idx13Sym := idxSym(1, 3)
+	// VPERMD index [0 4 1 5 2 6 3 7]: a 32-byte weight pair
+	// [c0..c3 of group k | c0..c3 of group k+1] -> per-column pairs.
+	permSym := func() string {
+		blob := make([]byte, 32)
+		for i, v := range []byte{0, 4, 1, 5, 2, 6, 3, 7} {
+			blob[4*i] = v
+		}
+		return pool.addBlob(blob)
+	}()
 
 	argOff, argBytes := repackGemmArgs(wide)
 	movArg := "MOVL"
@@ -279,73 +290,147 @@ func x64RepackGemmKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 	w("\tJNZ\tgemmy")
 	w("\tJMP\tgemmdone")
 
-	// ---- VNNI nest.
-	fmt.Fprintf(&b, "vgemmy:\n\tVMOVDQU ·%s(SB), X14\n", onesSym)
-	w("\tMOVL\t24(SP), R11")
+	// ---- VNNI nest: chunked like the AVX2 nest, but the activation
+	// prepass produces, per group PAIR and row, the 8 bytes
+	// [quad_k, quad_k+1] xor 0x80 (u8), so one VPBROADCASTQ serves a
+	// 256-bit VPDPBUSD against the pair of weight groups permuted to
+	// [c0g0 c0g1 c1g0 c1g1 | c2g0 c2g1 c3g0 c3g1] (s8). The +128 bias
+	// then sits on the ACTIVATION side and its correction is a weight
+	// column sum shared by all four rows: one VPDPBUSD(ones, weights)
+	// per pair, subtracted once per block in the pair domain before
+	// the same collapse the AVX2 nest uses.
+	//
+	//	R12 bp | AX ap (scales) | R11 scratch cursor | Y6 wsum
+	//	Y14 permute index | Y15 u8 ones
+	w("vgemmy:")
+	fmt.Fprintf(&b, "\tVMOVDQU ·%s(SB), Y14\n", permSym)
+	fmt.Fprintf(&b, "\tVMOVDQU ·%s(SB), X15\n", onesSym)
+	w("\tVINSERTI128\t$1, X15, Y15, Y15")
 	w("vgemmyy:")
+	w("\tMOVQ\t$0, 16(SP)")
+	w("\tMOVL\tR8, 8(SP)")
+	w("vgemmchunk:")
+	w("\tMOVL\t8(SP), R13")
+	w("\tMOVL\t$%d, AX", x64RepackGemmChunkBlocks)
+	w("\tCMPL\tR13, AX")
+	w("\tCMOVLGT\tAX, R13")
+	w("\tMOVL\tR13, 32(SP)")
+	// Prepass: per pair, rows 0/1 and 2/3 interleaved by dword.
+	w("\tMOVQ\tSI, AX")
+	w("\tADDQ\t16(SP), AX")
+	w("\tLEAQ\t64(SP), R11")
+	w("\tTESTL\tR13, R13")
+	w("\tJZ\tvgemmxinit")
+	w("vgemmpre:")
+	for p := 0; p < 4; p++ {
+		w("\tVMOVDQU\t%d(AX), X4", 8+32*p)
+		w("\tVMOVDQU\t%d(AX), X5", 8+32*p+16)
+		w("\tVPUNPCKLDQ\tX5, X4, X6")
+		w("\tVPUNPCKHDQ\tX5, X4, X7")
+		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X6, X6\n", biasSym)
+		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X7, X7\n", biasSym)
+		w("\tVMOVDQU\tX6, %d(R11)", 32*p)
+		w("\tVMOVDQU\tX7, %d(R11)", 32*p+16)
+	}
+	w("\tADDQ\t$136, AX")
+	w("\tADDQ\t$128, R11")
+	w("\tDECL\tR13")
+	w("\tJNZ\tvgemmpre")
+	w("vgemmxinit:")
 	w("\tMOVQ\tCX, DX")
+	w("\tADDQ\t16(SP), DX")
 	w("\tMOVQ\tBX, DI")
-	w("\tMOVQ\tR11, R13")
+	w("\tMOVL\t24(SP), R13")
 	w("vgemmx:")
-	w("\tVPXOR\tX8, X8, X8")
-	w("\tVPXOR\tX9, X9, X9")
-	w("\tVPXOR\tX10, X10, X10")
-	w("\tVPXOR\tX11, X11, X11")
+	w("\tCMPQ\t16(SP), $0")
+	w("\tJNE\tvgemmxload")
+	w("\tVPXOR\tY8, Y8, Y8")
+	w("\tVPXOR\tY9, Y9, Y9")
+	w("\tJMP\tvgemmxgo")
+	w("vgemmxload:")
+	w("\tLEAQ\t(DI)(R14*2), R12")
+	w("\tVMOVUPS\t(DI), X8")
+	w("\tVINSERTF128\t$1, (R12), Y8, Y8")
+	w("\tVMOVUPS\t(DI)(R14*1), X9")
+	w("\tVINSERTF128\t$1, (R12)(R14*1), Y9, Y9")
+	w("vgemmxgo:")
 	w("\tMOVQ\tDX, R12")
 	w("\tMOVQ\tSI, AX")
-	w("\tMOVL\tR8, 0(SP)")
-	w("\tTESTL\tR8, R8")
+	w("\tADDQ\t16(SP), AX")
+	w("\tMOVL\t32(SP), R11")
+	w("\tMOVL\tR11, 0(SP)")
+	w("\tLEAQ\t64(SP), R11")
+	w("\tCMPL\t0(SP), $0")
 	w("\tJZ\tvgemmstore")
 	w("vgemmblk:")
-	w("\tVPXOR\tX0, X0, X0")
-	w("\tVPXOR\tX1, X1, X1")
-	w("\tVPXOR\tX2, X2, X2")
-	w("\tVPXOR\tX3, X3, X3")
-	w("\tVPXOR\tX7, X7, X7")
-	for k := 0; k < 8; k++ {
-		w("\tVMOVDQU\t%d(R12), X4", 8+16*k)
-		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
-		w("\tVMOVDQU\t%d(AX), X5", 8+16*k)
-		w("\tVPDPBUSD\tX5, X14, X7") // rowsum += group sums
+	w("\tVPXOR\tY0, Y0, Y0")
+	w("\tVPXOR\tY1, Y1, Y1")
+	w("\tVPXOR\tY2, Y2, Y2")
+	w("\tVPXOR\tY3, Y3, Y3")
+	w("\tVPXOR\tY6, Y6, Y6")
+	for p := 0; p < 4; p++ {
+		w("\tVPERMD\t%d(R12), Y14, Y4", 8+32*p)
+		w("\tVPDPBUSD\tY4, Y15, Y6") // wsum += column sums (u8 ones x s8 weights)
 		for row := 0; row < 4; row++ {
-			w("\tVPBROADCASTD\t%d(AX), X6", 8+16*k+4*row)
-			w("\tVPDPBUSD\tX6, X4, X%d", row)
+			w("\tVPBROADCASTQ\t%d(R11), Y5", 32*p+8*row)
+			w("\tVPDPBUSD\tY4, Y5, Y%d", row) // acc_row += u8 acts x s8 weights
 		}
 	}
-	// acc_row -= 128 * rowsum[row].
+	// acc_row -= 128 * wsum (pair domain), then the AVX2 collapse.
+	w("\tVPSLLD\t$7, Y6, Y6")
 	for row := 0; row < 4; row++ {
-		w("\tVPSHUFD\t$%#02x, X7, X6", row*0x55)
-		w("\tVPSLLD\t$7, X6, X6")
-		w("\tVPSUBD\tX6, X%d, X%d", row, row)
+		w("\tVPSUBD\tY6, Y%d, Y%d", row, row)
 	}
-	// Scales: sumv_row += f32(acc_row) * (dcol * drow[row]).
-	w("\tVMOVQ\t(R12), X6")
-	w("\tVCVTPH2PS\tX6, X12")
-	w("\tVMOVQ\t(AX), X6")
-	w("\tVCVTPH2PS\tX6, X13")
-	for row := 0; row < 4; row++ {
-		w("\tVCVTDQ2PS\tX%d, X%d", row, row)
-		w("\tVPSHUFD\t$%#02x, X13, X7", row*0x55)
-		w("\tVMULPS\tX12, X7, X7")
-		w("\tVMULPS\tX%d, X7, X7", row)
-		w("\tVADDPS\tX7, X%d, X%d", 8+row, 8+row)
-	}
+	w("\tVPHADDD\tY1, Y0, Y10")
+	w("\tVPHADDD\tY3, Y2, Y11")
+	w("\tVPERM2I128\t$0x20, Y11, Y10, Y4")
+	w("\tVPERM2I128\t$0x31, Y11, Y10, Y5")
+	w("\tVPUNPCKLQDQ\tY5, Y4, Y10")
+	w("\tVPUNPCKHQDQ\tY5, Y4, Y11")
+	w("\tVMOVQ\t(R12), X7")
+	w("\tVCVTPH2PS\tX7, X12")
+	w("\tVINSERTF128\t$1, X12, Y12, Y12")
+	w("\tVMOVQ\t(AX), X7")
+	w("\tVCVTPH2PS\tX7, X13")
+	// Row scales per half without an index register: [d0 x4 | d2 x4]
+	// and [d1 x4 | d3 x4] from lane shuffles.
+	w("\tVPSHUFD\t$0x00, X13, X4")
+	w("\tVPSHUFD\t$0xaa, X13, X7")
+	w("\tVINSERTI128\t$1, X7, Y4, Y4")
+	w("\tVMULPS\tY12, Y4, Y4")
+	w("\tVPSHUFD\t$0x55, X13, X5")
+	w("\tVPSHUFD\t$0xff, X13, X7")
+	w("\tVINSERTI128\t$1, X7, Y5, Y5")
+	w("\tVMULPS\tY12, Y5, Y5")
+	w("\tVCVTDQ2PS\tY10, Y10")
+	w("\tVMULPS\tY4, Y10, Y10")
+	w("\tVADDPS\tY10, Y8, Y8")
+	w("\tVCVTDQ2PS\tY11, Y11")
+	w("\tVMULPS\tY5, Y11, Y11")
+	w("\tVADDPS\tY11, Y9, Y9")
 	w("\tADDQ\t$136, R12")
 	w("\tADDQ\t$136, AX")
+	w("\tADDQ\t$128, R11")
 	w("\tDECL\t0(SP)")
 	w("\tJNZ\tvgemmblk")
 	w("vgemmstore:")
+	w("\tLEAQ\t(DI)(R14*2), R12")
 	w("\tVMOVUPS\tX8, (DI)")
-	w("\tLEAQ\t(DI)(R14*1), R12")
-	w("\tVMOVUPS\tX9, (R12)")
-	w("\tADDQ\tR14, R12")
-	w("\tVMOVUPS\tX10, (R12)")
-	w("\tADDQ\tR14, R12")
-	w("\tVMOVUPS\tX11, (R12)")
+	w("\tVMOVUPS\tX9, (DI)(R14*1)")
+	w("\tVEXTRACTF128\t$1, Y8, X7")
+	w("\tVMOVUPS\tX7, (R12)")
+	w("\tVEXTRACTF128\t$1, Y9, X7")
+	w("\tVMOVUPS\tX7, (R12)(R14*1)")
 	w("\tADDQ\tR9, DX")
 	w("\tADDQ\t$16, DI")
 	w("\tSUBL\t$1, R13")
 	w("\tJNZ\tvgemmx")
+	w("\tMOVL\t32(SP), R13")
+	w("\tSUBL\tR13, 8(SP)")
+	w("\tIMUL3Q\t$136, R13, R13")
+	w("\tADDQ\tR13, 16(SP)")
+	w("\tCMPL\t8(SP), $0")
+	w("\tJNE\tvgemmchunk")
 	w("\tADDQ\tR9, SI")
 	w("\tADDQ\tR15, BX")
 	w("\tSUBL\t$1, R10")

--- a/internal/gcasm/repackgemv_a64.go
+++ b/internal/gcasm/repackgemv_a64.go
@@ -28,10 +28,13 @@ import (
 // Bounds: vx + nc4*xtotal, vy + nb*34 and s + nc*4 are checked against
 // memSize at entry.
 // a64GemvFourGroups selects the four-groups-per-pass main loop; when
-// false every group runs through the single-group loop (measurement
-// knob for the streaming pattern; the single-group loop keeps two
-// SDOT chains per block).
-var a64GemvFourGroups = true
+// false (the default) every group runs through the single-group loop,
+// two SDOT chains per block. Decode is DRAM-bound and one sequential
+// weight stream feeds the prefetchers best: on Apple M5 the single
+// stream decodes 3% faster than four interleaved streams (and 5% faster
+// than the transpiled fused loop), even though the four-stream loop
+// wins a warm-cache micro-benchmark (90 vs 83 GB/s).
+var a64GemvFourGroups = false
 
 func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
 	var b strings.Builder

--- a/internal/gcasm/repackgemv_a64.go
+++ b/internal/gcasm/repackgemv_a64.go
@@ -1,0 +1,211 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// a64RepackGemvKernel emits the q8_0x4 repack GEMV under sym: one
+// activation row (block_q8_0) against nc columns of interleaved
+// weights (block_q8_0x4), the decode-time matmul.
+//
+// Four column groups (16 outputs) per pass share the activation
+// loads: per block the 32 quant bytes arrive as two 16-byte registers
+// whose 4-byte lanes are the eight k-quads, and each weight group
+// SDOTs against the matching lane (sdot .4b[k]) into its own i32
+// accumulator — 32 independent SDOTs per block over four weight
+// streams, then per group scvtf -> x (dcol * da) -> + running f32 sum
+// (the wasm gemv's own per-block order). Leftover groups run one at a
+// time. The kernel exists to replace the transpiled fused loop, which
+// pays a bounds check per load and a table lookup per f16 scale; it is
+// bandwidth-bound after that.
+//
+// C signature (llama-wasm arch/wasm/repack.cpp):
+//
+//	gemv(int n, float *s, size_t bs, void *vx, void *vy, int nr, int nc)
+//
+// nr is 1 by contract (asserted in C); the kernel computes row 0.
+// Bounds: vx + nc4*xtotal, vy + nb*34 and s + nc*4 are checked against
+// memSize at entry.
+func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+	word := func(enc uint32, dis string) { w("\tWORD $0x%08x // %s", enc, dis) }
+	ldurQ := func(rt, rn, imm int) {
+		word(0x3CC00000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur q%d, [x%d, #%d]", rt, rn, imm))
+	}
+	sturQ := func(rt, rn, imm int) {
+		word(0x3C800000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("stur q%d, [x%d, #%d]", rt, rn, imm))
+	}
+	ldurD := func(rt, rn, imm int) {
+		word(0xFC400000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur d%d, [x%d, #%d]", rt, rn, imm))
+	}
+	ldurH := func(t, n, imm int) {
+		word(0x7C400000|uint32(imm&0x1FF)<<12|uint32(n)<<5|uint32(t), fmt.Sprintf("ldur h%d, [x%d, #%d]", t, n, imm))
+	}
+	fcvtSH := func(d, n int) { word(0x1EE24000|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvt s%d, h%d", d, n)) }
+	movi0 := func(d int) { word(0x4F000400|uint32(d), fmt.Sprintf("movi v%d.4s, #0", d)) }
+	sdotLane := func(d, n, m, idx int) {
+		enc := 0x4F80E000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
+		word(enc, fmt.Sprintf("sdot v%d.4s, v%d.16b, v%d.4b[%d]", d, n, m, idx))
+	}
+	fcvtl := func(d, n int) { word(0x0E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl v%d.4s, v%d.4h", d, n)) }
+	scvtf := func(d, n int) { word(0x4E21D800|uint32(n)<<5|uint32(d), fmt.Sprintf("scvtf v%d.4s, v%d.4s", d, n)) }
+	fmulLane := func(d, n, m, idx int) {
+		enc := 0x4F809000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
+		word(enc, fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+	}
+	fmulV := func(d, n, m int) {
+		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+	faddV := func(d, n, m int) {
+		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+
+	argOff, argBytes := repackGemmArgs(wide)
+	movArg := "MOVWU"
+	if wide {
+		movArg = "MOVD"
+	}
+	arg := func(name string, reg int) {
+		mv := movArg
+		if name == "l5" || name == "l6" {
+			mv = "MOVWU"
+		}
+		w("\t%s\t%s+%d(FP), R%d", mv, name, argOff[name], reg)
+	}
+
+	// Per-group block tail: v(acc) i32 -> f32, x (dcol * da), into v(sum).
+	// dcol comes from the group's block header, da is in v18.s[0].
+	tail := func(acc, sum, bp int) {
+		ldurD(19, bp, 0)
+		fcvtl(19, 19)
+		fmulLane(19, 19, 18, 0)
+		scvtf(acc, acc)
+		fmulV(acc, acc, 19)
+		faddV(sum, sum, acc)
+	}
+
+	w("// %s: q8_0x4 repack GEMV, four column groups per pass via by-element SDOT.", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	w("\tMOVW\tl0+8(FP), R1")
+	w("\tLSRW\t$5, R1, R1") // nb
+	w("\tMOVD\t$136, R8")
+	w("\tMUL\tR1, R8, R8") // xtotal
+	arg("l6", 7)
+	w("\tLSRW\t$2, R7, R7") // nc4
+	w("\tCBZW\tR7, gvdone")
+	arg("l3", 4)
+	w("\tMUL\tR7, R8, R26")
+	w("\tADD\tR4, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tgvoob")
+	arg("l4", 5)
+	w("\tMOVD\t$34, R26")
+	w("\tMUL\tR1, R26, R26")
+	w("\tADD\tR5, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tgvoob")
+	arg("l1", 2)
+	w("\tLSL\t$4, R7, R26")
+	w("\tADD\tR2, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tgvoob")
+	w("\tADD\tR20, R2, R2") // s (host)
+	w("\tADD\tR20, R4, R4") // vx (host)
+	w("\tADD\tR20, R5, R5") // vy (host)
+	w("\tLSL\t$2, R8, R9")  // 4*xtotal: stride of a 4-group pass
+
+	// ---- four groups per pass.
+	w("gv4:")
+	w("\tCMPW\t$4, R7")
+	w("\tBLT\tgv1")
+	movi0(28)
+	movi0(29)
+	movi0(30)
+	movi0(31)
+	w("\tMOVD\tR4, R13")
+	w("\tADD\tR13, R8, R14")
+	w("\tADD\tR14, R8, R19")
+	w("\tADD\tR19, R8, R23")
+	w("\tMOVD\tR5, R17")
+	w("\tMOVW\tR1, R15")
+	w("\tCBZW\tR15, gv4store")
+	w("gv4blk:")
+	movi0(24)
+	movi0(25)
+	movi0(26)
+	movi0(27)
+	ldurQ(16, 17, 2)  // quads 0..3
+	ldurQ(17, 17, 18) // quads 4..7
+	ldurH(18, 17, 0)
+	fcvtSH(18, 18) // da
+	for k := 0; k < 8; k++ {
+		act := 16 + k/4
+		for g, bp := range []int{13, 14, 19, 23} {
+			ldurQ(g, bp, 8+16*k)
+			sdotLane(24+g, g, act, k%4)
+		}
+	}
+	tail(24, 28, 13)
+	tail(25, 29, 14)
+	tail(26, 30, 19)
+	tail(27, 31, 23)
+	w("\tADD\t$136, R13, R13")
+	w("\tADD\t$136, R14, R14")
+	w("\tADD\t$136, R19, R19")
+	w("\tADD\t$136, R23, R23")
+	w("\tADD\t$34, R17, R17")
+	w("\tSUBW\t$1, R15, R15")
+	w("\tCBNZW\tR15, gv4blk")
+	w("gv4store:")
+	sturQ(28, 2, 0)
+	sturQ(29, 2, 16)
+	sturQ(30, 2, 32)
+	sturQ(31, 2, 48)
+	w("\tADD\t$64, R2, R2")
+	w("\tADD\tR9, R4, R4")
+	w("\tSUBW\t$4, R7, R7")
+	w("\tB\tgv4")
+
+	// ---- leftover groups, one at a time.
+	w("gv1:")
+	w("\tCBZW\tR7, gvdone")
+	movi0(28)
+	w("\tMOVD\tR4, R13")
+	w("\tMOVD\tR5, R17")
+	w("\tMOVW\tR1, R15")
+	w("\tCBZW\tR15, gv1store")
+	w("gv1blk:")
+	movi0(24)
+	ldurQ(16, 17, 2)
+	ldurQ(17, 17, 18)
+	ldurH(18, 17, 0)
+	fcvtSH(18, 18)
+	for k := 0; k < 8; k++ {
+		ldurQ(0, 13, 8+16*k)
+		sdotLane(24, 0, 16+k/4, k%4)
+	}
+	tail(24, 28, 13)
+	w("\tADD\t$136, R13, R13")
+	w("\tADD\t$34, R17, R17")
+	w("\tSUBW\t$1, R15, R15")
+	w("\tCBNZW\tR15, gv1blk")
+	w("gv1store:")
+	sturQ(28, 2, 0)
+	w("\tADD\t$16, R2, R2")
+	w("\tADD\tR8, R4, R4")
+	w("\tSUBW\t$1, R7, R7")
+	w("\tB\tgv1")
+	w("gvdone:")
+	w("\tRET")
+	w("gvoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/repackgemv_a64.go
+++ b/internal/gcasm/repackgemv_a64.go
@@ -14,8 +14,9 @@ import (
 // whose 4-byte lanes are the eight k-quads, and each weight group
 // SDOTs against the matching lane (sdot .4b[k]) into its own i32
 // accumulator — 32 independent SDOTs per block over four weight
-// streams, then per group scvtf -> x (dcol * da) -> + running f32 sum
-// (the wasm gemv's own per-block order). Leftover groups run one at a
+// streams, then per group scvtf -> x dcol -> fused x da + running f32
+// sum, in the wasm gemv's per-block order and with the GEMM nests'
+// rounding. Leftover groups run one at a
 // time. The kernel exists to replace the transpiled fused loop, which
 // pays a bounds check per load and a table lookup per f16 scale; it is
 // bandwidth-bound after that.
@@ -60,15 +61,12 @@ func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	}
 	fcvtl := func(d, n int) { word(0x0E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl v%d.4s, v%d.4h", d, n)) }
 	scvtf := func(d, n int) { word(0x4E21D800|uint32(n)<<5|uint32(d), fmt.Sprintf("scvtf v%d.4s, v%d.4s", d, n)) }
-	fmulLane := func(d, n, m, idx int) {
-		enc := 0x4F809000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
-		word(enc, fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+	fmlaLane := func(d, n, m, idx int) {
+		enc := 0x4F801000 | uint32(idx&1)<<21 | uint32(idx>>1)<<11 | uint32(m)<<16 | uint32(n)<<5 | uint32(d)
+		word(enc, fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
 	}
 	fmulV := func(d, n, m int) {
 		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
-	}
-	faddV := func(d, n, m int) {
-		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
 
 	argOff, argBytes := repackGemmArgs(wide)
@@ -84,15 +82,17 @@ func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 		w("\t%s\t%s+%d(FP), R%d", mv, name, argOff[name], reg)
 	}
 
-	// Per-group block tail: v(acc) i32 -> f32, x (dcol * da), into v(sum).
-	// dcol comes from the group's block header, da is in v18.s[0].
+	// Per-group block tail: v(sum) += (f32(v(acc)) * dcol) * da with the
+	// activation scale fused — the same sequence and rounding as the
+	// GEMM nests' tails, so a row scores the same whether it was decoded
+	// alone (this kernel) or inside a batch (the GEMM). dcol comes from
+	// the group's block header, da is in v18.s[0].
 	tail := func(acc, sum, bp int) {
 		ldurD(19, bp, 0)
 		fcvtl(19, 19)
-		fmulLane(19, 19, 18, 0)
 		scvtf(acc, acc)
 		fmulV(acc, acc, 19)
-		faddV(sum, sum, acc)
+		fmlaLane(sum, acc, 18, 0)
 	}
 
 	w("// %s: q8_0x4 repack GEMV, four column groups per pass via by-element SDOT.", sym)

--- a/internal/gcasm/repackgemv_a64.go
+++ b/internal/gcasm/repackgemv_a64.go
@@ -27,6 +27,12 @@ import (
 // nr is 1 by contract (asserted in C); the kernel computes row 0.
 // Bounds: vx + nc4*xtotal, vy + nb*34 and s + nc*4 are checked against
 // memSize at entry.
+// a64GemvFourGroups selects the four-groups-per-pass main loop; when
+// false every group runs through the single-group loop (measurement
+// knob for the streaming pattern; the single-group loop keeps two
+// SDOT chains per block).
+var a64GemvFourGroups = true
+
 func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
 	var b strings.Builder
 	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
@@ -123,6 +129,9 @@ func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 
 	// ---- four groups per pass.
 	w("gv4:")
+	if !a64GemvFourGroups {
+		w("\tB\tgv1")
+	}
 	w("\tCMPW\t$4, R7")
 	w("\tBLT\tgv1")
 	movi0(28)
@@ -183,14 +192,16 @@ func a64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, wide bool) st
 	w("\tCBZW\tR15, gv1store")
 	w("gv1blk:")
 	movi0(24)
+	movi0(25)
 	ldurQ(16, 17, 2)
 	ldurQ(17, 17, 18)
 	ldurH(18, 17, 0)
 	fcvtSH(18, 18)
 	for k := 0; k < 8; k++ {
-		ldurQ(0, 13, 8+16*k)
-		sdotLane(24, 0, 16+k/4, k%4)
+		ldurQ(k%2, 13, 8+16*k)
+		sdotLane(24+k%2, k%2, 16+k/4, k%4)
 	}
+	word(0x4EA08400|uint32(25)<<16|uint32(24)<<5|uint32(24), "add v24.4s, v24.4s, v25.4s")
 	tail(24, 28, 13)
 	w("\tADD\t$136, R13, R13")
 	w("\tADD\t$34, R17, R17")

--- a/internal/gcasm/repackgemv_test.go
+++ b/internal/gcasm/repackgemv_test.go
@@ -20,7 +20,7 @@ func TestRepackGemvKernelShape(t *testing.T) {
 	}
 	pool := &ConstPool{}
 	x := x64RepackGemvKernel("Fn9avx2", "trapstub", offs, pool, true)
-	for _, want := range []string{"VPMADDWD", "VPDPBUSD", "VPBROADCASTQ", "VPBROADCASTD", "gvg4blk:", "vgvg4blk:", "gvg1blk:", "VZEROUPPER", "$" + strconv.Itoa(x64RepackGemvFrame) + "-56"} {
+	for _, want := range []string{"VPMADDWD", "VPDPBUSD", "VPBROADCASTQ", "VBROADCASTI128", "VINSERTI128", "gvg4blk:", "vgvg4blk:", "gvg1blk:", "VZEROUPPER", "$" + strconv.Itoa(x64RepackGemvFrame) + "-56"} {
 		if !strings.Contains(x, want) {
 			t.Errorf("x64 gemv missing %q", want)
 		}

--- a/internal/gcasm/repackgemv_test.go
+++ b/internal/gcasm/repackgemv_test.go
@@ -1,0 +1,222 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRepackGemvKernelShape(t *testing.T) {
+	offs := &ModuleOffsets{M: 8, MemSize: 0}
+	a := a64RepackGemvKernel("Fn9dotprod", "trapstub", offs, true)
+	for _, want := range []string{"sdot v27.4s, v3.16b, v17.4b[3]", "gv4blk:", "gv1blk:", "fcvt s18, h18", "$16-56"} {
+		if !strings.Contains(a, want) {
+			t.Errorf("a64 gemv missing %q", want)
+		}
+	}
+	pool := &ConstPool{}
+	x := x64RepackGemvKernel("Fn9avx2", "trapstub", offs, pool, true)
+	for _, want := range []string{"VPMADDWD", "VPDPBUSD", "VPBROADCASTQ", "VPBROADCASTD", "gvg4blk:", "vgvg4blk:", "gvg1blk:", "VZEROUPPER", "$" + strconv.Itoa(x64RepackGemvFrame) + "-56"} {
+		if !strings.Contains(x, want) {
+			t.Errorf("x64 gemv missing %q", want)
+		}
+	}
+}
+
+// repackGemvRunSrc: one activation row (block_q8_0) against nc columns
+// of block_q8_0x4 weights, compared with a float64 reference per
+// column (small relative tolerance: the kernel fuses nothing but the
+// f32 sums run in block order like the reference, so this is tight).
+const repackGemvRunSrc = `package gemvrun
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+type mockModule struct {
+	memSizePtr *uint64
+	mem        unsafe.Pointer
+}
+
+func f16bits(f float32) uint16 {
+	b := math.Float32bits(f)
+	sign := uint16(b>>16) & 0x8000
+	exp := int32(b>>23&0xFF) - 127 + 15
+	man := b >> 13 & 0x3FF
+	if exp <= 0 || exp >= 31 {
+		return sign | 0x3C00
+	}
+	return sign | uint16(exp)<<10 | uint16(man)
+}
+
+func f16val(h uint16) float64 {
+	sign := float64(1)
+	if h&0x8000 != 0 {
+		sign = -1
+	}
+	exp := int32(h >> 10 & 0x1F)
+	man := float64(h & 0x3FF)
+	if exp == 0 {
+		return sign * man / 1024 * math.Pow(2, -14)
+	}
+	return sign * (1 + man/1024) * math.Pow(2, float64(exp-15))
+}
+
+func runGemv(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32), n, nc int) {
+	t.Helper()
+	nb := n / 32
+	sOff := 256
+	vyOff := 4096
+	vxOff := vyOff + nb*34 + 64
+	mem := make([]byte, vxOff+(nc/4)*nb*136+4096)
+	rng := uint32(0xBEEF) + uint32(n*31+nc)
+	nextI8 := func() int8 {
+		rng = rng*1664525 + 1013904223
+		return int8(int32(rng>>24)%255 - 127)
+	}
+	// activation row: nb blocks of [d f16][32 x i8]
+	for l := 0; l < nb; l++ {
+		base := vyOff + l*34
+		h := f16bits(0.75 + float32(l%5)*0.125)
+		mem[base], mem[base+1] = byte(h), byte(h>>8)
+		for i := 0; i < 32; i++ {
+			mem[base+2+i] = byte(nextI8())
+		}
+	}
+	// weights: (nc/4) groups x nb blocks of [4 x d f16][128 x i8]
+	for g := 0; g < (nc/4)*nb; g++ {
+		base := vxOff + g*136
+		for j := 0; j < 4; j++ {
+			h := f16bits(1.0 + float32(g%3)*0.5 + float32(j)*0.25)
+			mem[base+2*j], mem[base+2*j+1] = byte(h), byte(h>>8)
+		}
+		for i := 0; i < 128; i++ {
+			mem[base+8+i] = byte(nextI8())
+		}
+	}
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	kernel(m, int32(n), int64(sOff), 0, int64(vxOff), int64(vyOff), 1, int32(nc))
+	for x := 0; x < nc/4; x++ {
+		for col := 0; col < 4; col++ {
+			var want float64
+			for l := 0; l < nb; l++ {
+				a := vyOff + l*34
+				bq := vxOff + (x*nb+l)*136
+				da := f16val(uint16(mem[a]) | uint16(mem[a+1])<<8)
+				db := f16val(uint16(mem[bq+2*col]) | uint16(mem[bq+2*col+1])<<8)
+				sumi := 0
+				for k := 0; k < 8; k++ {
+					for i := 0; i < 4; i++ {
+						sumi += int(int8(mem[bq+8+k*16+col*4+i])) * int(int8(mem[a+2+k*4+i]))
+					}
+				}
+				want += float64(sumi) * da * db
+			}
+			off := sOff + (x*4+col)*4
+			got := float64(math.Float32frombits(uint32(mem[off]) | uint32(mem[off+1])<<8 | uint32(mem[off+2])<<16 | uint32(mem[off+3])<<24))
+			if math.Abs(got-want) > 1e-3+1e-4*math.Abs(want) {
+				t.Fatalf("n=%d nc=%d s[%d] = %v, want %v", n, nc, x*4+col, got, want)
+			}
+		}
+	}
+	for off := sOff + nc*4; off < vyOff; off++ {
+		if mem[off] != 0 {
+			t.Fatalf("n=%d nc=%d byte %d past s written", n, nc, off)
+		}
+	}
+}
+`
+
+const repackGemvRunTest = `package gemvrun
+
+import "testing"
+
+func TestGemv(t *testing.T) {
+	for _, c := range [][2]int{{64, 16}, {64, 20}, {32, 4}, {96, 28}, {32 * 600, 8}, {32 * 513, 4}} {
+		runGemv(t, GemvKernel, c[0], c[1])
+	}
+}
+`
+
+func writeGemvRunTree(t *testing.T, dir, arch, kernelAsm, extraGo, runTest string) {
+	t.Helper()
+	trapstub := "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n"
+	if arch == "amd64" {
+		trapstub = "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
+	}
+	files := map[string]string{
+		"go.mod": "module gemvrun\n\ngo 1.25.0\n",
+		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" +
+			kernelAsm + trapstub,
+		"run.go":      repackGemvRunSrc + extraGo,
+		"run_test.go": runTest,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestA64RepackGemvKernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	kernel := a64RepackGemvKernel("GemvKernel", "trapstub", offs, true)
+	dir := t.TempDir()
+	writeGemvRunTree(t, dir, "arm64", kernel,
+		"\nfunc GemvKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\n",
+		repackGemvRunTest)
+	runArm64Gate(t, dir, ".", "TestGemv", kernel)
+}
+
+func TestX64RepackGemvKernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	pool := &ConstPool{}
+	kernel := x64RepackGemvKernel("GemvKernel", "trapstub", offs, pool, true)
+	dir := t.TempDir()
+	writeGemvRunTree(t, dir, "amd64", kernel+"\n"+pool.Emit(),
+		"\nfunc GemvKernel(m *mockModule, l0 int32, l1, l2, l3, l4 int64, l5, l6 int32)\nfunc trapstub()\n\nvar _ = trapstub\nvar gcasmHasAVX512VNNI bool\n",
+		`package gemvrun
+
+import "testing"
+
+func TestGemvX64(t *testing.T) {
+	gcasmHasAVX512VNNI = false
+	for _, c := range [][2]int{{64, 16}, {64, 20}, {32, 4}, {96, 28}, {32 * 600, 8}, {32 * 513, 4}} {
+		runGemv(t, GemvKernel, c[0], c[1])
+	}
+}
+
+func TestGemvX64VNNI(t *testing.T) {
+	gcasmHasAVX512VNNI = true
+	for _, c := range [][2]int{{64, 16}, {64, 20}, {32, 4}, {96, 28}, {32 * 600, 8}, {32 * 513, 4}} {
+		runGemv(t, GemvKernel, c[0], c[1])
+	}
+}
+`)
+	bin := filepath.Join(dir, "gemvrun.test")
+	build := exec.Command("go", "test", "-c", "-o", bin, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOARCH=amd64")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 assemble/link failed: %v\n%s\n--- asm ---\n%s", err, out, kernel)
+	}
+	if runtime.GOARCH != "amd64" || !hostHasAVX2(t) {
+		t.Skipf("assembled+linked OK; skipping execution (GOARCH=%s, avx2=%v)", runtime.GOARCH, hostHasAVX2(t))
+	}
+	runName := "TestGemvX64$"
+	if hostHasVNNI(t) {
+		runName = "TestGemvX64"
+	}
+	cmd := exec.Command(bin, "-test.run", runName, "-test.v")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 execution failed: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/repackgemv_x64.go
+++ b/internal/gcasm/repackgemv_x64.go
@@ -1,0 +1,464 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// x64RepackGemvChunkBlocks / x64RepackGemvFrame size the GEMV's stack
+// scratch: the activation row is prepared once per chunk of blocks
+// (AVX2: the eight k-quads widened to i16, 64 bytes per block; VNNI:
+// the quads xor 0x80 plus the block's byte sum, 48 bytes per block).
+const (
+	x64RepackGemvChunkBlocks = 512
+	x64RepackGemvFrame       = 64 + x64RepackGemvChunkBlocks*64
+)
+
+// x64RepackGemvKernel emits the q8_0x4 repack GEMV under sym for amd64
+// (see a64RepackGemvKernel for the contract): one activation row
+// against nc columns, four column groups per pass sharing the
+// activation operands, leftover groups one at a time.
+//
+// AVX2 nest: per weight group VPMOVSXBW (16 i16 = 4 columns x 4 k),
+// VPMADDWD against the row's widened k-quad broadcast (VPBROADCASTQ
+// from the scratch) and VPADDD into the group's pair-domain ymm; per
+// block the pair domain collapses (VPHADDD + lane fold) to the four
+// column sums, converts, scales by dcol * da and accumulates.
+//
+// VNNI nest: weights stay s8 in xmm, the activation quad arrives as
+// u8 (xor 0x80) by VPBROADCASTD, one VPDPBUSD per group; the +128
+// bias is undone with the block's activation byte sum, which the
+// prepass stores once per block and every column group reuses.
+func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+	c16 := func(bt byte) string {
+		blob := make([]byte, 16)
+		for i := range blob {
+			blob[i] = bt
+		}
+		return pool.addBlob(blob)
+	}
+	biasSym := c16(0x80)
+	onesSym := c16(0x01)
+
+	argOff, argBytes := repackGemmArgs(wide)
+	movArg := "MOVL"
+	if wide {
+		movArg = "MOVQ"
+	}
+	arg := func(name, reg string) {
+		mv := movArg
+		if name == "l5" || name == "l6" {
+			mv = "MOVL"
+		}
+		w("\t%s\t%s+%d(FP), %s", mv, name, argOff[name], reg)
+	}
+	memCheck := func() {
+		w("\tCMPQ\tR15, R12")
+		w("\tJCS\tgvoob")
+	}
+
+	// Register file after the prologue:
+	//	CX vx (host, current pass) | SI vy (host) | BX s (host)
+	//	R8 nb | R9 xtotal | R10 nc4 left
+	//	0(SP) blocks left | 8(SP) chunk byte offset (weights/acts)
+	//	16(SP) chunk blocks | 24(SP) groups left | 32(SP) 4th weight cursor
+	//	64(SP).. scratch
+	//	per pass: R13/R14/R15/DX weight cursors, AX act cursor,
+	//	R11 scratch cursor, DI block counter
+	w("// %s: q8_0x4 repack GEMV, four column groups per pass via AVX2 / VNNI.", sym)
+	w("TEXT ·%s(SB), $%d-%d", sym, x64RepackGemvFrame, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R15", offs.MemSize)
+	w("\tMOVQ\t(R15), R15")
+	w("\tMOVQ\t%d(AX), R14", offs.M)
+	w("\tMOVL\tl0+8(FP), R8")
+	w("\tSHRL\t$5, R8")
+	w("\tIMUL3Q\t$136, R8, R9")
+	arg("l6", "R10")
+	w("\tSHRL\t$2, R10")
+	w("\tTESTL\tR10, R10")
+	w("\tJZ\tgvdone")
+	arg("l3", "CX")
+	w("\tMOVQ\tR10, R12")
+	w("\tIMULQ\tR9, R12")
+	w("\tADDQ\tCX, R12")
+	memCheck()
+	arg("l4", "SI")
+	w("\tIMUL3Q\t$34, R8, R12")
+	w("\tADDQ\tSI, R12")
+	memCheck()
+	arg("l1", "BX")
+	w("\tMOVQ\tR10, R12")
+	w("\tSHLQ\t$4, R12")
+	w("\tADDQ\tBX, R12")
+	memCheck()
+	w("\tADDQ\tR14, CX")
+	w("\tADDQ\tR14, SI")
+	w("\tADDQ\tR14, BX")
+	w("\tCMPB\t·gcasmHasAVX512VNNI(SB), $0")
+	w("\tJNE\tvgvy")
+
+	// chunkHead emits the chunk bookkeeping shared by both nests:
+	// blocks left, chunk size, and the prepass over the activation
+	// chunk (perBlock emits one block's prepass at AX -> R11).
+	chunkLoop := func(p string, perBlock func(), blockBytes int, pass func(p string)) {
+		w("\tMOVQ\t$0, 8(SP)")
+		w("\tMOVL\tR8, 0(SP)")
+		w("%schunk:", p)
+		w("\tMOVL\t0(SP), R13")
+		w("\tMOVL\t$%d, AX", x64RepackGemvChunkBlocks)
+		w("\tCMPL\tR13, AX")
+		w("\tCMOVLGT\tAX, R13")
+		w("\tMOVL\tR13, 16(SP)")
+		w("\tMOVQ\tSI, AX")
+		w("\tADDQ\t8(SP), AX")
+		w("\tLEAQ\t64(SP), R11")
+		w("\tTESTL\tR13, R13")
+		w("\tJZ\t%spassinit", p)
+		w("%spre:", p)
+		perBlock()
+		w("\tADDQ\t$34, AX")
+		w("\tADDQ\t$%d, R11", blockBytes)
+		w("\tDECL\tR13")
+		w("\tJNZ\t%spre", p)
+		w("%spassinit:", p)
+		pass(p)
+		// Next chunk: advance the chunk byte offsets (acts 34/block,
+		// weights 136/block are tracked from the same block count).
+		w("\tMOVL\t16(SP), R13")
+		w("\tSUBL\tR13, 0(SP)")
+		w("\tADDQ\tR13, 8(SP)")
+		w("\tCMPL\t0(SP), $0")
+		w("\tJNE\t%schunk", p)
+		w("\tJMP\tgvdone")
+	}
+
+	// ---- AVX2 nest.
+	avx2Pass := func(p string) {
+		// Column groups: R10 counts; CX advances by xtotal per group.
+		// The pass loops over ALL column groups for this chunk, adding
+		// into s (zeroed on the first chunk).
+		w("\tMOVQ\tCX, DX") // group cursor (weights base of group 0)
+		w("\tMOVQ\tBX, DI") // s cursor
+		w("\tMOVL\tR10, R12")
+		w("\tMOVL\tR12, 24(SP)") // groups left
+		w("%sg4:", p)
+		w("\tCMPL\t24(SP), $4")
+		w("\tJLT\t%sg1", p)
+		// f32 accumulators Y8..Y11: zero on chunk 0, else reload.
+		w("\tCMPQ\t8(SP), $0")
+		w("\tJNE\t%sg4load", p)
+		for g := 0; g < 4; g++ {
+			w("\tVPXOR\tX%d, X%d, X%d", 8+g, 8+g, 8+g)
+		}
+		w("\tJMP\t%sg4go", p)
+		w("%sg4load:", p)
+		for g := 0; g < 4; g++ {
+			w("\tVMOVUPS\t%d(DI), X%d", 16*g, 8+g)
+		}
+		w("%sg4go:", p)
+		// weight cursors at the chunk offset (blocks * 136)
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$136, R12, R12")
+		w("\tLEAQ\t(DX)(R12*1), R13")
+		w("\tLEAQ\t(R13)(R9*1), R14")
+		w("\tLEAQ\t(R14)(R9*1), R15")
+		w("\tLEAQ\t(R15)(R9*1), AX")
+		w("\tMOVQ\tAX, 32(SP)") // 4th weight cursor lives in memory (AX is the act cursor)
+		w("\tMOVQ\tSI, AX")
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$34, R12, R12")
+		w("\tADDQ\tR12, AX")
+		w("\tLEAQ\t64(SP), R11")
+		w("\tMOVL\t16(SP), R12")
+		w("\tTESTL\tR12, R12")
+		w("\tJZ\t%sg4store", p)
+		w("%sg4blk:", p)
+		for g := 0; g < 4; g++ {
+			w("\tVPXOR\tY%d, Y%d, Y%d", g, g, g)
+		}
+		w("\tMOVQ\t32(SP), DI") // 4th cursor
+		for k := 0; k < 8; k++ {
+			w("\tVPBROADCASTQ\t%d(R11), Y5", 8*k)
+			for g, cur := range []string{"R13", "R14", "R15", "DI"} {
+				w("\tVPMOVSXBW\t%d(%s), Y4", 8+16*k, cur)
+				w("\tVPMADDWD\tY4, Y5, Y4")
+				w("\tVPADDD\tY4, Y%d, Y%d", g, g)
+			}
+		}
+		// da: f16 at (AX) -> broadcast f32 in Y6 (low lane used).
+		w("\tVMOVD\t(AX), X6")
+		w("\tVCVTPH2PS\tX6, X6")
+		w("\tVPSHUFD\t$0x00, X6, X6")
+		for g, cur := range []string{"R13", "R14", "R15", "DI"} {
+			// collapse pair domain -> 4 column sums in X(g)
+			w("\tVPHADDD\tY%d, Y%d, Y%d", g, g, g)
+			w("\tVEXTRACTI128\t$1, Y%d, X4", g)
+			w("\tVPUNPCKLQDQ\tX4, X%d, X%d", g, g)
+			w("\tVCVTDQ2PS\tX%d, X%d", g, g)
+			w("\tVMOVQ\t(%s), X7", cur)
+			w("\tVCVTPH2PS\tX7, X7")
+			w("\tVMULPS\tX6, X7, X7")
+			w("\tVMULPS\tX7, X%d, X%d", g, g)
+			w("\tVADDPS\tX%d, X%d, X%d", g, 8+g, 8+g)
+		}
+		w("\tADDQ\t$136, DI")
+		w("\tMOVQ\tDI, 32(SP)")
+		w("\tADDQ\t$136, R13")
+		w("\tADDQ\t$136, R14")
+		w("\tADDQ\t$136, R15")
+		w("\tADDQ\t$34, AX")
+		w("\tADDQ\t$64, R11")
+		w("\tDECL\tR12")
+		w("\tJNZ\t%sg4blk", p)
+		w("%sg4store:", p)
+		w("\tMOVQ\tBX, DI")
+		w("\tMOVL\tR10, R12")
+		w("\tSUBL\t24(SP), R12") // groups done
+		w("\tSHLL\t$4, R12")
+		w("\tADDQ\tR12, DI")
+		for g := 0; g < 4; g++ {
+			w("\tVMOVUPS\tX%d, %d(DI)", 8+g, 16*g)
+		}
+		w("\tLEAQ\t(DX)(R9*4), DX")
+		w("\tSUBL\t$4, 24(SP)")
+		w("\tJMP\t%sg4", p)
+		// ---- leftover groups
+		w("%sg1:", p)
+		w("\tCMPL\t24(SP), $0")
+		w("\tJEQ\t%spassend", p)
+		w("\tMOVQ\tBX, DI")
+		w("\tMOVL\tR10, R12")
+		w("\tSUBL\t24(SP), R12")
+		w("\tSHLL\t$4, R12")
+		w("\tADDQ\tR12, DI")
+		w("\tCMPQ\t8(SP), $0")
+		w("\tJNE\t%sg1load", p)
+		w("\tVPXOR\tX8, X8, X8")
+		w("\tJMP\t%sg1go", p)
+		w("%sg1load:", p)
+		w("\tVMOVUPS\t(DI), X8")
+		w("%sg1go:", p)
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$136, R12, R12")
+		w("\tLEAQ\t(DX)(R12*1), R13")
+		w("\tMOVQ\tSI, AX")
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$34, R12, R12")
+		w("\tADDQ\tR12, AX")
+		w("\tLEAQ\t64(SP), R11")
+		w("\tMOVL\t16(SP), R12")
+		w("\tTESTL\tR12, R12")
+		w("\tJZ\t%sg1store", p)
+		w("%sg1blk:", p)
+		w("\tVPXOR\tY0, Y0, Y0")
+		for k := 0; k < 8; k++ {
+			w("\tVPBROADCASTQ\t%d(R11), Y5", 8*k)
+			w("\tVPMOVSXBW\t%d(R13), Y4", 8+16*k)
+			w("\tVPMADDWD\tY4, Y5, Y4")
+			w("\tVPADDD\tY4, Y0, Y0")
+		}
+		w("\tVMOVD\t(AX), X6")
+		w("\tVCVTPH2PS\tX6, X6")
+		w("\tVPSHUFD\t$0x00, X6, X6")
+		w("\tVPHADDD\tY0, Y0, Y0")
+		w("\tVEXTRACTI128\t$1, Y0, X4")
+		w("\tVPUNPCKLQDQ\tX4, X0, X0")
+		w("\tVCVTDQ2PS\tX0, X0")
+		w("\tVMOVQ\t(R13), X7")
+		w("\tVCVTPH2PS\tX7, X7")
+		w("\tVMULPS\tX6, X7, X7")
+		w("\tVMULPS\tX7, X0, X0")
+		w("\tVADDPS\tX0, X8, X8")
+		w("\tADDQ\t$136, R13")
+		w("\tADDQ\t$34, AX")
+		w("\tADDQ\t$64, R11")
+		w("\tDECL\tR12")
+		w("\tJNZ\t%sg1blk", p)
+		w("%sg1store:", p)
+		w("\tVMOVUPS\tX8, (DI)")
+		w("\tADDQ\tR9, DX")
+		w("\tSUBL\t$1, 24(SP)")
+		w("\tJMP\t%sg1", p)
+		w("%spassend:", p)
+	}
+	avx2Pre := func() {
+		// quads 0..3 and 4..7 -> i16, 32 bytes each
+		w("\tVPMOVSXBW\t2(AX), Y4")
+		w("\tVMOVDQU\tY4, (R11)")
+		w("\tVPMOVSXBW\t18(AX), Y4")
+		w("\tVMOVDQU\tY4, 32(R11)")
+	}
+	chunkLoop("gv", avx2Pre, 64, avx2Pass)
+
+	// ---- VNNI nest: scratch per block = 32 bytes of u8 quads (xor
+	// 0x80) followed by the block's byte sum as i32 x4 (16 bytes).
+	vnniPre := func() {
+		w("\tVMOVDQU\t2(AX), X4")
+		w("\tVMOVDQU\t18(AX), X5")
+		// byte sum (s8): VPDPBUSD(ones u8, quads s8) -> 4 lanes, then fold
+		w("\tVPXOR\tX6, X6, X6")
+		w("\tVPDPBUSD\tX4, X15, X6")
+		w("\tVPDPBUSD\tX5, X15, X6")
+		w("\tVPHADDD\tX6, X6, X6")
+		w("\tVPHADDD\tX6, X6, X6")
+		w("\tVPSLLD\t$7, X6, X6") // 128 * sum, replicated
+		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
+		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X5, X5\n", biasSym)
+		w("\tVMOVDQU\tX4, (R11)")
+		w("\tVMOVDQU\tX5, 16(R11)")
+		w("\tVMOVDQU\tX6, 32(R11)")
+	}
+	vnniPass := func(p string) {
+		w("\tMOVQ\tCX, DX")
+		w("\tMOVL\tR10, R12")
+		w("\tMOVL\tR12, 24(SP)")
+		w("%sg4:", p)
+		w("\tCMPL\t24(SP), $4")
+		w("\tJLT\t%sg1", p)
+		w("\tMOVQ\tBX, DI")
+		w("\tMOVL\tR10, R12")
+		w("\tSUBL\t24(SP), R12")
+		w("\tSHLL\t$4, R12")
+		w("\tADDQ\tR12, DI")
+		w("\tCMPQ\t8(SP), $0")
+		w("\tJNE\t%sg4load", p)
+		for g := 0; g < 4; g++ {
+			w("\tVPXOR\tX%d, X%d, X%d", 8+g, 8+g, 8+g)
+		}
+		w("\tJMP\t%sg4go", p)
+		w("%sg4load:", p)
+		for g := 0; g < 4; g++ {
+			w("\tVMOVUPS\t%d(DI), X%d", 16*g, 8+g)
+		}
+		w("%sg4go:", p)
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$136, R12, R12")
+		w("\tLEAQ\t(DX)(R12*1), R13")
+		w("\tLEAQ\t(R13)(R9*1), R14")
+		w("\tLEAQ\t(R14)(R9*1), R15")
+		w("\tLEAQ\t(R15)(R9*1), AX")
+		w("\tMOVQ\tAX, 32(SP)")
+		w("\tMOVQ\tSI, AX")
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$34, R12, R12")
+		w("\tADDQ\tR12, AX")
+		w("\tLEAQ\t64(SP), R11")
+		w("\tMOVL\t16(SP), R12")
+		w("\tTESTL\tR12, R12")
+		w("\tJZ\t%sg4store", p)
+		w("%sg4blk:", p)
+		for g := 0; g < 4; g++ {
+			w("\tVPXOR\tX%d, X%d, X%d", g, g, g)
+		}
+		w("\tMOVQ\t32(SP), DI")
+		for k := 0; k < 8; k++ {
+			w("\tVPBROADCASTD\t%d(R11), X5", 4*k)
+			for g, cur := range []string{"R13", "R14", "R15", "DI"} {
+				w("\tVMOVDQU\t%d(%s), X4", 8+16*k, cur)
+				w("\tVPDPBUSD\tX4, X5, X%d", g)
+			}
+		}
+		w("\tVMOVD\t(AX), X6")
+		w("\tVCVTPH2PS\tX6, X6")
+		w("\tVPSHUFD\t$0x00, X6, X6")
+		for g, cur := range []string{"R13", "R14", "R15", "DI"} {
+			w("\tVPSUBD\t32(R11), X%d, X%d", g, g) // - 128 * sum(a)
+			w("\tVCVTDQ2PS\tX%d, X%d", g, g)
+			w("\tVMOVQ\t(%s), X7", cur)
+			w("\tVCVTPH2PS\tX7, X7")
+			w("\tVMULPS\tX6, X7, X7")
+			w("\tVMULPS\tX7, X%d, X%d", g, g)
+			w("\tVADDPS\tX%d, X%d, X%d", g, 8+g, 8+g)
+		}
+		w("\tADDQ\t$136, DI")
+		w("\tMOVQ\tDI, 32(SP)")
+		w("\tADDQ\t$136, R13")
+		w("\tADDQ\t$136, R14")
+		w("\tADDQ\t$136, R15")
+		w("\tADDQ\t$34, AX")
+		w("\tADDQ\t$48, R11")
+		w("\tDECL\tR12")
+		w("\tJNZ\t%sg4blk", p)
+		w("%sg4store:", p)
+		w("\tMOVQ\tBX, DI")
+		w("\tMOVL\tR10, R12")
+		w("\tSUBL\t24(SP), R12")
+		w("\tSHLL\t$4, R12")
+		w("\tADDQ\tR12, DI")
+		for g := 0; g < 4; g++ {
+			w("\tVMOVUPS\tX%d, %d(DI)", 8+g, 16*g)
+		}
+		w("\tLEAQ\t(DX)(R9*4), DX")
+		w("\tSUBL\t$4, 24(SP)")
+		w("\tJMP\t%sg4", p)
+		w("%sg1:", p)
+		w("\tCMPL\t24(SP), $0")
+		w("\tJEQ\t%spassend", p)
+		w("\tMOVQ\tBX, DI")
+		w("\tMOVL\tR10, R12")
+		w("\tSUBL\t24(SP), R12")
+		w("\tSHLL\t$4, R12")
+		w("\tADDQ\tR12, DI")
+		w("\tCMPQ\t8(SP), $0")
+		w("\tJNE\t%sg1load", p)
+		w("\tVPXOR\tX8, X8, X8")
+		w("\tJMP\t%sg1go", p)
+		w("%sg1load:", p)
+		w("\tVMOVUPS\t(DI), X8")
+		w("%sg1go:", p)
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$136, R12, R12")
+		w("\tLEAQ\t(DX)(R12*1), R13")
+		w("\tMOVQ\tSI, AX")
+		w("\tMOVQ\t8(SP), R12")
+		w("\tIMUL3Q\t$34, R12, R12")
+		w("\tADDQ\tR12, AX")
+		w("\tLEAQ\t64(SP), R11")
+		w("\tMOVL\t16(SP), R12")
+		w("\tTESTL\tR12, R12")
+		w("\tJZ\t%sg1store", p)
+		w("%sg1blk:", p)
+		w("\tVPXOR\tX0, X0, X0")
+		for k := 0; k < 8; k++ {
+			w("\tVPBROADCASTD\t%d(R11), X5", 4*k)
+			w("\tVMOVDQU\t%d(R13), X4", 8+16*k)
+			w("\tVPDPBUSD\tX4, X5, X0")
+		}
+		w("\tVMOVD\t(AX), X6")
+		w("\tVCVTPH2PS\tX6, X6")
+		w("\tVPSHUFD\t$0x00, X6, X6")
+		w("\tVPSUBD\t32(R11), X0, X0")
+		w("\tVCVTDQ2PS\tX0, X0")
+		w("\tVMOVQ\t(R13), X7")
+		w("\tVCVTPH2PS\tX7, X7")
+		w("\tVMULPS\tX6, X7, X7")
+		w("\tVMULPS\tX7, X0, X0")
+		w("\tVADDPS\tX0, X8, X8")
+		w("\tADDQ\t$136, R13")
+		w("\tADDQ\t$34, AX")
+		w("\tADDQ\t$48, R11")
+		w("\tDECL\tR12")
+		w("\tJNZ\t%sg1blk", p)
+		w("%sg1store:", p)
+		w("\tVMOVUPS\tX8, (DI)")
+		w("\tADDQ\tR9, DX")
+		w("\tSUBL\t$1, 24(SP)")
+		w("\tJMP\t%sg1", p)
+		w("%spassend:", p)
+	}
+	fmt.Fprintf(&b, "vgvy:\n\tVMOVDQU ·%s(SB), X15\n", onesSym)
+	chunkLoop("vgv", vnniPre, 48, vnniPass)
+
+	w("gvdone:")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("gvoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/repackgemv_x64.go
+++ b/internal/gcasm/repackgemv_x64.go
@@ -8,10 +8,12 @@ import (
 // x64RepackGemvChunkBlocks / x64RepackGemvFrame size the GEMV's stack
 // scratch: the activation row is prepared once per chunk of blocks
 // (AVX2: the eight k-quads widened to i16, 64 bytes per block; VNNI:
-// the raw quads plus 128 x the block's byte sum, 48 bytes per block).
+// the four k-quad pairs each laid out as [quad 2j x4 | quad 2j+1 x4]
+// for a 256-bit VPDPBUSD, plus 128 x the block's byte sum, 144 bytes
+// per block).
 const (
 	x64RepackGemvChunkBlocks = 512
-	x64RepackGemvFrame       = 64 + x64RepackGemvChunkBlocks*64
+	x64RepackGemvFrame       = 64 + x64RepackGemvChunkBlocks*144
 )
 
 // x64RepackGemvKernel emits the q8_0x4 repack GEMV under sym for amd64
@@ -25,11 +27,17 @@ const (
 // block the pair domain collapses (VPHADDD + lane fold) to the four
 // column sums, converts, scales by dcol * da and accumulates.
 //
-// VNNI nest: the weight group is biased to u8 (xor 0x80) in register,
-// the activation quad arrives as s8 by VPBROADCASTD, one VPDPBUSD per
-// group; the +128 weight bias is undone with the block's activation
-// byte sum, which the prepass stores once per block and every column
-// group reuses.
+// VNNI nest: 32 weight bytes at a time — two consecutive k-quads of
+// the four columns — biased to u8 (xor 0x80) in register, against the
+// prepared activation pair [quad 2j x4 | quad 2j+1 x4] (s8) straight
+// from the scratch as the VPDPBUSD memory operand: two instructions per
+// 32 bytes, two independent accumulators per column group (even and odd
+// pairs), the halves folded per block. The +128 weight bias is undone
+// with the block's activation byte sum, which the prepass stores once
+// per block and every column group reuses. (The first version did
+// 16 bytes per VPDPBUSD with a broadcast activation quad: half the work
+// per instruction, and on Zen 4 decode sat at ~18 GB/s while native
+// llama.cpp pulled 24.)
 func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
 	var b strings.Builder
 	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
@@ -308,9 +316,55 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		w("\tVPHADDD\tX6, X6, X6")
 		w("\tVPHADDD\tX6, X6, X6")
 		w("\tVPSLLD\t$7, X6, X6") // 128 * sum, replicated
-		w("\tVMOVDQU\tX4, (R11)")
-		w("\tVMOVDQU\tX5, 16(R11)")
-		w("\tVMOVDQU\tX6, 32(R11)")
+		w("\tVMOVDQU\tX6, 128(R11)")
+		// pairs: [quad 2j x4 | quad 2j+1 x4] at 32j(R11)
+		for j := 0; j < 4; j++ {
+			src := 4 + j/2
+			lo, hi := 0x00, 0x55
+			if j%2 == 1 {
+				lo, hi = 0xAA, 0xFF
+			}
+			w("\tVPSHUFD\t$0x%02x, X%d, X6", lo, src)
+			w("\tVPSHUFD\t$0x%02x, X%d, X7", hi, src)
+			w("\tVINSERTI128\t$1, X7, Y6, Y6")
+			w("\tVMOVDQU\tY6, %d(R11)", 32*j)
+		}
+	}
+	// vnniBlock emits one block of the VNNI nest for the given weight
+	// cursors: acc[g] (even pairs) / accB[g] (odd pairs) accumulate the
+	// four column sums of group g in both 128-bit halves; the tail folds
+	// them, removes the bias, scales and adds into X(8+g).
+	vnniAccB := []int{5, 7, 12, 14}
+	vnniBlock := func(curs []string) {
+		for g := range curs {
+			w("\tVPXOR\tY%d, Y%d, Y%d", g, g, g)
+			w("\tVPXOR\tY%d, Y%d, Y%d", vnniAccB[g], vnniAccB[g], vnniAccB[g])
+		}
+		for j := 0; j < 4; j++ {
+			for g, cur := range curs {
+				acc := g
+				if j%2 == 1 {
+					acc = vnniAccB[g]
+				}
+				w("\tVPXOR\t%d(%s), Y13, Y4", 8+32*j, cur)
+				w("\tVPDPBUSD\t%d(R11), Y4, Y%d", 32*j, acc) // acc += u8(w+128) . s8(a)
+			}
+		}
+		w("\tVMOVD\t(AX), X6")
+		w("\tVCVTPH2PS\tX6, X6")
+		w("\tVPSHUFD\t$0x00, X6, X6")
+		for g, cur := range curs {
+			w("\tVPADDD\tY%d, Y%d, Y%d", vnniAccB[g], g, g)
+			w("\tVEXTRACTI128\t$1, Y%d, X4", g)
+			w("\tVPADDD\tX4, X%d, X%d", g, g)
+			w("\tVPSUBD\t128(R11), X%d, X%d", g, g) // - 128 * sum(a)
+			w("\tVCVTDQ2PS\tX%d, X%d", g, g)
+			w("\tVMOVQ\t(%s), X7", cur)
+			w("\tVCVTPH2PS\tX7, X7")
+			w("\tVMULPS\tX6, X7, X7")
+			w("\tVMULPS\tX7, X%d, X%d", g, g)
+			w("\tVADDPS\tX%d, X%d, X%d", g, 8+g, 8+g)
+		}
 	}
 	vnniPass := func(p string) {
 		w("\tMOVQ\tCX, DX")
@@ -351,37 +405,15 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		w("\tTESTL\tR12, R12")
 		w("\tJZ\t%sg4store", p)
 		w("%sg4blk:", p)
-		for g := 0; g < 4; g++ {
-			w("\tVPXOR\tX%d, X%d, X%d", g, g, g)
-		}
 		w("\tMOVQ\t32(SP), DI")
-		for k := 0; k < 8; k++ {
-			w("\tVPBROADCASTD\t%d(R11), X5", 4*k)
-			for g, cur := range []string{"R13", "R14", "R15", "DI"} {
-				w("\tVMOVDQU\t%d(%s), X4", 8+16*k, cur)
-				fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
-				w("\tVPDPBUSD\tX5, X4, X%d", g) // acc += u8(w+128) . s8(a)
-			}
-		}
-		w("\tVMOVD\t(AX), X6")
-		w("\tVCVTPH2PS\tX6, X6")
-		w("\tVPSHUFD\t$0x00, X6, X6")
-		for g, cur := range []string{"R13", "R14", "R15", "DI"} {
-			w("\tVPSUBD\t32(R11), X%d, X%d", g, g) // - 128 * sum(a)
-			w("\tVCVTDQ2PS\tX%d, X%d", g, g)
-			w("\tVMOVQ\t(%s), X7", cur)
-			w("\tVCVTPH2PS\tX7, X7")
-			w("\tVMULPS\tX6, X7, X7")
-			w("\tVMULPS\tX7, X%d, X%d", g, g)
-			w("\tVADDPS\tX%d, X%d, X%d", g, 8+g, 8+g)
-		}
+		vnniBlock([]string{"R13", "R14", "R15", "DI"})
 		w("\tADDQ\t$136, DI")
 		w("\tMOVQ\tDI, 32(SP)")
 		w("\tADDQ\t$136, R13")
 		w("\tADDQ\t$136, R14")
 		w("\tADDQ\t$136, R15")
 		w("\tADDQ\t$34, AX")
-		w("\tADDQ\t$48, R11")
+		w("\tADDQ\t$144, R11")
 		w("\tDECL\tR12")
 		w("\tJNZ\t%sg4blk", p)
 		w("%sg4store:", p)
@@ -423,26 +455,10 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		w("\tTESTL\tR12, R12")
 		w("\tJZ\t%sg1store", p)
 		w("%sg1blk:", p)
-		w("\tVPXOR\tX0, X0, X0")
-		for k := 0; k < 8; k++ {
-			w("\tVPBROADCASTD\t%d(R11), X5", 4*k)
-			w("\tVMOVDQU\t%d(R13), X4", 8+16*k)
-			fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
-			w("\tVPDPBUSD\tX5, X4, X0")
-		}
-		w("\tVMOVD\t(AX), X6")
-		w("\tVCVTPH2PS\tX6, X6")
-		w("\tVPSHUFD\t$0x00, X6, X6")
-		w("\tVPSUBD\t32(R11), X0, X0")
-		w("\tVCVTDQ2PS\tX0, X0")
-		w("\tVMOVQ\t(R13), X7")
-		w("\tVCVTPH2PS\tX7, X7")
-		w("\tVMULPS\tX6, X7, X7")
-		w("\tVMULPS\tX7, X0, X0")
-		w("\tVADDPS\tX0, X8, X8")
+		vnniBlock([]string{"R13"})
 		w("\tADDQ\t$136, R13")
 		w("\tADDQ\t$34, AX")
-		w("\tADDQ\t$48, R11")
+		w("\tADDQ\t$144, R11")
 		w("\tDECL\tR12")
 		w("\tJNZ\t%sg1blk", p)
 		w("%sg1store:", p)
@@ -452,8 +468,8 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		w("\tJMP\t%sg1", p)
 		w("%spassend:", p)
 	}
-	fmt.Fprintf(&b, "vgvy:\n\tVMOVDQU ·%s(SB), X15\n", onesSym)
-	chunkLoop("vgv", vnniPre, 48, vnniPass)
+	fmt.Fprintf(&b, "vgvy:\n\tVMOVDQU ·%s(SB), X15\n\tVBROADCASTI128 ·%s(SB), Y13\n", onesSym, biasSym)
+	chunkLoop("vgv", vnniPre, 144, vnniPass)
 
 	w("gvdone:")
 	w("\tVZEROUPPER")

--- a/internal/gcasm/repackgemv_x64.go
+++ b/internal/gcasm/repackgemv_x64.go
@@ -8,7 +8,7 @@ import (
 // x64RepackGemvChunkBlocks / x64RepackGemvFrame size the GEMV's stack
 // scratch: the activation row is prepared once per chunk of blocks
 // (AVX2: the eight k-quads widened to i16, 64 bytes per block; VNNI:
-// the quads xor 0x80 plus the block's byte sum, 48 bytes per block).
+// the raw quads plus 128 x the block's byte sum, 48 bytes per block).
 const (
 	x64RepackGemvChunkBlocks = 512
 	x64RepackGemvFrame       = 64 + x64RepackGemvChunkBlocks*64
@@ -25,10 +25,11 @@ const (
 // block the pair domain collapses (VPHADDD + lane fold) to the four
 // column sums, converts, scales by dcol * da and accumulates.
 //
-// VNNI nest: weights stay s8 in xmm, the activation quad arrives as
-// u8 (xor 0x80) by VPBROADCASTD, one VPDPBUSD per group; the +128
-// bias is undone with the block's activation byte sum, which the
-// prepass stores once per block and every column group reuses.
+// VNNI nest: the weight group is biased to u8 (xor 0x80) in register,
+// the activation quad arrives as s8 by VPBROADCASTD, one VPDPBUSD per
+// group; the +128 weight bias is undone with the block's activation
+// byte sum, which the prepass stores once per block and every column
+// group reuses.
 func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
 	var b strings.Builder
 	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
@@ -113,8 +114,9 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		w("\tCMPL\tR13, AX")
 		w("\tCMOVLGT\tAX, R13")
 		w("\tMOVL\tR13, 16(SP)")
-		w("\tMOVQ\tSI, AX")
-		w("\tADDQ\t8(SP), AX")
+		w("\tMOVQ\t8(SP), AX")
+		w("\tIMUL3Q\t$34, AX, AX")
+		w("\tADDQ\tSI, AX")
 		w("\tLEAQ\t64(SP), R11")
 		w("\tTESTL\tR13, R13")
 		w("\tJZ\t%spassinit", p)
@@ -306,8 +308,6 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		w("\tVPHADDD\tX6, X6, X6")
 		w("\tVPHADDD\tX6, X6, X6")
 		w("\tVPSLLD\t$7, X6, X6") // 128 * sum, replicated
-		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
-		fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X5, X5\n", biasSym)
 		w("\tVMOVDQU\tX4, (R11)")
 		w("\tVMOVDQU\tX5, 16(R11)")
 		w("\tVMOVDQU\tX6, 32(R11)")
@@ -359,7 +359,8 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 			w("\tVPBROADCASTD\t%d(R11), X5", 4*k)
 			for g, cur := range []string{"R13", "R14", "R15", "DI"} {
 				w("\tVMOVDQU\t%d(%s), X4", 8+16*k, cur)
-				w("\tVPDPBUSD\tX4, X5, X%d", g)
+				fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
+				w("\tVPDPBUSD\tX5, X4, X%d", g) // acc += u8(w+128) . s8(a)
 			}
 		}
 		w("\tVMOVD\t(AX), X6")
@@ -426,7 +427,8 @@ func x64RepackGemvKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPo
 		for k := 0; k < 8; k++ {
 			w("\tVPBROADCASTD\t%d(R11), X5", 4*k)
 			w("\tVMOVDQU\t%d(R13), X4", 8+16*k)
-			w("\tVPDPBUSD\tX4, X5, X0")
+			fmt.Fprintf(&b, "\tVPXOR ·%s(SB), X4, X4\n", biasSym)
+			w("\tVPDPBUSD\tX5, X4, X0")
 		}
 		w("\tVMOVD\t(AX), X6")
 		w("\tVCVTPH2PS\tX6, X6")

--- a/internal/gcasm/simdgemm_f32_a64.go
+++ b/internal/gcasm/simdgemm_f32_a64.go
@@ -33,7 +33,7 @@ func simdGemmF32Export(mod *wasm.Module, cfg Config) string {
 // the a64 and x64 emitters.
 func simdGemmF32Args(wide bool) (map[string]int, int) {
 	if wide {
-		return map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32, "l4": 36, "l5": 40}, 48
+		return map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32, "l4": 36, "l5": 40}, 44
 	}
 	return map[string]int{"l0": 8, "l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28}, 32
 }

--- a/internal/gcasm/simdgemm_f32_a64.go
+++ b/internal/gcasm/simdgemm_f32_a64.go
@@ -57,6 +57,18 @@ var kernelRetargetTable = []kernelRetarget{
 		a64:      a64VecSwigluKernel,
 		x64:      x64VecSwigluKernel,
 	},
+	{
+		export:   "dbg_vec_dot_f16",
+		argBytes: func(wide bool) int { _, n := vecDotF16Args(wide); return n },
+		a64:      a64VecDotF16Kernel,
+		x64:      x64VecDotF16Kernel,
+	},
+	{
+		export:   "dbg_vec_mad_f16_f32",
+		argBytes: func(wide bool) int { _, n := vecMadF16F32Args(wide); return n },
+		a64:      a64VecMadF16F32Kernel,
+		x64:      x64VecMadF16F32Kernel,
+	},
 }
 
 // kernelRetargetExports resolves the retarget table against the

--- a/internal/gcasm/simdgemm_f32_a64.go
+++ b/internal/gcasm/simdgemm_f32_a64.go
@@ -21,9 +21,11 @@ type kernelRetarget struct {
 
 // kernelRetargetTable lists the exports llama-wasm publishes for
 // retargeting: ggml's simd_gemm (the tiled flash-attention QK^T / PV
-// micro-GEMM) and the vector exp kernels behind soft_max and swiglu.
-// All three reproduce the wasm arithmetic up to fused multiply-adds
-// (native-style rounding, which the FastMath gate admits).
+// micro-GEMM), the q8_0x4 repack GEMV (decode's matmul) and the
+// vector exp kernels behind soft_max and swiglu. All reproduce the
+// wasm arithmetic up to fused multiply-adds (native-style rounding,
+// which the FastMath gate admits); the GEMV keeps the wasm's exact
+// per-block order.
 var kernelRetargetTable = []kernelRetarget{
 	{
 		export:   "dbg_simd_gemm_f32",
@@ -34,6 +36,14 @@ var kernelRetargetTable = []kernelRetarget{
 		x64: func(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
 			return x64SimdGemmF32Kernel(sym, trapSym, offs, wide)
 		},
+	},
+	{
+		export:   "dbg_gemv_q8_0_4x4",
+		argBytes: func(wide bool) int { _, n := repackGemmArgs(wide); return n },
+		a64: func(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+			return a64RepackGemvKernel(sym, trapSym, offs, wide)
+		},
+		x64: x64RepackGemvKernel,
 	},
 	{
 		export:   "dbg_vec_soft_max_f32",

--- a/internal/gcasm/simdgemm_f32_a64.go
+++ b/internal/gcasm/simdgemm_f32_a64.go
@@ -45,9 +45,10 @@ func simdGemmF32Args(wide bool) (map[string]int, int) {
 // per k shared by the rows, one LD1R broadcast per row) for the bulk;
 // 4 rows x 4 columns and 4 rows x 1 column for the column tail; then
 // the same three shapes for the row tail one row at a time. Every
-// element's sum is formed as acc = acc + (b * a) in k order — the wasm
-// GGML_F32x4_FMA is add(mul(b, c), a) — so the result matches the
-// transformed body bit for bit whatever the tile.
+// element's sum is formed as acc = fma(b, a, acc) in k order: the wasm
+// body rounds the product and the sum separately, the kernel fuses
+// them (one rounding, the more accurate result) — the native-style
+// rounding the FastMath gate admits, as in the vec_dot tile kernels.
 //
 // Bounds: the three spans A[M*K], B[K*N], C[M*N] are checked against
 // memSize once at entry; a non-positive dimension returns without
@@ -73,11 +74,9 @@ func a64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 	ld1rPost := func(t, n int) {
 		word(0x4DDFC800|uint32(n)<<5|uint32(t), fmt.Sprintf("ld1r {v%d.4s}, [x%d], #4", t, n))
 	}
-	fmulV := func(d, n, m int) {
-		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
-	}
-	faddV := func(d, n, m int) {
-		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	// fmla d.4s, n.4s, m.4s: d += n * m, one rounding (fast-math).
+	fmlaV := func(d, n, m int) {
+		word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
 	}
 
 	argOff, argBytes := simdGemmF32Args(wide)
@@ -147,8 +146,7 @@ func a64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 		ld1rPost(23, 23)
 		for r := 0; r < 4; r++ {
 			for c := 0; c < nv; c++ {
-				fmulV(24+c, 16+c, 20+r)
-				faddV(4*r+c, 4*r+c, 24+c)
+				fmlaV(4*r+c, 16+c, 20+r)
 			}
 		}
 		w("\tADD\tR8, R22, R22")
@@ -167,8 +165,7 @@ func a64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 		}
 		ld1rPost(20, 16)
 		for c := 0; c < nv; c++ {
-			fmulV(24+c, 16+c, 20)
-			faddV(c, c, 24+c)
+			fmlaV(c, 16+c, 20)
 		}
 		w("\tADD\tR8, R22, R22")
 		w("\tSUBW\t$1, R24, R24")
@@ -188,21 +185,17 @@ func a64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 		w("\tFMOVS\t(R22), F16")
 		w("\tFMOVS\t(R16), F20")
 		w("\tADD\t$4, R16, R16")
-		w("\tFMULS\tF16, F20, F24")
-		w("\tFADDS\tF24, F0, F0")
+		w("\tFMADDS\tF16, F0, F20, F0")
 		if rows == 4 {
 			w("\tFMOVS\t(R17), F21")
 			w("\tADD\t$4, R17, R17")
-			w("\tFMULS\tF16, F21, F25")
-			w("\tFADDS\tF25, F1, F1")
+			w("\tFMADDS\tF16, F1, F21, F1")
 			w("\tFMOVS\t(R19), F22")
 			w("\tADD\t$4, R19, R19")
-			w("\tFMULS\tF16, F22, F26")
-			w("\tFADDS\tF26, F2, F2")
+			w("\tFMADDS\tF16, F2, F22, F2")
 			w("\tFMOVS\t(R23), F23")
 			w("\tADD\t$4, R23, R23")
-			w("\tFMULS\tF16, F23, F27")
-			w("\tFADDS\tF27, F3, F3")
+			w("\tFMADDS\tF16, F3, F23, F3")
 		}
 		w("\tADD\tR8, R22, R22")
 		w("\tSUBW\t$1, R24, R24")

--- a/internal/gcasm/simdgemm_f32_a64.go
+++ b/internal/gcasm/simdgemm_f32_a64.go
@@ -7,21 +7,75 @@ import (
 	"github.com/goccy/wasm2go/internal/wasm"
 )
 
-// simdGemmF32Export resolves the f32 GEMM retarget target: llama-wasm
-// exports ggml's simd_gemm (the tiled flash-attention QK^T / PV
-// micro-GEMM) under a stable debug name so the transpiler can swap its
-// body for a native register-tiled kernel. The kernel reproduces the
-// wasm arithmetic exactly — per element a k-ordered multiply-then-add
-// into the running sum — so it is bit-identical to the transformed
-// body; the FastMath gate is only the retarget infrastructure's.
-// Returns the FnN symbol, or "" when the export is absent.
-func simdGemmF32Export(mod *wasm.Module, cfg Config) string {
+// kernelRetarget describes one by-export native kernel: the wasm
+// function exported under `export` has its feature body replaced
+// wholesale by a64/x64 (see the repack GEMM retarget for the origin of
+// the scheme). argBytes is the ABI0 argument frame the emitted TEXT
+// declares; the bundle checks it against the transformed body's.
+type kernelRetarget struct {
+	export   string
+	argBytes func(wide bool) int
+	a64      func(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string
+	x64      func(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string
+}
+
+// kernelRetargetTable lists the exports llama-wasm publishes for
+// retargeting: ggml's simd_gemm (the tiled flash-attention QK^T / PV
+// micro-GEMM) and the vector exp kernels behind soft_max and swiglu.
+// All three reproduce the wasm arithmetic up to fused multiply-adds
+// (native-style rounding, which the FastMath gate admits).
+var kernelRetargetTable = []kernelRetarget{
+	{
+		export:   "dbg_simd_gemm_f32",
+		argBytes: func(wide bool) int { _, n := simdGemmF32Args(wide); return n },
+		a64: func(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+			return a64SimdGemmF32Kernel(sym, trapSym, offs, wide)
+		},
+		x64: func(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+			return x64SimdGemmF32Kernel(sym, trapSym, offs, wide)
+		},
+	},
+	{
+		export:   "dbg_vec_soft_max_f32",
+		argBytes: func(wide bool) int { _, n, _, _ := vecExpArgs(wide); return n },
+		a64:      a64VecSoftMaxKernel,
+		x64:      x64VecSoftMaxKernel,
+	},
+	{
+		export:   "dbg_vec_swiglu_f32",
+		argBytes: func(wide bool) int { _, _, _, n := vecExpArgs(wide); return n },
+		a64:      a64VecSwigluKernel,
+		x64:      x64VecSwigluKernel,
+	},
+}
+
+// kernelRetargetExports resolves the retarget table against the
+// module's exports: FnN symbol -> kernel. FastMath only, and subject
+// to the same opt-out as the repack GEMM retarget.
+func kernelRetargetExports(mod *wasm.Module, cfg Config) map[string]kernelRetarget {
+	out := map[string]kernelRetarget{}
 	if !cfg.FastMath || cfg.DisableRepackGemm {
-		return ""
+		return out
 	}
 	for _, e := range mod.Exports {
-		if e.Kind == wasm.ExportFunc && e.Name == "dbg_simd_gemm_f32" {
-			return fmt.Sprintf("Fn%d", e.Index)
+		if e.Kind != wasm.ExportFunc {
+			continue
+		}
+		for _, kr := range kernelRetargetTable {
+			if e.Name == kr.export {
+				out[fmt.Sprintf("Fn%d", e.Index)] = kr
+			}
+		}
+	}
+	return out
+}
+
+// simdGemmF32Export resolves the f32 GEMM retarget target (kept for
+// the export gate test): the FnN symbol, or "".
+func simdGemmF32Export(mod *wasm.Module, cfg Config) string {
+	for sym, kr := range kernelRetargetExports(mod, cfg) {
+		if kr.export == "dbg_simd_gemm_f32" {
+			return sym
 		}
 	}
 	return ""

--- a/internal/gcasm/simdgemm_f32_a64.go
+++ b/internal/gcasm/simdgemm_f32_a64.go
@@ -1,0 +1,330 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+// simdGemmF32Export resolves the f32 GEMM retarget target: llama-wasm
+// exports ggml's simd_gemm (the tiled flash-attention QK^T / PV
+// micro-GEMM) under a stable debug name so the transpiler can swap its
+// body for a native register-tiled kernel. The kernel reproduces the
+// wasm arithmetic exactly — per element a k-ordered multiply-then-add
+// into the running sum — so it is bit-identical to the transformed
+// body; the FastMath gate is only the retarget infrastructure's.
+// Returns the FnN symbol, or "" when the export is absent.
+func simdGemmF32Export(mod *wasm.Module, cfg Config) string {
+	if !cfg.FastMath || cfg.DisableRepackGemm {
+		return ""
+	}
+	for _, e := range mod.Exports {
+		if e.Kind == wasm.ExportFunc && e.Name == "dbg_simd_gemm_f32" {
+			return fmt.Sprintf("Fn%d", e.Index)
+		}
+	}
+	return ""
+}
+
+// simdGemmF32Args returns the ABI0 stack offsets of the GEMM's
+// arguments (l0 C, l1 A, l2 B pointers; l3 M, l4 K, l5 N int32) and
+// the argument-byte count for the module's pointer width. Shared by
+// the a64 and x64 emitters.
+func simdGemmF32Args(wide bool) (map[string]int, int) {
+	if wide {
+		return map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32, "l4": 36, "l5": 40}, 48
+	}
+	return map[string]int{"l0": 8, "l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28}, 32
+}
+
+// a64SimdGemmF32Kernel emits C[M x N] += A[M x K] * B[K x N] (row-major
+// f32, unit inner strides) under sym for arm64.
+//
+// Tiles: 4 rows x 16 columns (16 f32x4 accumulators, four B vectors
+// per k shared by the rows, one LD1R broadcast per row) for the bulk;
+// 4 rows x 4 columns and 4 rows x 1 column for the column tail; then
+// the same three shapes for the row tail one row at a time. Every
+// element's sum is formed as acc = acc + (b * a) in k order — the wasm
+// GGML_F32x4_FMA is add(mul(b, c), a) — so the result matches the
+// transformed body bit for bit whatever the tile.
+//
+// Bounds: the three spans A[M*K], B[K*N], C[M*N] are checked against
+// memSize once at entry; a non-positive dimension returns without
+// touching memory (the wasm body reads and rewrites C unchanged when
+// K == 0 — no observable difference).
+//
+// Register file after the prologue: R2 C row base, R3 A row base,
+// R4 B base (host pointers); R5 rows left, R6 K, R7 N; R8 N*4 (B/C row
+// stride), R9 K*4 (A row stride); R10 cols left, R11 C column cursor,
+// R12 B column cursor; R16/R17/R19/R23 A row cursors, R22 B k cursor,
+// R24 k counter; R13/R14/R15 C row pointers; R26 scratch.
+func a64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+	word := func(enc uint32, dis string) { w("\tWORD $0x%08x // %s", enc, dis) }
+	ldurQ := func(rt, rn, imm int) {
+		word(0x3CC00000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur q%d, [x%d, #%d]", rt, rn, imm))
+	}
+	sturQ := func(rt, rn, imm int) {
+		word(0x3C800000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("stur q%d, [x%d, #%d]", rt, rn, imm))
+	}
+	// ld1r {vT.4s}, [xN], #4 — broadcast one f32 and post-increment.
+	ld1rPost := func(t, n int) {
+		word(0x4DDFC800|uint32(n)<<5|uint32(t), fmt.Sprintf("ld1r {v%d.4s}, [x%d], #4", t, n))
+	}
+	fmulV := func(d, n, m int) {
+		word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+	faddV := func(d, n, m int) {
+		word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
+	}
+
+	argOff, argBytes := simdGemmF32Args(wide)
+	movPtr := "MOVWU"
+	if wide {
+		movPtr = "MOVD"
+	}
+
+	w("// %s: f32 GEMM C += A*B, 4x16 / 4x4 / 4x1 tiles (row tail 1xN).", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	w("\tMOVW\tl3+%d(FP), R5", argOff["l3"])
+	w("\tMOVW\tl4+%d(FP), R6", argOff["l4"])
+	w("\tMOVW\tl5+%d(FP), R7", argOff["l5"])
+	w("\tCMPW\t$1, R5")
+	w("\tBLT\tsgdone")
+	w("\tCMPW\t$1, R6")
+	w("\tBLT\tsgdone")
+	w("\tCMPW\t$1, R7")
+	w("\tBLT\tsgdone")
+	w("\t%s\tl0+%d(FP), R2", movPtr, argOff["l0"])
+	w("\t%s\tl1+%d(FP), R3", movPtr, argOff["l1"])
+	w("\t%s\tl2+%d(FP), R4", movPtr, argOff["l2"])
+	// Spans: A M*K*4, B K*N*4, C M*N*4 (all positive int32 products,
+	// exact in 64 bits).
+	w("\tMUL\tR5, R6, R26")
+	w("\tLSL\t$2, R26, R26")
+	w("\tADD\tR3, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tsgoob")
+	w("\tMUL\tR6, R7, R26")
+	w("\tLSL\t$2, R26, R26")
+	w("\tADD\tR4, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tsgoob")
+	w("\tMUL\tR5, R7, R26")
+	w("\tLSL\t$2, R26, R26")
+	w("\tADD\tR2, R26, R26")
+	w("\tCMP\tR26, R21")
+	w("\tBLO\tsgoob")
+	w("\tADD\tR20, R2, R2")
+	w("\tADD\tR20, R3, R3")
+	w("\tADD\tR20, R4, R4")
+	w("\tLSL\t$2, R7, R8") // N*4
+	w("\tLSL\t$2, R6, R9") // K*4
+
+	// kloop4 emits the k loop for a 4-row tile with nv B vectors
+	// (nv = 4 or 1): accumulators v(4r+c) for row r, vector c.
+	kloop4 := func(p string, nv int) {
+		w("\tMOVD\tR3, R16")
+		w("\tADD\tR16, R9, R17")
+		w("\tADD\tR17, R9, R19")
+		w("\tADD\tR19, R9, R23")
+		w("\tMOVD\tR12, R22")
+		w("\tMOVW\tR6, R24")
+		w("%sk:", p)
+		for c := 0; c < nv; c++ {
+			ldurQ(16+c, 22, 16*c)
+		}
+		ld1rPost(20, 16)
+		ld1rPost(21, 17)
+		ld1rPost(22, 19)
+		ld1rPost(23, 23)
+		for r := 0; r < 4; r++ {
+			for c := 0; c < nv; c++ {
+				fmulV(24+c, 16+c, 20+r)
+				faddV(4*r+c, 4*r+c, 24+c)
+			}
+		}
+		w("\tADD\tR8, R22, R22")
+		w("\tSUBW\t$1, R24, R24")
+		w("\tCBNZW\tR24, %sk", p)
+	}
+	// kloop1 emits the k loop for a 1-row tile with nv B vectors:
+	// accumulators v(c).
+	kloop1 := func(p string, nv int) {
+		w("\tMOVD\tR3, R16")
+		w("\tMOVD\tR12, R22")
+		w("\tMOVW\tR6, R24")
+		w("%sk:", p)
+		for c := 0; c < nv; c++ {
+			ldurQ(16+c, 22, 16*c)
+		}
+		ld1rPost(20, 16)
+		for c := 0; c < nv; c++ {
+			fmulV(24+c, 16+c, 20)
+			faddV(c, c, 24+c)
+		}
+		w("\tADD\tR8, R22, R22")
+		w("\tSUBW\t$1, R24, R24")
+		w("\tCBNZW\tR24, %sk", p)
+	}
+	// scalar column: rows x 1 element, F0..F3 accumulators.
+	kscalar := func(p string, rows int) {
+		w("\tMOVD\tR3, R16")
+		if rows == 4 {
+			w("\tADD\tR16, R9, R17")
+			w("\tADD\tR17, R9, R19")
+			w("\tADD\tR19, R9, R23")
+		}
+		w("\tMOVD\tR12, R22")
+		w("\tMOVW\tR6, R24")
+		w("%sk:", p)
+		w("\tFMOVS\t(R22), F16")
+		w("\tFMOVS\t(R16), F20")
+		w("\tADD\t$4, R16, R16")
+		w("\tFMULS\tF16, F20, F24")
+		w("\tFADDS\tF24, F0, F0")
+		if rows == 4 {
+			w("\tFMOVS\t(R17), F21")
+			w("\tADD\t$4, R17, R17")
+			w("\tFMULS\tF16, F21, F25")
+			w("\tFADDS\tF25, F1, F1")
+			w("\tFMOVS\t(R19), F22")
+			w("\tADD\t$4, R19, R19")
+			w("\tFMULS\tF16, F22, F26")
+			w("\tFADDS\tF26, F2, F2")
+			w("\tFMOVS\t(R23), F23")
+			w("\tADD\t$4, R23, R23")
+			w("\tFMULS\tF16, F23, F27")
+			w("\tFADDS\tF27, F3, F3")
+		}
+		w("\tADD\tR8, R22, R22")
+		w("\tSUBW\t$1, R24, R24")
+		w("\tCBNZW\tR24, %sk", p)
+	}
+	rowPtrs := func() {
+		w("\tADD\tR11, R8, R13")
+		w("\tADD\tR13, R8, R14")
+		w("\tADD\tR14, R8, R15")
+	}
+
+	// ---- 4-row blocks.
+	w("sgrows4:")
+	w("\tCMPW\t$4, R5")
+	w("\tBLT\tsgrows1")
+	w("\tMOVW\tR7, R10")
+	w("\tMOVD\tR2, R11")
+	w("\tMOVD\tR4, R12")
+	w("sg4c16:")
+	w("\tCMPW\t$16, R10")
+	w("\tBLT\tsg4c4")
+	rowPtrs()
+	for r, reg := range []int{11, 13, 14, 15} {
+		for c := 0; c < 4; c++ {
+			ldurQ(4*r+c, reg, 16*c)
+		}
+	}
+	kloop4("sg4c16", 4)
+	for r, reg := range []int{11, 13, 14, 15} {
+		for c := 0; c < 4; c++ {
+			sturQ(4*r+c, reg, 16*c)
+		}
+	}
+	w("\tADD\t$64, R11, R11")
+	w("\tADD\t$64, R12, R12")
+	w("\tSUBW\t$16, R10, R10")
+	w("\tB\tsg4c16")
+	w("sg4c4:")
+	w("\tCMPW\t$4, R10")
+	w("\tBLT\tsg4c1")
+	rowPtrs()
+	for r, reg := range []int{11, 13, 14, 15} {
+		ldurQ(4*r, reg, 0)
+	}
+	kloop4("sg4c4", 1)
+	for r, reg := range []int{11, 13, 14, 15} {
+		sturQ(4*r, reg, 0)
+	}
+	w("\tADD\t$16, R11, R11")
+	w("\tADD\t$16, R12, R12")
+	w("\tSUBW\t$4, R10, R10")
+	w("\tB\tsg4c4")
+	w("sg4c1:")
+	w("\tCBZW\tR10, sg4next")
+	rowPtrs()
+	w("\tFMOVS\t(R11), F0")
+	w("\tFMOVS\t(R13), F1")
+	w("\tFMOVS\t(R14), F2")
+	w("\tFMOVS\t(R15), F3")
+	kscalar("sg4c1", 4)
+	w("\tFMOVS\tF0, (R11)")
+	w("\tFMOVS\tF1, (R13)")
+	w("\tFMOVS\tF2, (R14)")
+	w("\tFMOVS\tF3, (R15)")
+	w("\tADD\t$4, R11, R11")
+	w("\tADD\t$4, R12, R12")
+	w("\tSUBW\t$1, R10, R10")
+	w("\tB\tsg4c1")
+	w("sg4next:")
+	w("\tADD\tR8<<2, R2, R2")
+	w("\tADD\tR9<<2, R3, R3")
+	w("\tSUBW\t$4, R5, R5")
+	w("\tB\tsgrows4")
+
+	// ---- row tail, one row at a time.
+	w("sgrows1:")
+	w("\tCBZW\tR5, sgdone")
+	w("\tMOVW\tR7, R10")
+	w("\tMOVD\tR2, R11")
+	w("\tMOVD\tR4, R12")
+	w("sg1c16:")
+	w("\tCMPW\t$16, R10")
+	w("\tBLT\tsg1c4")
+	for c := 0; c < 4; c++ {
+		ldurQ(c, 11, 16*c)
+	}
+	kloop1("sg1c16", 4)
+	for c := 0; c < 4; c++ {
+		sturQ(c, 11, 16*c)
+	}
+	w("\tADD\t$64, R11, R11")
+	w("\tADD\t$64, R12, R12")
+	w("\tSUBW\t$16, R10, R10")
+	w("\tB\tsg1c16")
+	w("sg1c4:")
+	w("\tCMPW\t$4, R10")
+	w("\tBLT\tsg1c1")
+	ldurQ(0, 11, 0)
+	kloop1("sg1c4", 1)
+	sturQ(0, 11, 0)
+	w("\tADD\t$16, R11, R11")
+	w("\tADD\t$16, R12, R12")
+	w("\tSUBW\t$4, R10, R10")
+	w("\tB\tsg1c4")
+	w("sg1c1:")
+	w("\tCBZW\tR10, sg1next")
+	w("\tFMOVS\t(R11), F0")
+	kscalar("sg1c1", 1)
+	w("\tFMOVS\tF0, (R11)")
+	w("\tADD\t$4, R11, R11")
+	w("\tADD\t$4, R12, R12")
+	w("\tSUBW\t$1, R10, R10")
+	w("\tB\tsg1c1")
+	w("sg1next:")
+	w("\tADD\tR8, R2, R2")
+	w("\tADD\tR9, R3, R3")
+	w("\tSUBW\t$1, R5, R5")
+	w("\tB\tsgrows1")
+	w("sgdone:")
+	w("\tRET")
+	w("sgoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/simdgemm_f32_test.go
+++ b/internal/gcasm/simdgemm_f32_test.go
@@ -32,7 +32,7 @@ func TestSimdGemmF32KernelShape(t *testing.T) {
 	for _, want := range []string{
 		"ld1r {v20.4s}, [x16], #4", "fmul v24.4s, v16.4s, v20.4s", "fadd v15.4s, v15.4s, v27.4s",
 		"sg4c16k:", "sg4c4k:", "sg4c1k:", "sg1c16k:", "sg1c4k:", "sg1c1k:", "sgoob:",
-		"TEXT ·Fn12dotprod(SB), $16-48",
+		"TEXT ·Fn12dotprod(SB), $16-44",
 	} {
 		if !strings.Contains(a, want) {
 			t.Errorf("a64 kernel missing %q", want)
@@ -45,7 +45,7 @@ func TestSimdGemmF32KernelShape(t *testing.T) {
 	for _, want := range []string{
 		"VBROADCASTSS", "VMULPS\tY8, Y10, Y11", "VADDPS\tY11, Y7, Y7", "VMULSS", "VADDSS",
 		"sg4c16k:", "sg4c8k:", "sg4c4k:", "sg4c1k:", "sg1c16k:", "sg1c1k:", "VZEROUPPER",
-		"TEXT ·Fn12avx2(SB), $16-48",
+		"TEXT ·Fn12avx2(SB), $16-44",
 	} {
 		if !strings.Contains(x, want) {
 			t.Errorf("x64 kernel missing %q", want)

--- a/internal/gcasm/simdgemm_f32_test.go
+++ b/internal/gcasm/simdgemm_f32_test.go
@@ -1,0 +1,220 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+func TestSimdGemmF32ExportGate(t *testing.T) {
+	mod := &wasm.Module{Exports: []wasm.Export{
+		{Name: "dbg_simd_gemm_f32", Kind: wasm.ExportFunc, Index: 12},
+	}}
+	if got := simdGemmF32Export(mod, Config{FastMath: true}); got != "Fn12" {
+		t.Errorf("FastMath retarget = %q, want Fn12", got)
+	}
+	if got := simdGemmF32Export(mod, Config{FastMath: true, DisableRepackGemm: true}); got != "" {
+		t.Errorf("opt-out retarget = %q, want none", got)
+	}
+	if got := simdGemmF32Export(mod, Config{}); got != "" {
+		t.Errorf("non-FastMath retarget = %q, want none", got)
+	}
+}
+
+func TestSimdGemmF32KernelShape(t *testing.T) {
+	offs := &ModuleOffsets{M: 8, MemSize: 0}
+	a := a64SimdGemmF32Kernel("Fn12dotprod", "trapstub", offs, true)
+	for _, want := range []string{
+		"ld1r {v20.4s}, [x16], #4", "fmul v24.4s, v16.4s, v20.4s", "fadd v15.4s, v15.4s, v27.4s",
+		"sg4c16k:", "sg4c4k:", "sg4c1k:", "sg1c16k:", "sg1c4k:", "sg1c1k:", "sgoob:",
+		"TEXT ·Fn12dotprod(SB), $16-48",
+	} {
+		if !strings.Contains(a, want) {
+			t.Errorf("a64 kernel missing %q", want)
+		}
+	}
+	if n := a64SimdGemmF32Kernel("Fn12dotprod", "trapstub", offs, false); !strings.Contains(n, "$16-32") || !strings.Contains(n, "MOVWU\tl0+8(FP)") {
+		t.Error("a64 narrow kernel: wrong argument frame")
+	}
+	x := x64SimdGemmF32Kernel("Fn12avx2", "trapstub", offs, true)
+	for _, want := range []string{
+		"VBROADCASTSS", "VMULPS\tY8, Y10, Y11", "VADDPS\tY11, Y7, Y7", "VMULSS", "VADDSS",
+		"sg4c16k:", "sg4c8k:", "sg4c4k:", "sg4c1k:", "sg1c16k:", "sg1c1k:", "VZEROUPPER",
+		"TEXT ·Fn12avx2(SB), $16-48",
+	} {
+		if !strings.Contains(x, want) {
+			t.Errorf("x64 kernel missing %q", want)
+		}
+	}
+	if strings.Contains(x, "VFMADD") {
+		t.Error("x64 kernel must not use FMA (the wasm body rounds the product)")
+	}
+}
+
+// simdGemmRunSrc is the execution driver: random A/B/C in a mock module
+// memory, the kernel, and a float32 reference that accumulates in the
+// same k order — the comparison is bit-exact.
+const simdGemmRunSrc = `package gemmrun
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+type mockModule struct {
+	memSizePtr *uint64
+	mem        unsafe.Pointer
+}
+
+type gemmCase struct{ m, k, n int }
+
+var gemmCases = []gemmCase{
+	{64, 64, 64}, // flash-attention tiles
+	{7, 5, 21},   // every tail shape
+	{4, 3, 16},
+	{1, 8, 1},
+	{5, 1, 17},
+	{8, 2, 12},
+	{3, 7, 9},
+}
+
+func putF32(mem []byte, off int, f float32) {
+	b := math.Float32bits(f)
+	mem[off], mem[off+1], mem[off+2], mem[off+3] = byte(b), byte(b>>8), byte(b>>16), byte(b>>24)
+}
+
+func getF32(mem []byte, off int) float32 {
+	return math.Float32frombits(uint32(mem[off]) | uint32(mem[off+1])<<8 | uint32(mem[off+2])<<16 | uint32(mem[off+3])<<24)
+}
+
+func runCase(t *testing.T, kernel func(m *mockModule, l0, l1, l2 int64, l3, l4, l5 int32), c gemmCase) {
+	t.Helper()
+	aOff := 256
+	bOff := aOff + c.m*c.k*4 + 64
+	cOff := bOff + c.k*c.n*4 + 64
+	mem := make([]byte, cOff+c.m*c.n*4+4096)
+	rng := uint32(0xC0FFEE)
+	next := func() float32 {
+		rng = rng*1664525 + 1013904223
+		return float32(int32(rng>>8)%2001-1000) / 128
+	}
+	A := make([]float32, c.m*c.k)
+	B := make([]float32, c.k*c.n)
+	C := make([]float32, c.m*c.n)
+	for i := range A {
+		A[i] = next()
+		putF32(mem, aOff+4*i, A[i])
+	}
+	for i := range B {
+		B[i] = next()
+		putF32(mem, bOff+4*i, B[i])
+	}
+	for i := range C {
+		C[i] = next()
+		putF32(mem, cOff+4*i, C[i])
+	}
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	kernel(m, int64(cOff), int64(aOff), int64(bOff), int32(c.m), int32(c.k), int32(c.n))
+	for i := 0; i < c.m; i++ {
+		for j := 0; j < c.n; j++ {
+			acc := C[i*c.n+j]
+			for kk := 0; kk < c.k; kk++ {
+				acc = acc + B[kk*c.n+j]*A[i*c.k+kk]
+			}
+			if got := getF32(mem, cOff+4*(i*c.n+j)); got != acc {
+				t.Fatalf("case %+v: C[%d][%d] = %v, want %v", c, i, j, got, acc)
+			}
+		}
+	}
+	// Nothing else was touched.
+	for off := cOff + c.m*c.n*4; off < len(mem); off++ {
+		if mem[off] != 0 {
+			t.Fatalf("case %+v: byte %d past C written", c, off)
+		}
+	}
+}
+`
+
+func writeSimdGemmRunTree(t *testing.T, dir, arch, kernelAsm, extraGo, runTest string) {
+	t.Helper()
+	trapstub := "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n"
+	if arch == "amd64" {
+		trapstub = "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
+	}
+	files := map[string]string{
+		"go.mod": "module gemmrun\n\ngo 1.25.0\n",
+		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" +
+			kernelAsm + trapstub,
+		"run.go":      simdGemmRunSrc + extraGo,
+		"run_test.go": runTest,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestA64SimdGemmF32KernelGate assembles and links the arm64 kernel on
+// every host and executes the bit-exact comparison on arm64 hosts.
+func TestA64SimdGemmF32KernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	kernel := a64SimdGemmF32Kernel("GemmKernel", "trapstub", offs, true)
+	dir := t.TempDir()
+	writeSimdGemmRunTree(t, dir, "arm64", kernel,
+		"\nfunc GemmKernel(m *mockModule, l0, l1, l2 int64, l3, l4, l5 int32)\nfunc trapstub()\n\nvar _ = trapstub\n",
+		`package gemmrun
+
+import "testing"
+
+func TestSimdGemmA64(t *testing.T) {
+	for _, c := range gemmCases {
+		runCase(t, GemmKernel, c)
+	}
+}
+`)
+	runArm64Gate(t, dir, ".", "TestSimdGemmA64", kernel)
+}
+
+// TestX64SimdGemmF32KernelGate assembles and links the amd64 kernel on
+// every host and executes the bit-exact comparison when the host has
+// AVX2.
+func TestX64SimdGemmF32KernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	kernel := x64SimdGemmF32Kernel("GemmKernel", "trapstub", offs, true)
+	dir := t.TempDir()
+	writeSimdGemmRunTree(t, dir, "amd64", kernel,
+		"\nfunc GemmKernel(m *mockModule, l0, l1, l2 int64, l3, l4, l5 int32)\nfunc trapstub()\n\nvar _ = trapstub\n",
+		`package gemmrun
+
+import "testing"
+
+func TestSimdGemmX64(t *testing.T) {
+	for _, c := range gemmCases {
+		runCase(t, GemmKernel, c)
+	}
+}
+`)
+	bin := filepath.Join(dir, "gemmrun.test")
+	build := exec.Command("go", "test", "-c", "-o", bin, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOARCH=amd64")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 assemble/link failed: %v\n%s\n--- asm ---\n%s", err, out, kernel)
+	}
+	if runtime.GOARCH != "amd64" || !hostHasAVX2(t) {
+		t.Skipf("assembled+linked OK; skipping execution (GOARCH=%s, avx2=%v)", runtime.GOARCH, hostHasAVX2(t))
+	}
+	cmd := exec.Command(bin, "-test.run", "TestSimdGemmX64", "-test.v")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 execution failed: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/simdgemm_f32_test.go
+++ b/internal/gcasm/simdgemm_f32_test.go
@@ -30,7 +30,7 @@ func TestSimdGemmF32KernelShape(t *testing.T) {
 	offs := &ModuleOffsets{M: 8, MemSize: 0}
 	a := a64SimdGemmF32Kernel("Fn12dotprod", "trapstub", offs, true)
 	for _, want := range []string{
-		"ld1r {v20.4s}, [x16], #4", "fmul v24.4s, v16.4s, v20.4s", "fadd v15.4s, v15.4s, v27.4s",
+		"ld1r {v20.4s}, [x16], #4", "fmla v15.4s, v19.4s, v23.4s", "FMADDS",
 		"sg4c16k:", "sg4c4k:", "sg4c1k:", "sg1c16k:", "sg1c4k:", "sg1c1k:", "sgoob:",
 		"TEXT ·Fn12dotprod(SB), $16-44",
 	} {
@@ -43,7 +43,7 @@ func TestSimdGemmF32KernelShape(t *testing.T) {
 	}
 	x := x64SimdGemmF32Kernel("Fn12avx2", "trapstub", offs, true)
 	for _, want := range []string{
-		"VBROADCASTSS", "VMULPS\tY8, Y10, Y11", "VADDPS\tY11, Y7, Y7", "VMULSS", "VADDSS",
+		"VBROADCASTSS", "VFMADD231PS\tY8, Y10, Y0", "VFMADD231PS\tY9, Y10, Y7", "VFMADD231SS",
 		"sg4c16k:", "sg4c8k:", "sg4c4k:", "sg4c1k:", "sg1c16k:", "sg1c1k:", "VZEROUPPER",
 		"TEXT ·Fn12avx2(SB), $16-44",
 	} {
@@ -51,14 +51,12 @@ func TestSimdGemmF32KernelShape(t *testing.T) {
 			t.Errorf("x64 kernel missing %q", want)
 		}
 	}
-	if strings.Contains(x, "VFMADD") {
-		t.Error("x64 kernel must not use FMA (the wasm body rounds the product)")
-	}
 }
 
 // simdGemmRunSrc is the execution driver: random A/B/C in a mock module
-// memory, the kernel, and a float32 reference that accumulates in the
-// same k order — the comparison is bit-exact.
+// memory, the kernel, and a reference that fuses each multiply-add in
+// float64 in the same k order; the kernel's single-rounded f32 FMAs
+// must land within a few ulps of it.
 const simdGemmRunSrc = `package gemmrun
 
 import (
@@ -124,11 +122,12 @@ func runCase(t *testing.T, kernel func(m *mockModule, l0, l1, l2 int64, l3, l4, 
 	kernel(m, int64(cOff), int64(aOff), int64(bOff), int32(c.m), int32(c.k), int32(c.n))
 	for i := 0; i < c.m; i++ {
 		for j := 0; j < c.n; j++ {
-			acc := C[i*c.n+j]
+			acc := float64(C[i*c.n+j])
 			for kk := 0; kk < c.k; kk++ {
-				acc = acc + B[kk*c.n+j]*A[i*c.k+kk]
+				acc = float64(float32(math.FMA(float64(B[kk*c.n+j]), float64(A[i*c.k+kk]), acc)))
 			}
-			if got := getF32(mem, cOff+4*(i*c.n+j)); got != acc {
+			got := float64(getF32(mem, cOff+4*(i*c.n+j)))
+			if math.Abs(got-acc) > 1e-6*math.Max(1, math.Abs(acc)) {
 				t.Fatalf("case %+v: C[%d][%d] = %v, want %v", c, i, j, got, acc)
 			}
 		}

--- a/internal/gcasm/simdgemm_f32_x64.go
+++ b/internal/gcasm/simdgemm_f32_x64.go
@@ -1,0 +1,277 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// x64SimdGemmF32Kernel emits C[M x N] += A[M x K] * B[K x N] (row-major
+// f32, unit inner strides) under sym for amd64 — the AVX2 twin of
+// a64SimdGemmF32Kernel (see there for the contract).
+//
+// Tiles: 4 rows x 16 columns (eight ymm accumulators, two B ymm per k
+// shared by the rows, one VBROADCASTSS per row) for the bulk; 4 x 8
+// (ymm), 4 x 4 (xmm) and 4 x 1 for the column tail; the same shapes
+// one row at a time for the row tail. acc = acc + (b * a) in k order,
+// no FMA, so the result matches the transformed body bit for bit.
+//
+// Register file after the prologue: CX C row base, SI A row base,
+// BX B base (host pointers); R10 rows left, R9 K, R8 N*4 (B/C row
+// stride), 8(SP) K*4 (A row stride); 0(SP) cols left, DI C column
+// cursor, DX B column cursor; R13/R14/R15/AX A row cursors, R12 B k
+// cursor, R11 k counter.
+func x64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+
+	argOff, argBytes := simdGemmF32Args(wide)
+	movPtr := "MOVL"
+	if wide {
+		movPtr = "MOVQ"
+	}
+
+	w("// %s: f32 GEMM C += A*B, 4x16 / 4x8 / 4x4 / 4x1 tiles (row tail 1xN).", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R15", offs.MemSize)
+	w("\tMOVQ\t(R15), R15")
+	w("\tMOVQ\t%d(AX), R14", offs.M)
+	w("\tMOVLQSX\tl3+%d(FP), R10", argOff["l3"])
+	w("\tMOVLQSX\tl4+%d(FP), R9", argOff["l4"])
+	w("\tMOVLQSX\tl5+%d(FP), R8", argOff["l5"])
+	w("\tTESTQ\tR10, R10")
+	w("\tJLE\tsgdone")
+	w("\tTESTQ\tR9, R9")
+	w("\tJLE\tsgdone")
+	w("\tTESTQ\tR8, R8")
+	w("\tJLE\tsgdone")
+	w("\t%s\tl0+%d(FP), CX", movPtr, argOff["l0"])
+	w("\t%s\tl1+%d(FP), SI", movPtr, argOff["l1"])
+	w("\t%s\tl2+%d(FP), BX", movPtr, argOff["l2"])
+	// Spans: A M*K*4, B K*N*4, C M*N*4.
+	w("\tMOVQ\tR10, R12")
+	w("\tIMULQ\tR9, R12")
+	w("\tSHLQ\t$2, R12")
+	w("\tADDQ\tSI, R12")
+	w("\tCMPQ\tR15, R12")
+	w("\tJCS\tsgoob")
+	w("\tMOVQ\tR9, R12")
+	w("\tIMULQ\tR8, R12")
+	w("\tSHLQ\t$2, R12")
+	w("\tADDQ\tBX, R12")
+	w("\tCMPQ\tR15, R12")
+	w("\tJCS\tsgoob")
+	w("\tMOVQ\tR10, R12")
+	w("\tIMULQ\tR8, R12")
+	w("\tSHLQ\t$2, R12")
+	w("\tADDQ\tCX, R12")
+	w("\tCMPQ\tR15, R12")
+	w("\tJCS\tsgoob")
+	w("\tADDQ\tR14, CX")
+	w("\tADDQ\tR14, SI")
+	w("\tADDQ\tR14, BX")
+	w("\tSHLQ\t$2, R8") // N*4
+	w("\tMOVQ\tR9, R12")
+	w("\tSHLQ\t$2, R12")
+	w("\tMOVQ\tR12, 8(SP)") // K*4
+
+	// A row cursors for a 4-row tile: R13 row0, R14 row1, R15 row2, AX row3.
+	aRows4 := func() {
+		w("\tMOVQ\tSI, R13")
+		w("\tMOVQ\tSI, R14")
+		w("\tADDQ\t8(SP), R14")
+		w("\tMOVQ\tR14, R15")
+		w("\tADDQ\t8(SP), R15")
+		w("\tMOVQ\tR15, AX")
+		w("\tADDQ\t8(SP), AX")
+	}
+	aRegs := []string{"R13", "R14", "R15", "AX"}
+	// kloop emits the k loop: rows (4 or 1) x vectors described by
+	// width ("Y" 8 floats or "X" 4 floats) and count nv; accumulator
+	// register for (row r, vector c) is r*nv+c.
+	kloop := func(p string, rows int, width string, nv int) {
+		if rows == 4 {
+			aRows4()
+		} else {
+			w("\tMOVQ\tSI, R13")
+		}
+		w("\tMOVQ\tDX, R12")
+		w("\tMOVQ\tR9, R11")
+		w("%sk:", p)
+		bReg := rows * nv // B vectors follow the accumulators
+		bc := bReg + nv   // broadcast
+		tmp := bc + 1     // product
+		vsz := 32
+		if width == "X" {
+			vsz = 16
+		}
+		for c := 0; c < nv; c++ {
+			w("\tVMOVUPS\t%d(R12), %s%d", vsz*c, width, bReg+c)
+		}
+		for r := 0; r < rows; r++ {
+			w("\tVBROADCASTSS\t(%s), %s%d", aRegs[r], width, bc)
+			w("\tADDQ\t$4, %s", aRegs[r])
+			for c := 0; c < nv; c++ {
+				w("\tVMULPS\t%s%d, %s%d, %s%d", width, bReg+c, width, bc, width, tmp)
+				w("\tVADDPS\t%s%d, %s%d, %s%d", width, tmp, width, r*nv+c, width, r*nv+c)
+			}
+		}
+		w("\tADDQ\tR8, R12")
+		w("\tDECQ\tR11")
+		w("\tJNZ\t%sk", p)
+	}
+	kscalar := func(p string, rows int) {
+		if rows == 4 {
+			aRows4()
+		} else {
+			w("\tMOVQ\tSI, R13")
+		}
+		w("\tMOVQ\tDX, R12")
+		w("\tMOVQ\tR9, R11")
+		w("%sk:", p)
+		w("\tVMOVSS\t(R12), X8")
+		for r := 0; r < rows; r++ {
+			w("\tVMOVSS\t(%s), X9", aRegs[r])
+			w("\tADDQ\t$4, %s", aRegs[r])
+			w("\tVMULSS\tX8, X9, X9")
+			w("\tVADDSS\tX9, X%d, X%d", r, r)
+		}
+		w("\tADDQ\tR8, R12")
+		w("\tDECQ\tR11")
+		w("\tJNZ\t%sk", p)
+	}
+	// C row pointers for a 4-row tile: DI row0, R12 row1 .. computed
+	// on the fly from R8 (used only around loads/stores, where R12 is
+	// free).
+	cRow := func(r int) string {
+		switch r {
+		case 0:
+			return "(DI)"
+		case 1:
+			return "(DI)(R8*1)"
+		case 2:
+			return "(DI)(R8*2)"
+		}
+		return "(R12)"
+	}
+	cRow3Setup := func() {
+		w("\tLEAQ\t(DI)(R8*2), R12")
+		w("\tADDQ\tR8, R12")
+	}
+	loadTile := func(rows int, width string, nv int) {
+		vsz := 32
+		if width == "X" {
+			vsz = 16
+		}
+		if rows == 4 {
+			cRow3Setup()
+		}
+		for r := 0; r < rows; r++ {
+			for c := 0; c < nv; c++ {
+				if vsz*c == 0 {
+					w("\tVMOVUPS\t%s, %s%d", cRow(r), width, r*nv+c)
+				} else {
+					w("\tVMOVUPS\t%d%s, %s%d", vsz*c, cRow(r), width, r*nv+c)
+				}
+			}
+		}
+	}
+	storeTile := func(rows int, width string, nv int) {
+		vsz := 32
+		if width == "X" {
+			vsz = 16
+		}
+		if rows == 4 {
+			cRow3Setup()
+		}
+		for r := 0; r < rows; r++ {
+			for c := 0; c < nv; c++ {
+				if vsz*c == 0 {
+					w("\tVMOVUPS\t%s%d, %s", width, r*nv+c, cRow(r))
+				} else {
+					w("\tVMOVUPS\t%s%d, %d%s", width, r*nv+c, vsz*c, cRow(r))
+				}
+			}
+		}
+	}
+	colBlock := func(p string, rows, cols int, width string, nv int, next string) {
+		w("%s:", p)
+		w("\tCMPQ\t0(SP), $%d", cols)
+		w("\tJLT\t%s", next)
+		loadTile(rows, width, nv)
+		kloop(p, rows, width, nv)
+		storeTile(rows, width, nv)
+		w("\tADDQ\t$%d, DI", 4*cols)
+		w("\tADDQ\t$%d, DX", 4*cols)
+		w("\tSUBQ\t$%d, 0(SP)", cols)
+		w("\tJMP\t%s", p)
+	}
+	scalarBlock := func(p string, rows int, next string) {
+		w("%s:", p)
+		w("\tCMPQ\t0(SP), $0")
+		w("\tJEQ\t%s", next)
+		if rows == 4 {
+			cRow3Setup()
+		}
+		for r := 0; r < rows; r++ {
+			w("\tVMOVSS\t%s, X%d", cRow(r), r)
+		}
+		kscalar(p, rows)
+		if rows == 4 {
+			cRow3Setup()
+		}
+		for r := 0; r < rows; r++ {
+			w("\tVMOVSS\tX%d, %s", r, cRow(r))
+		}
+		w("\tADDQ\t$4, DI")
+		w("\tADDQ\t$4, DX")
+		w("\tSUBQ\t$1, 0(SP)")
+		w("\tJMP\t%s", p)
+	}
+
+	// ---- 4-row blocks.
+	w("sgrows4:")
+	w("\tCMPQ\tR10, $4")
+	w("\tJLT\tsgrows1")
+	w("\tMOVQ\tR8, 0(SP)")
+	w("\tSHRQ\t$2, 0(SP)") // cols left = N
+	w("\tMOVQ\tCX, DI")
+	w("\tMOVQ\tBX, DX")
+	colBlock("sg4c16", 4, 16, "Y", 2, "sg4c8")
+	colBlock("sg4c8", 4, 8, "Y", 1, "sg4c4")
+	colBlock("sg4c4", 4, 4, "X", 1, "sg4c1")
+	scalarBlock("sg4c1", 4, "sg4next")
+	w("sg4next:")
+	w("\tLEAQ\t(CX)(R8*4), CX")
+	w("\tMOVQ\t8(SP), R12")
+	w("\tLEAQ\t(SI)(R12*4), SI")
+	w("\tSUBQ\t$4, R10")
+	w("\tJMP\tsgrows4")
+
+	// ---- row tail, one row at a time.
+	w("sgrows1:")
+	w("\tTESTQ\tR10, R10")
+	w("\tJZ\tsgdone")
+	w("\tMOVQ\tR8, 0(SP)")
+	w("\tSHRQ\t$2, 0(SP)")
+	w("\tMOVQ\tCX, DI")
+	w("\tMOVQ\tBX, DX")
+	colBlock("sg1c16", 1, 16, "Y", 2, "sg1c8")
+	colBlock("sg1c8", 1, 8, "Y", 1, "sg1c4")
+	colBlock("sg1c4", 1, 4, "X", 1, "sg1c1")
+	scalarBlock("sg1c1", 1, "sg1next")
+	w("sg1next:")
+	w("\tADDQ\tR8, CX")
+	w("\tADDQ\t8(SP), SI")
+	w("\tSUBQ\t$1, R10")
+	w("\tJMP\tsgrows1")
+	w("sgdone:")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("sgoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return b.String()
+}

--- a/internal/gcasm/simdgemm_f32_x64.go
+++ b/internal/gcasm/simdgemm_f32_x64.go
@@ -12,8 +12,8 @@ import (
 // Tiles: 4 rows x 16 columns (eight ymm accumulators, two B ymm per k
 // shared by the rows, one VBROADCASTSS per row) for the bulk; 4 x 8
 // (ymm), 4 x 4 (xmm) and 4 x 1 for the column tail; the same shapes
-// one row at a time for the row tail. acc = acc + (b * a) in k order,
-// no FMA, so the result matches the transformed body bit for bit.
+// one row at a time for the row tail. acc = fma(b, a, acc) in k order
+// (one rounding; the wasm body rounds twice — fast-math, as on arm64).
 //
 // Register file after the prologue: CX C row base, SI A row base,
 // BX B base (host pointers); R10 rows left, R9 K, R8 N*4 (B/C row
@@ -101,7 +101,6 @@ func x64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 		w("%sk:", p)
 		bReg := rows * nv // B vectors follow the accumulators
 		bc := bReg + nv   // broadcast
-		tmp := bc + 1     // product
 		vsz := 32
 		if width == "X" {
 			vsz = 16
@@ -113,8 +112,7 @@ func x64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 			w("\tVBROADCASTSS\t(%s), %s%d", aRegs[r], width, bc)
 			w("\tADDQ\t$4, %s", aRegs[r])
 			for c := 0; c < nv; c++ {
-				w("\tVMULPS\t%s%d, %s%d, %s%d", width, bReg+c, width, bc, width, tmp)
-				w("\tVADDPS\t%s%d, %s%d, %s%d", width, tmp, width, r*nv+c, width, r*nv+c)
+				w("\tVFMADD231PS\t%s%d, %s%d, %s%d", width, bReg+c, width, bc, width, r*nv+c)
 			}
 		}
 		w("\tADDQ\tR8, R12")
@@ -134,8 +132,7 @@ func x64SimdGemmF32Kernel(sym, trapSym string, offs *ModuleOffsets, wide bool) s
 		for r := 0; r < rows; r++ {
 			w("\tVMOVSS\t(%s), X9", aRegs[r])
 			w("\tADDQ\t$4, %s", aRegs[r])
-			w("\tVMULSS\tX8, X9, X9")
-			w("\tVADDSS\tX9, X%d, X%d", r, r)
+			w("\tVFMADD231SS\tX8, X9, X%d", r)
 		}
 		w("\tADDQ\tR8, R12")
 		w("\tDECQ\tR11")

--- a/internal/gcasm/vecexp_a64.go
+++ b/internal/gcasm/vecexp_a64.go
@@ -1,0 +1,336 @@
+package gcasm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// vecExpConsts is the constant block the vector exp kernels load:
+// sixteen 32-bit lanes (f32 unless noted), the ARM optimized-routines
+// expf polynomial ggml_v_expf uses on every native ISA.
+//
+//	0 r = 0x1.8p23   1 log2e        2 c1 0x1.62e4p-1   3 c2 0x1.7f7d1cp-20
+//	4 p0 0x1.0e4020p-7  5 p1 0x1.573e2ep-5  6 p2 0x1.555e66p-3  7 p3 0x1.fffdb6p-2
+//	8 p4 0x1.ffffecp-1  9 126.0  10 192.0  11 1.0 (also the 0x3f800000 addend)
+//	12 u32 0x82000000  13 u32 0x7f000000  14 abs mask 0x7fffffff  15 0
+func vecExpConsts() []byte {
+	f := []float32{
+		0x1.8p23, 0x1.715476p+0, 0x1.62e4p-1, 0x1.7f7d1cp-20,
+		0x1.0e4020p-7, 0x1.573e2ep-5, 0x1.555e66p-3, 0x1.fffdb6p-2,
+		0x1.ffffecp-1, 126, 192, 1,
+	}
+	blob := make([]byte, 64)
+	for i, v := range f {
+		binary.LittleEndian.PutUint32(blob[4*i:], math.Float32bits(v))
+	}
+	binary.LittleEndian.PutUint32(blob[48:], 0x82000000)
+	binary.LittleEndian.PutUint32(blob[52:], 0x7f000000)
+	binary.LittleEndian.PutUint32(blob[56:], 0x7fffffff)
+	return blob
+}
+
+// vecExpArgs returns the ABI0 offsets of the exp kernels' arguments.
+// soft_max(n int32, y, x ptr, max f32) -> f64; swiglu(n int32, y, x, g
+// ptr). Pointers follow the module's width; the f64 result sits after
+// the last argument, 8-aligned.
+func vecExpArgs(wide bool) (softmax map[string]int, softmaxArgBytes int, swiglu map[string]int, swigluArgBytes int) {
+	if wide {
+		return map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32, "r0": 40}, 48,
+			map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32}, 40
+	}
+	return map[string]int{"l0": 8, "l1": 12, "l2": 16, "l3": 20, "r0": 24}, 32,
+		map[string]int{"l0": 8, "l1": 12, "l2": 16, "l3": 20}, 24
+}
+
+// a64VecExp holds the NEON emitters shared by the arm64 exp kernels.
+// Constant registers after a64VecExpLoadConsts: v28..v31 = the 16
+// lanes of vecExpConsts (by-element operands), v27 = dup 126, v26 =
+// dup 192, v25 = dup 1.0 (bits 0x3f800000), v24 = dup 0x82000000,
+// v23 = dup 0x7f000000, v22 = dup r, v21 = dup p1, v20 = dup p3.
+type a64VecExp struct {
+	w    func(format string, args ...any)
+	word func(enc uint32, dis string)
+}
+
+func (e *a64VecExp) fmlaV(d, n, m int) {
+	e.word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecExp) fmlaLane(d, n, m, idx int) {
+	e.word(0x4F801000|uint32(idx&1)<<21|uint32(idx>>1)<<11|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+}
+
+func (e *a64VecExp) fmlsLane(d, n, m, idx int) {
+	e.word(0x4F805000|uint32(idx&1)<<21|uint32(idx>>1)<<11|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmls v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+}
+
+func (e *a64VecExp) fmulLane(d, n, m, idx int) {
+	e.word(0x4F809000|uint32(idx&1)<<21|uint32(idx>>1)<<11|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+}
+
+func (e *a64VecExp) fmulV(d, n, m int) {
+	e.word(0x6E20DC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmul v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecExp) faddV(d, n, m int) {
+	e.word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecExp) fsubV(d, n, m int) {
+	e.word(0x4EA0D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fsub v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecExp) fdivV(d, n, m int) {
+	e.word(0x6E20FC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fdiv v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecExp) mov(d, n int) {
+	e.word(0x4EA01C00|uint32(n)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("mov v%d.16b, v%d.16b", d, n))
+}
+
+func (e *a64VecExp) dupLane(d, n, idx int) {
+	e.word(0x4E000400|uint32((idx<<3)|4)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("dup v%d.4s, v%d.s[%d]", d, n, idx))
+}
+
+func (e *a64VecExp) ldurQ(rt, rn, imm int) {
+	e.word(0x3CC00000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur q%d, [x%d, #%d]", rt, rn, imm))
+}
+
+func (e *a64VecExp) sturQ(rt, rn, imm int) {
+	e.word(0x3C800000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("stur q%d, [x%d, #%d]", rt, rn, imm))
+}
+
+// loadConsts materializes the constant registers from the pool blob.
+func (e *a64VecExp) loadConsts(sym string, reg int) {
+	e.w("\tMOVD\t$·%s(SB), R%d", sym, reg)
+	e.w("\tVLD1\t(R%d), [V28.S4, V29.S4, V30.S4, V31.S4]", reg)
+	e.dupLane(27, 30, 1) // 126
+	e.dupLane(26, 30, 2) // 192
+	e.dupLane(25, 30, 3) // 1.0
+	e.dupLane(24, 31, 0) // 0x82000000
+	e.dupLane(23, 31, 1) // 0x7f000000
+	e.dupLane(22, 28, 0) // r
+	e.dupLane(21, 29, 1) // p1
+	e.dupLane(20, 29, 3) // p3
+}
+
+// exp computes v(out) = expf(v(x)) lane-wise, clobbering v0..v11
+// except x/out. x may equal out. The arithmetic is ggml_v_expf's
+// (fused multiply-adds, the special-range select computed branch-free):
+// numbers above 88.38 flush to +inf, beneath -103.97 to zero.
+func (e *a64VecExp) exp(out, x int) {
+	const (
+		z  = 1
+		n  = 2
+		b  = 3
+		ee = 4
+		k  = 5
+		an = 6
+		c  = 7
+		u  = 8
+		t1 = 9
+		t2 = 10
+		m  = 11
+	)
+	// z = r + x*log2e ; n = z - r
+	e.mov(z, 22)
+	e.fmlaLane(z, x, 28, 1)
+	e.fsubV(n, z, 22)
+	// b = x - n*c1 - n*c2
+	e.mov(b, x)
+	e.fmlsLane(b, n, 28, 2)
+	e.fmlsLane(b, n, 28, 3)
+	// e = bits(z) << 23 ; k = e + 1.0bits
+	e.word(0x4F375400|uint32(z)<<5|uint32(ee), fmt.Sprintf("shl v%d.4s, v%d.4s, #23", ee, z))
+	e.word(0x4EA08400|uint32(25)<<16|uint32(ee)<<5|uint32(k), fmt.Sprintf("add v%d.4s, v%d.4s, v25.4s", k, ee))
+	// an = |n| ; c = an > 126
+	e.word(0x4EA0F800|uint32(n)<<5|uint32(an), fmt.Sprintf("fabs v%d.4s, v%d.4s", an, n))
+	e.word(0x6EA0E400|uint32(27)<<16|uint32(an)<<5|uint32(c), fmt.Sprintf("fcmgt v%d.4s, v%d.4s, v27.4s", c, an))
+	// u = b*b ; t1 = p1 + b*p0 ; t2 = p3 + b*p2 ; j = (p4*b) + (t2 + t1*u)*u
+	e.fmulV(u, b, b)
+	e.mov(t1, 21)
+	e.fmlaLane(t1, b, 29, 0)
+	e.mov(t2, 20)
+	e.fmlaLane(t2, b, 29, 2)
+	e.fmlaV(t2, t1, u)
+	e.fmulLane(m, b, 30, 0)
+	e.fmlaV(m, t2, u) // m = j
+	// res(t1) = k + j*k
+	e.mov(t1, k)
+	e.fmlaV(t1, m, k)
+	// d(z) = (n <= 0) & 0x82000000 ; s1(b) = d + 0x7f000000 ; s2(u) = e - d
+	e.word(0x6EA0D800|uint32(n)<<5|uint32(z), fmt.Sprintf("fcmle v%d.4s, v%d.4s, #0.0", z, n))
+	e.word(0x4E201C00|uint32(24)<<16|uint32(z)<<5|uint32(z), fmt.Sprintf("and v%d.16b, v%d.16b, v24.16b", z, z))
+	e.word(0x4EA08400|uint32(23)<<16|uint32(z)<<5|uint32(b), fmt.Sprintf("add v%d.4s, v%d.4s, v23.4s", b, z))
+	e.word(0x6EA08400|uint32(z)<<16|uint32(ee)<<5|uint32(u), fmt.Sprintf("sub v%d.4s, v%d.4s, v%d.4s", u, ee, z))
+	// alt(t2) = (s2 + s2*j) * s1 ; big(k) = s1*s1 ; cbig(n) = an > 192
+	e.mov(t2, u)
+	e.fmlaV(t2, u, m)
+	e.fmulV(t2, t2, b)
+	e.fmulV(k, b, b)
+	e.word(0x6EA0E400|uint32(26)<<16|uint32(an)<<5|uint32(n), fmt.Sprintf("fcmgt v%d.4s, v%d.4s, v26.4s", n, an))
+	// out = cbig ? big : (c ? alt : res)
+	e.word(0x6E601C00|uint32(t1)<<16|uint32(t2)<<5|uint32(c), fmt.Sprintf("bsl v%d.16b, v%d.16b, v%d.16b", c, t2, t1))
+	e.word(0x6E601C00|uint32(c)<<16|uint32(k)<<5|uint32(n), fmt.Sprintf("bsl v%d.16b, v%d.16b, v%d.16b", n, k, c))
+	e.mov(out, n)
+}
+
+// a64VecSoftMaxKernel emits ggml_vec_soft_max_f32 under sym:
+// y[i] = expf(x[i] - max), returns the f64 sum of y. Four lanes per
+// step, then one lane at a time for the tail; each step's lane sum is
+// added to the f64 accumulator (as the native ggml loops do).
+func a64VecSoftMaxKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
+	var sb strings.Builder
+	e := &a64VecExp{}
+	e.w = func(format string, args ...any) { fmt.Fprintf(&sb, format+"\n", args...) }
+	e.word = func(enc uint32, dis string) { e.w("\tWORD $0x%08x // %s", enc, dis) }
+	cSym := pool.addBlob(vecExpConsts())
+	args, argBytes, _, _ := vecExpArgs(wide)
+	movPtr := "MOVWU"
+	if wide {
+		movPtr = "MOVD"
+	}
+	w := e.w
+	w("// %s: y = expf(x - max), returns sum(y) (f64).", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tFMOVD\tZR, F15")
+	w("\tMOVW\tl0+%d(FP), R1", args["l0"])
+	w("\tCMPW\t$1, R1")
+	w("\tBLT\tsmdone")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	w("\t%s\tl1+%d(FP), R2", movPtr, args["l1"])
+	w("\t%s\tl2+%d(FP), R3", movPtr, args["l2"])
+	w("\tLSL\t$2, R1, R26")
+	w("\tADD\tR2, R26, R27")
+	w("\tCMP\tR27, R21")
+	w("\tBLO\tsmoob")
+	w("\tADD\tR3, R26, R27")
+	w("\tCMP\tR27, R21")
+	w("\tBLO\tsmoob")
+	w("\tADD\tR20, R2, R2")
+	w("\tADD\tR20, R3, R3")
+	e.loadConsts(cSym, 4)
+	w("\tFMOVS\tl3+%d(FP), F14", args["l3"])
+	e.dupLane(14, 14, 0)
+	w("smloop4:")
+	w("\tCMPW\t$4, R1")
+	w("\tBLT\tsmtail")
+	e.ldurQ(0, 3, 0)
+	e.fsubV(0, 0, 14)
+	e.exp(0, 0)
+	e.sturQ(0, 2, 0)
+	// lane sum -> f64 accumulator
+	e.word(0x6E20D400|uint32(0)<<16|uint32(0)<<5|uint32(1), "faddp v1.4s, v0.4s, v0.4s")
+	e.word(0x7E30D800|uint32(1)<<5|uint32(1), "faddp s1, v1.2s")
+	w("\tFCVTSD\tF1, F1")
+	w("\tFADDD\tF1, F15, F15")
+	w("\tADD\t$16, R2, R2")
+	w("\tADD\t$16, R3, R3")
+	w("\tSUBW\t$4, R1, R1")
+	w("\tB\tsmloop4")
+	w("smtail:")
+	w("\tCBZW\tR1, smdone")
+	w("\tFMOVS\t(R3), F0")
+	e.fsubV(0, 0, 14)
+	e.exp(0, 0)
+	w("\tFMOVS\tF0, (R2)")
+	w("\tFCVTSD\tF0, F1")
+	w("\tFADDD\tF1, F15, F15")
+	w("\tADD\t$4, R2, R2")
+	w("\tADD\t$4, R3, R3")
+	w("\tSUBW\t$1, R1, R1")
+	w("\tB\tsmtail")
+	w("smdone:")
+	w("\tFMOVD\tF15, r0+%d(FP)", args["r0"])
+	w("\tRET")
+	w("smoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}
+
+// a64VecSwigluKernel emits ggml_vec_swiglu_f32 under sym:
+// y[i] = x[i] / (1 + expf(-x[i])) * g[i].
+func a64VecSwigluKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
+	var sb strings.Builder
+	e := &a64VecExp{}
+	e.w = func(format string, args ...any) { fmt.Fprintf(&sb, format+"\n", args...) }
+	e.word = func(enc uint32, dis string) { e.w("\tWORD $0x%08x // %s", enc, dis) }
+	cSym := pool.addBlob(vecExpConsts())
+	_, _, args, argBytes := vecExpArgs(wide)
+	movPtr := "MOVWU"
+	if wide {
+		movPtr = "MOVD"
+	}
+	w := e.w
+	fneg := func(d, n int) {
+		e.word(0x6EA0F800|uint32(n)<<5|uint32(d), fmt.Sprintf("fneg v%d.4s, v%d.4s", d, n))
+	}
+	w("// %s: y = x / (1 + expf(-x)) * g.", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVW\tl0+%d(FP), R1", args["l0"])
+	w("\tCMPW\t$1, R1")
+	w("\tBLT\tswdone")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	w("\t%s\tl1+%d(FP), R2", movPtr, args["l1"])
+	w("\t%s\tl2+%d(FP), R3", movPtr, args["l2"])
+	w("\t%s\tl3+%d(FP), R4", movPtr, args["l3"])
+	w("\tLSL\t$2, R1, R26")
+	for _, r := range []int{2, 3, 4} {
+		w("\tADD\tR%d, R26, R27", r)
+		w("\tCMP\tR27, R21")
+		w("\tBLO\tswoob")
+	}
+	w("\tADD\tR20, R2, R2")
+	w("\tADD\tR20, R3, R3")
+	w("\tADD\tR20, R4, R4")
+	e.loadConsts(cSym, 5)
+	// v13 keeps x across the exp, v12 the gate.
+	w("swloop4:")
+	w("\tCMPW\t$4, R1")
+	w("\tBLT\tswtail")
+	e.ldurQ(13, 3, 0)
+	e.ldurQ(12, 4, 0)
+	fneg(0, 13)
+	e.exp(0, 0)
+	e.faddV(0, 0, 25)
+	e.fdivV(0, 13, 0)
+	e.fmulV(0, 0, 12)
+	e.sturQ(0, 2, 0)
+	w("\tADD\t$16, R2, R2")
+	w("\tADD\t$16, R3, R3")
+	w("\tADD\t$16, R4, R4")
+	w("\tSUBW\t$4, R1, R1")
+	w("\tB\tswloop4")
+	w("swtail:")
+	w("\tCBZW\tR1, swdone")
+	w("\tFMOVS\t(R3), F13")
+	w("\tFMOVS\t(R4), F12")
+	fneg(0, 13)
+	e.exp(0, 0)
+	e.faddV(0, 0, 25)
+	e.fdivV(0, 13, 0)
+	e.fmulV(0, 0, 12)
+	w("\tFMOVS\tF0, (R2)")
+	w("\tADD\t$4, R2, R2")
+	w("\tADD\t$4, R3, R3")
+	w("\tADD\t$4, R4, R4")
+	w("\tSUBW\t$1, R1, R1")
+	w("\tB\tswtail")
+	w("swdone:")
+	w("\tRET")
+	w("swoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}

--- a/internal/gcasm/vecexp_test.go
+++ b/internal/gcasm/vecexp_test.go
@@ -1,0 +1,255 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goccy/wasm2go/internal/wasm"
+)
+
+func TestKernelRetargetExports(t *testing.T) {
+	mod := &wasm.Module{Exports: []wasm.Export{
+		{Name: "dbg_simd_gemm_f32", Kind: wasm.ExportFunc, Index: 12},
+		{Name: "dbg_vec_soft_max_f32", Kind: wasm.ExportFunc, Index: 13},
+		{Name: "dbg_vec_swiglu_f32", Kind: wasm.ExportFunc, Index: 14},
+		{Name: "dbg_gemv_q8_0_4x4", Kind: wasm.ExportFunc, Index: 15},
+	}}
+	got := kernelRetargetExports(mod, Config{FastMath: true})
+	if len(got) != 3 || got["Fn13"].export != "dbg_vec_soft_max_f32" || got["Fn14"].export != "dbg_vec_swiglu_f32" {
+		t.Fatalf("retargets = %v", got)
+	}
+	if got["Fn13"].argBytes(true) != 48 || got["Fn13"].argBytes(false) != 32 || got["Fn14"].argBytes(true) != 40 || got["Fn14"].argBytes(false) != 24 {
+		t.Fatal("exp kernel argument frames")
+	}
+	if len(kernelRetargetExports(mod, Config{})) != 0 {
+		t.Fatal("non-FastMath must not retarget")
+	}
+}
+
+func TestVecExpKernelShape(t *testing.T) {
+	offs := &ModuleOffsets{M: 8, MemSize: 0}
+	pool := &ConstPool{}
+	a := a64VecSoftMaxKernel("Fn13dotprod", "trapstub", offs, pool, true)
+	for _, want := range []string{"fmla v1.4s, v0.4s, v28.s[1]", "shl v4.4s, v1.4s, #23", "bsl v7.16b", "faddp s1, v1.2s", "FCVTSD", "r0+40(FP)", "$16-48"} {
+		if !strings.Contains(a, want) {
+			t.Errorf("a64 soft_max missing %q", want)
+		}
+	}
+	if s := a64VecSwigluKernel("Fn14dotprod", "trapstub", offs, pool, true); !strings.Contains(s, "fdiv v0.4s, v13.4s, v0.4s") || !strings.Contains(s, "$16-40") {
+		t.Error("a64 swiglu shape")
+	}
+	x := x64VecSoftMaxKernel("Fn13avx2", "trapstub", offs, pool, true)
+	for _, want := range []string{"VFMADD231PS", "VPSLLD\t$23", "VBLENDVPS", "VCVTSS2SD", "r0+40(FP)", "VZEROUPPER", "$16-48"} {
+		if !strings.Contains(x, want) {
+			t.Errorf("x64 soft_max missing %q", want)
+		}
+	}
+	if s := x64VecSwigluKernel("Fn14avx2", "trapstub", offs, pool, true); !strings.Contains(s, "VDIVPS") || !strings.Contains(s, "$16-40") {
+		t.Error("x64 swiglu shape")
+	}
+	if !strings.Contains(pool.Emit(), "GLOBL") {
+		t.Error("constant pool empty")
+	}
+}
+
+// vecExpRunSrc drives both kernels against float64 references: values
+// must agree to a few ulps (the polynomial's own error plus fused
+// rounding), the sum within 1e-6 relative, and out-of-range inputs
+// must flush exactly as the reference does.
+const vecExpRunSrc = `package exprun
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+type mockModule struct {
+	memSizePtr *uint64
+	mem        unsafe.Pointer
+}
+
+func putF32(mem []byte, off int, f float32) {
+	b := math.Float32bits(f)
+	mem[off], mem[off+1], mem[off+2], mem[off+3] = byte(b), byte(b>>8), byte(b>>16), byte(b>>24)
+}
+
+func getF32(mem []byte, off int) float32 {
+	return math.Float32frombits(uint32(mem[off]) | uint32(mem[off+1])<<8 | uint32(mem[off+2])<<16 | uint32(mem[off+3])<<24)
+}
+
+func inputs(n int, seed uint32) []float32 {
+	rng := seed
+	out := make([]float32, n)
+	for i := range out {
+		rng = rng*1664525 + 1013904223
+		switch i % 11 {
+		case 0:
+			out[i] = float32(math.Inf(-1))
+		case 1:
+			out[i] = -110 - float32(rng>>28)
+		case 2:
+			out[i] = -90 + float32(rng>>28)
+		case 3:
+			out[i] = 0
+		default:
+			out[i] = float32(int32(rng>>8)%20001-10000) / 500 // [-20, 20]
+		}
+	}
+	return out
+}
+
+func close32(got float32, want float64, tolRel float64) bool {
+	if math.IsInf(want, 1) {
+		return math.IsInf(float64(got), 1)
+	}
+	if want == 0 {
+		return got == 0
+	}
+	if math.Abs(want) < 1.2e-38 {
+		// Subnormal results: the scaled special path of the polynomial
+		// (as in ggml's own kernels) carries a few subnormal ulps of
+		// error; the ulp there is 2^-149.
+		return math.Abs(float64(got)-want) <= 8*1.401298464324817e-45
+	}
+	return math.Abs(float64(got)-want) <= tolRel*math.Abs(want)
+}
+
+func runSoftMax(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2 int64, l3 float32) float64, n int) {
+	t.Helper()
+	x := inputs(n, uint32(n)*7919+1)
+	mem := make([]byte, 4096+8*n*4)
+	xOff, yOff := 256, 256+n*4+64
+	for i, v := range x {
+		putF32(mem, xOff+4*i, v)
+	}
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	const max = float32(3.25)
+	sum := kernel(m, int32(n), int64(yOff), int64(xOff), max)
+	var want float64
+	for i, v := range x {
+		w := math.Exp(float64(v) - float64(max))
+		if float64(v)-float64(max) < -103.97 {
+			w = 0
+		}
+		got := getF32(mem, yOff+4*i)
+		if !close32(got, w, 4e-6) {
+			t.Fatalf("n=%d y[%d] = %v, want %v (x=%v)", n, i, got, w, v)
+		}
+		want += float64(got)
+	}
+	if math.Abs(sum-want) > 1e-6*math.Max(1, math.Abs(want)) {
+		t.Fatalf("n=%d sum = %v, want %v", n, sum, want)
+	}
+	for off := yOff + 4*n; off < len(mem); off++ {
+		if mem[off] != 0 {
+			t.Fatalf("n=%d byte %d past y written", n, off)
+		}
+	}
+}
+
+func runSwiglu(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3 int64), n int) {
+	t.Helper()
+	x := inputs(n, uint32(n)*31+5)
+	g := inputs(n, uint32(n)*17+3)
+	for i := range x {
+		if math.IsInf(float64(x[i]), 0) {
+			x[i] = -50
+		}
+		if math.IsInf(float64(g[i]), 0) {
+			g[i] = 2
+		}
+	}
+	mem := make([]byte, 4096+12*n*4)
+	xOff := 256
+	gOff := xOff + n*4 + 64
+	yOff := gOff + n*4 + 64
+	for i := range x {
+		putF32(mem, xOff+4*i, x[i])
+		putF32(mem, gOff+4*i, g[i])
+	}
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	kernel(m, int32(n), int64(yOff), int64(xOff), int64(gOff))
+	for i := range x {
+		w := float64(x[i]) / (1 + math.Exp(-float64(x[i]))) * float64(g[i])
+		got := getF32(mem, yOff+4*i)
+		if math.Abs(float64(got)-w) > 4e-6*math.Abs(w)+1e-30 {
+			t.Fatalf("n=%d y[%d] = %v, want %v (x=%v g=%v)", n, i, got, w, x[i], g[i])
+		}
+	}
+}
+`
+
+func writeVecExpRunTree(t *testing.T, dir, arch, kernelAsm, extraGo, runTest string) {
+	t.Helper()
+	trapstub := "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n"
+	if arch == "amd64" {
+		trapstub = "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
+	}
+	files := map[string]string{
+		"go.mod": "module exprun\n\ngo 1.25.0\n",
+		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" +
+			kernelAsm + trapstub,
+		"run.go":      vecExpRunSrc + extraGo,
+		"run_test.go": runTest,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+const vecExpDecls = "\nfunc SoftMaxKernel(m *mockModule, l0 int32, l1, l2 int64, l3 float32) float64\nfunc SwigluKernel(m *mockModule, l0 int32, l1, l2, l3 int64)\nfunc trapstub()\n\nvar _ = trapstub\n"
+
+const vecExpRunTest = `package exprun
+
+import "testing"
+
+func TestVecExp(t *testing.T) {
+	for _, n := range []int{64, 1, 3, 4, 7, 9, 15, 16, 4864} {
+		runSoftMax(t, SoftMaxKernel, n)
+		runSwiglu(t, SwigluKernel, n)
+	}
+}
+`
+
+func TestA64VecExpKernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	pool := &ConstPool{}
+	asm := a64VecSoftMaxKernel("SoftMaxKernel", "trapstub", offs, pool, true) + "\n" +
+		a64VecSwigluKernel("SwigluKernel", "trapstub", offs, pool, true) + "\n" + pool.Emit()
+	dir := t.TempDir()
+	writeVecExpRunTree(t, dir, "arm64", asm, vecExpDecls, vecExpRunTest)
+	runArm64Gate(t, dir, ".", "TestVecExp", asm)
+}
+
+func TestX64VecExpKernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	pool := &ConstPool{}
+	asm := x64VecSoftMaxKernel("SoftMaxKernel", "trapstub", offs, pool, true) + "\n" +
+		x64VecSwigluKernel("SwigluKernel", "trapstub", offs, pool, true) + "\n" + pool.Emit()
+	dir := t.TempDir()
+	writeVecExpRunTree(t, dir, "amd64", asm, vecExpDecls, vecExpRunTest)
+	bin := filepath.Join(dir, "exprun.test")
+	build := exec.Command("go", "test", "-c", "-o", bin, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOARCH=amd64")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 assemble/link failed: %v\n%s\n--- asm ---\n%s", err, out, asm)
+	}
+	if runtime.GOARCH != "amd64" || !hostHasAVX2(t) {
+		t.Skipf("assembled+linked OK; skipping execution (GOARCH=%s, avx2=%v)", runtime.GOARCH, hostHasAVX2(t))
+	}
+	cmd := exec.Command(bin, "-test.run", "TestVecExp", "-test.v")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 execution failed: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/vecexp_test.go
+++ b/internal/gcasm/vecexp_test.go
@@ -19,7 +19,7 @@ func TestKernelRetargetExports(t *testing.T) {
 		{Name: "dbg_gemv_q8_0_4x4", Kind: wasm.ExportFunc, Index: 15},
 	}}
 	got := kernelRetargetExports(mod, Config{FastMath: true})
-	if len(got) != 3 || got["Fn13"].export != "dbg_vec_soft_max_f32" || got["Fn14"].export != "dbg_vec_swiglu_f32" {
+	if len(got) != 4 || got["Fn13"].export != "dbg_vec_soft_max_f32" || got["Fn14"].export != "dbg_vec_swiglu_f32" || got["Fn15"].export != "dbg_gemv_q8_0_4x4" {
 		t.Fatalf("retargets = %v", got)
 	}
 	if got["Fn13"].argBytes(true) != 48 || got["Fn13"].argBytes(false) != 32 || got["Fn14"].argBytes(true) != 40 || got["Fn14"].argBytes(false) != 24 {

--- a/internal/gcasm/vecexp_test.go
+++ b/internal/gcasm/vecexp_test.go
@@ -17,9 +17,11 @@ func TestKernelRetargetExports(t *testing.T) {
 		{Name: "dbg_vec_soft_max_f32", Kind: wasm.ExportFunc, Index: 13},
 		{Name: "dbg_vec_swiglu_f32", Kind: wasm.ExportFunc, Index: 14},
 		{Name: "dbg_gemv_q8_0_4x4", Kind: wasm.ExportFunc, Index: 15},
+		{Name: "dbg_vec_dot_f16", Kind: wasm.ExportFunc, Index: 16},
+		{Name: "dbg_vec_mad_f16_f32", Kind: wasm.ExportFunc, Index: 17},
 	}}
 	got := kernelRetargetExports(mod, Config{FastMath: true})
-	if len(got) != 4 || got["Fn13"].export != "dbg_vec_soft_max_f32" || got["Fn14"].export != "dbg_vec_swiglu_f32" || got["Fn15"].export != "dbg_gemv_q8_0_4x4" {
+	if len(got) != 6 || got["Fn16"].argBytes(true) != 68 || got["Fn16"].argBytes(false) != 40 || got["Fn17"].argBytes(true) != 36 || got["Fn17"].argBytes(false) != 24 || got["Fn13"].export != "dbg_vec_soft_max_f32" || got["Fn14"].export != "dbg_vec_swiglu_f32" || got["Fn15"].export != "dbg_gemv_q8_0_4x4" {
 		t.Fatalf("retargets = %v", got)
 	}
 	if got["Fn13"].argBytes(true) != 48 || got["Fn13"].argBytes(false) != 32 || got["Fn14"].argBytes(true) != 40 || got["Fn14"].argBytes(false) != 24 {

--- a/internal/gcasm/vecexp_x64.go
+++ b/internal/gcasm/vecexp_x64.go
@@ -1,0 +1,274 @@
+package gcasm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// x64VecExp holds the AVX2 emitters shared by the amd64 exp kernels.
+// Constants come from 32-byte replicated pool blobs used as memory
+// operands, so no register holds them; the kernels run in ymm for the
+// bulk and reuse the same emitter at xmm width for the tails.
+type x64VecExp struct {
+	w    func(format string, args ...any)
+	c    map[string]string // constant name -> pool symbol
+	pool *ConstPool
+}
+
+func newX64VecExp(w func(string, ...any), pool *ConstPool) *x64VecExp {
+	e := &x64VecExp{w: w, c: map[string]string{}, pool: pool}
+	rep := func(name string, bits uint32) {
+		blob := make([]byte, 32)
+		for i := 0; i < 8; i++ {
+			binary.LittleEndian.PutUint32(blob[4*i:], bits)
+		}
+		e.c[name] = pool.addBlob(blob)
+	}
+	f := func(name string, v float32) { rep(name, math.Float32bits(v)) }
+	f("r", 0x1.8p23)
+	f("log2e", 0x1.715476p+0)
+	f("c1", 0x1.62e4p-1)
+	f("c2", 0x1.7f7d1cp-20)
+	f("p0", 0x1.0e4020p-7)
+	f("p1", 0x1.573e2ep-5)
+	f("p2", 0x1.555e66p-3)
+	f("p3", 0x1.fffdb6p-2)
+	f("p4", 0x1.ffffecp-1)
+	f("c126", 126)
+	f("c192", 192)
+	f("one", 1)
+	rep("m82", 0x82000000)
+	rep("m7f", 0x7f000000)
+	rep("abs", 0x7fffffff)
+	rep("zero", 0)
+	return e
+}
+
+func (e *x64VecExp) sym(name string) string { return "·" + e.c[name] + "(SB)" }
+
+// exp computes W(out) = expf(W(x)) lane-wise at width W ("Y" or "X"),
+// clobbering registers 1..11 except x/out. Same arithmetic as the
+// arm64 twin (ggml_v_expf with fused multiply-adds; the special-range
+// select is computed branch-free).
+func (e *x64VecExp) exp(W string, out, x int) {
+	r := func(i int) string { return fmt.Sprintf("%s%d", W, i) }
+	const (
+		z  = 1
+		n  = 2
+		b  = 3
+		ee = 4
+		k  = 5
+		an = 6
+		c  = 7
+		u  = 8
+		t1 = 9
+		t2 = 10
+		m  = 11
+	)
+	w := e.w
+	// z = r + x*log2e ; n = z - r
+	w("\tVMOVUPS\t%s, %s", e.sym("r"), r(z))
+	w("\tVFMADD231PS\t%s, %s, %s", e.sym("log2e"), r(x), r(z))
+	w("\tVSUBPS\t%s, %s, %s", e.sym("r"), r(z), r(n))
+	// b = x - n*c1 - n*c2
+	w("\tVMOVAPS\t%s, %s", r(x), r(b))
+	w("\tVFNMADD231PS\t%s, %s, %s", e.sym("c1"), r(n), r(b))
+	w("\tVFNMADD231PS\t%s, %s, %s", e.sym("c2"), r(n), r(b))
+	// e = bits(z) << 23 ; k = e + 1.0bits
+	w("\tVPSLLD\t$23, %s, %s", r(z), r(ee))
+	w("\tVPADDD\t%s, %s, %s", e.sym("one"), r(ee), r(k))
+	// an = |n| ; c = an > 126
+	w("\tVANDPS\t%s, %s, %s", e.sym("abs"), r(n), r(an))
+	w("\tVCMPPS\t$0x1e, %s, %s, %s", e.sym("c126"), r(an), r(c))
+	// u = b*b ; t1 = p1 + b*p0 ; t2 = p3 + b*p2 ; j(m) = p4*b + (t2 + t1*u)*u
+	w("\tVMULPS\t%s, %s, %s", r(b), r(b), r(u))
+	w("\tVMOVUPS\t%s, %s", e.sym("p1"), r(t1))
+	w("\tVFMADD231PS\t%s, %s, %s", e.sym("p0"), r(b), r(t1))
+	w("\tVMOVUPS\t%s, %s", e.sym("p3"), r(t2))
+	w("\tVFMADD231PS\t%s, %s, %s", e.sym("p2"), r(b), r(t2))
+	w("\tVFMADD231PS\t%s, %s, %s", r(u), r(t1), r(t2))
+	w("\tVMULPS\t%s, %s, %s", e.sym("p4"), r(b), r(m))
+	w("\tVFMADD231PS\t%s, %s, %s", r(u), r(t2), r(m))
+	// res(t1) = k + j*k
+	w("\tVMOVAPS\t%s, %s", r(k), r(t1))
+	w("\tVFMADD231PS\t%s, %s, %s", r(k), r(m), r(t1))
+	// d(z) = (n <= 0) & 0x82000000 ; s1(b) = d + 0x7f000000 ; s2(u) = e - d
+	w("\tVCMPPS\t$0x12, %s, %s, %s", e.sym("zero"), r(n), r(z))
+	w("\tVANDPS\t%s, %s, %s", e.sym("m82"), r(z), r(z))
+	w("\tVPADDD\t%s, %s, %s", e.sym("m7f"), r(z), r(b))
+	w("\tVPSUBD\t%s, %s, %s", r(z), r(ee), r(u))
+	// alt(t2) = (s2 + s2*j) * s1 ; big(k) = s1*s1 ; cbig(n) = an > 192
+	w("\tVMOVAPS\t%s, %s", r(u), r(t2))
+	w("\tVFMADD231PS\t%s, %s, %s", r(m), r(u), r(t2))
+	w("\tVMULPS\t%s, %s, %s", r(b), r(t2), r(t2))
+	w("\tVMULPS\t%s, %s, %s", r(b), r(b), r(k))
+	w("\tVCMPPS\t$0x1e, %s, %s, %s", e.sym("c192"), r(an), r(n))
+	// out = cbig ? big : (c ? alt : res)
+	w("\tVBLENDVPS\t%s, %s, %s, %s", r(c), r(t2), r(t1), r(c))
+	w("\tVBLENDVPS\t%s, %s, %s, %s", r(n), r(k), r(c), r(out))
+}
+
+// x64VecSoftMaxKernel emits ggml_vec_soft_max_f32 under sym (AVX2):
+// y[i] = expf(x[i] - max), returns the f64 sum of y. Eight lanes per
+// step, four for the first tail, one for the last; each step's lane
+// sum joins the f64 accumulator in X15.
+func x64VecSoftMaxKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
+	var sb strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&sb, format+"\n", args...) }
+	e := newX64VecExp(w, pool)
+	args, argBytes, _, _ := vecExpArgs(wide)
+	movPtr := "MOVL"
+	if wide {
+		movPtr = "MOVQ"
+	}
+	w("// %s: y = expf(x - max), returns sum(y) (f64).", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tVXORPS\tX15, X15, X15")
+	w("\tMOVLQSX\tl0+%d(FP), CX", args["l0"])
+	w("\tTESTQ\tCX, CX")
+	w("\tJLE\tsmdone")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R11", offs.MemSize)
+	w("\tMOVQ\t(R11), R11")
+	w("\tMOVQ\t%d(AX), R10", offs.M)
+	w("\t%s\tl1+%d(FP), DI", movPtr, args["l1"])
+	w("\t%s\tl2+%d(FP), SI", movPtr, args["l2"])
+	w("\tLEAQ\t(DI)(CX*4), R8")
+	w("\tCMPQ\tR11, R8")
+	w("\tJCS\tsmoob")
+	w("\tLEAQ\t(SI)(CX*4), R8")
+	w("\tCMPQ\tR11, R8")
+	w("\tJCS\tsmoob")
+	w("\tADDQ\tR10, DI")
+	w("\tADDQ\tR10, SI")
+	w("\tVBROADCASTSS\tl3+%d(FP), Y14", args["l3"])
+	lanesum := func(W string) {
+		if W == "Y" {
+			w("\tVEXTRACTF128\t$1, Y0, X1")
+			w("\tVADDPS\tX1, X0, X0")
+		}
+		w("\tVHADDPS\tX0, X0, X0")
+		w("\tVHADDPS\tX0, X0, X0")
+		w("\tVCVTSS2SD\tX0, X0, X0")
+		w("\tVADDSD\tX0, X15, X15")
+	}
+	w("smloop8:")
+	w("\tCMPQ\tCX, $8")
+	w("\tJLT\tsmloop4")
+	w("\tVMOVUPS\t(SI), Y0")
+	w("\tVSUBPS\tY14, Y0, Y0")
+	e.exp("Y", 0, 0)
+	w("\tVMOVUPS\tY0, (DI)")
+	lanesum("Y")
+	w("\tADDQ\t$32, DI")
+	w("\tADDQ\t$32, SI")
+	w("\tSUBQ\t$8, CX")
+	w("\tJMP\tsmloop8")
+	w("smloop4:")
+	w("\tCMPQ\tCX, $4")
+	w("\tJLT\tsmtail")
+	w("\tVMOVUPS\t(SI), X0")
+	w("\tVSUBPS\tX14, X0, X0")
+	e.exp("X", 0, 0)
+	w("\tVMOVUPS\tX0, (DI)")
+	lanesum("X")
+	w("\tADDQ\t$16, DI")
+	w("\tADDQ\t$16, SI")
+	w("\tSUBQ\t$4, CX")
+	w("\tJMP\tsmloop4")
+	w("smtail:")
+	w("\tTESTQ\tCX, CX")
+	w("\tJZ\tsmdone")
+	w("\tVMOVSS\t(SI), X0")
+	w("\tVSUBPS\tX14, X0, X0")
+	e.exp("X", 0, 0)
+	w("\tVMOVSS\tX0, (DI)")
+	w("\tVCVTSS2SD\tX0, X0, X0")
+	w("\tVADDSD\tX0, X15, X15")
+	w("\tADDQ\t$4, DI")
+	w("\tADDQ\t$4, SI")
+	w("\tSUBQ\t$1, CX")
+	w("\tJMP\tsmtail")
+	w("smdone:")
+	w("\tVMOVSD\tX15, r0+%d(FP)", args["r0"])
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("smoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}
+
+// x64VecSwigluKernel emits ggml_vec_swiglu_f32 under sym (AVX2):
+// y[i] = x[i] / (1 + expf(-x[i])) * g[i].
+func x64VecSwigluKernel(sym, trapSym string, offs *ModuleOffsets, pool *ConstPool, wide bool) string {
+	var sb strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&sb, format+"\n", args...) }
+	e := newX64VecExp(w, pool)
+	_, _, args, argBytes := vecExpArgs(wide)
+	movPtr := "MOVL"
+	if wide {
+		movPtr = "MOVQ"
+	}
+	w("// %s: y = x / (1 + expf(-x)) * g.", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVLQSX\tl0+%d(FP), CX", args["l0"])
+	w("\tTESTQ\tCX, CX")
+	w("\tJLE\tswdone")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R11", offs.MemSize)
+	w("\tMOVQ\t(R11), R11")
+	w("\tMOVQ\t%d(AX), R10", offs.M)
+	w("\t%s\tl1+%d(FP), DI", movPtr, args["l1"])
+	w("\t%s\tl2+%d(FP), SI", movPtr, args["l2"])
+	w("\t%s\tl3+%d(FP), DX", movPtr, args["l3"])
+	for _, reg := range []string{"DI", "SI", "DX"} {
+		w("\tLEAQ\t(%s)(CX*4), R8", reg)
+		w("\tCMPQ\tR11, R8")
+		w("\tJCS\tswoob")
+	}
+	w("\tADDQ\tR10, DI")
+	w("\tADDQ\tR10, SI")
+	w("\tADDQ\tR10, DX")
+	// 13 keeps x across the exp, 12 the gate.
+	body := func(W string, load, store string, step int, next string, lbl string) {
+		w("%s:", lbl)
+		if step > 1 {
+			w("\tCMPQ\tCX, $%d", step)
+			w("\tJLT\t%s", next)
+		} else {
+			w("\tTESTQ\tCX, CX")
+			w("\tJZ\t%s", next)
+		}
+		w("\t%s\t(SI), %s13", load, W)
+		w("\t%s\t(DX), %s12", load, W)
+		w("\tVXORPS\t%s0, %s0, %s0", W, W, W)
+		w("\tVSUBPS\t%s13, %s0, %s0", W, W, W)
+		e.exp(W, 0, 0)
+		w("\tVADDPS\t%s, %s0, %s0", e.sym("one"), W, W)
+		w("\tVDIVPS\t%s0, %s13, %s0", W, W, W)
+		w("\tVMULPS\t%s12, %s0, %s0", W, W, W)
+		w("\t%s\t%s0, (DI)", store, W)
+		w("\tADDQ\t$%d, DI", 4*step)
+		w("\tADDQ\t$%d, SI", 4*step)
+		w("\tADDQ\t$%d, DX", 4*step)
+		w("\tSUBQ\t$%d, CX", step)
+		w("\tJMP\t%s", lbl)
+	}
+	body("Y", "VMOVUPS", "VMOVUPS", 8, "swloop4", "swloop8")
+	body("X", "VMOVUPS", "VMOVUPS", 4, "swtail", "swloop4")
+	body("X", "VMOVSS", "VMOVSS", 1, "swdone", "swtail")
+	w("swdone:")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("swoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}

--- a/internal/gcasm/vecf16_a64.go
+++ b/internal/gcasm/vecf16_a64.go
@@ -1,0 +1,298 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The f16 attention vectors: llama-wasm exports ggml's f16 dot
+// (dbg_vec_dot_f16) and the f16-by-f32 multiply-add it uses for the V
+// accumulate on wasm (dbg_vec_mad_f16_f32). Both run once per KV
+// position in the single-query flash-attention path, so at long
+// contexts they are the decode step; the wasm versions widen every f16
+// through a table lookup, the kernels here use the hardware conversion
+// (FCVTL / VCVTPH2PS) and fused multiply-add. FastMath only: the sums
+// are f32 with fused rounding where the wasm keeps double partials.
+
+// vecDotF16Args is the frame of
+//
+//	ggml_vec_dot_f16(int n, float *s, size_t bs, ggml_fp16_t *x, size_t bx, ggml_fp16_t *y, size_t by, int nrc)
+//
+// nrc is 1 by contract; bs / bx / by are unused there and here.
+func vecDotF16Args(wide bool) (map[string]int, int) {
+	if wide {
+		return map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32, "l4": 40, "l5": 48, "l6": 56, "l7": 64}, 68
+	}
+	return map[string]int{"l0": 8, "l1": 12, "l2": 16, "l3": 20, "l4": 24, "l5": 28, "l6": 32, "l7": 36}, 40
+}
+
+// vecMadF16F32Args is the frame of
+//
+//	ggml_vec_mad_f16_f32(int n, float *y, const ggml_fp16_t *x, float v)   // y += v * x
+func vecMadF16F32Args(wide bool) (map[string]int, int) {
+	if wide {
+		return map[string]int{"l0": 8, "l1": 16, "l2": 24, "l3": 32}, 36
+	}
+	return map[string]int{"l0": 8, "l1": 12, "l2": 16, "l3": 20}, 24
+}
+
+// a64VecF16 holds the NEON emitters shared by the arm64 f16 kernels.
+type a64VecF16 struct {
+	w    func(format string, args ...any)
+	word func(enc uint32, dis string)
+}
+
+func newA64VecF16(sb *strings.Builder) *a64VecF16 {
+	e := &a64VecF16{}
+	e.w = func(format string, args ...any) { fmt.Fprintf(sb, format+"\n", args...) }
+	e.word = func(enc uint32, dis string) { e.w("\tWORD $0x%08x // %s", enc, dis) }
+	return e
+}
+
+func (e *a64VecF16) ldurQ(rt, rn, imm int) {
+	e.word(0x3CC00000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur q%d, [x%d, #%d]", rt, rn, imm))
+}
+
+func (e *a64VecF16) sturQ(rt, rn, imm int) {
+	e.word(0x3C800000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("stur q%d, [x%d, #%d]", rt, rn, imm))
+}
+
+func (e *a64VecF16) ldurD(rt, rn, imm int) {
+	e.word(0xFC400000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur d%d, [x%d, #%d]", rt, rn, imm))
+}
+
+func (e *a64VecF16) ldurH(rt, rn, imm int) {
+	e.word(0x7C400000|uint32(imm&0x1FF)<<12|uint32(rn)<<5|uint32(rt), fmt.Sprintf("ldur h%d, [x%d, #%d]", rt, rn, imm))
+}
+
+// fcvtl widens the low four halves of n; fcvtl2 the high four.
+func (e *a64VecF16) fcvtl(d, n int) {
+	e.word(0x0E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl v%d.4s, v%d.4h", d, n))
+}
+
+func (e *a64VecF16) fcvtl2(d, n int) {
+	e.word(0x4E217800|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvtl2 v%d.4s, v%d.8h", d, n))
+}
+
+func (e *a64VecF16) fcvtSH(d, n int) {
+	e.word(0x1EE24000|uint32(n)<<5|uint32(d), fmt.Sprintf("fcvt s%d, h%d", d, n))
+}
+
+func (e *a64VecF16) fmlaV(d, n, m int) {
+	e.word(0x4E20CC00|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecF16) fmlaLane(d, n, m, idx int) {
+	e.word(0x4F801000|uint32(idx&1)<<21|uint32(idx>>1)<<11|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fmla v%d.4s, v%d.4s, v%d.s[%d]", d, n, m, idx))
+}
+
+// fmaddS: sd = sa + sn * sm.
+func (e *a64VecF16) fmaddS(d, n, m, a int) {
+	e.word(0x1F000000|uint32(m)<<16|uint32(a)<<10|uint32(n)<<5|uint32(d), fmt.Sprintf("fmadd s%d, s%d, s%d, s%d", d, n, m, a))
+}
+
+func (e *a64VecF16) faddV(d, n, m int) {
+	e.word(0x4E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("fadd v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecF16) faddpV(d, n, m int) {
+	e.word(0x6E20D400|uint32(m)<<16|uint32(n)<<5|uint32(d), fmt.Sprintf("faddp v%d.4s, v%d.4s, v%d.4s", d, n, m))
+}
+
+func (e *a64VecF16) faddpS(d, n int) {
+	e.word(0x7E30D800|uint32(n)<<5|uint32(d), fmt.Sprintf("faddp s%d, v%d.2s", d, n))
+}
+
+func (e *a64VecF16) movi0(d int) {
+	e.word(0x4F000400|uint32(d), fmt.Sprintf("movi v%d.4s, #0", d))
+}
+
+// a64VecDotF16Kernel emits *s = sum(x[i] * y[i]) over n f16 pairs under
+// sym: four f32 accumulators over 16 elements per step (the wasm
+// version's own 4 x 4 arrangement), a 4-wide tail and a scalar tail,
+// then a tree reduce. Bounds: s + 4, x + 2n, y + 2n against memSize.
+func a64VecDotF16Kernel(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+	var sb strings.Builder
+	e := newA64VecF16(&sb)
+	w := e.w
+	args, argBytes := vecDotF16Args(wide)
+	movPtr := "MOVWU"
+	if wide {
+		movPtr = "MOVD"
+	}
+	w("// %s: f16 dot product, f32 accumulate.", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	w("\tMOVW\tl0+%d(FP), R1", args["l0"])
+	w("\t%s\tl1+%d(FP), R2", movPtr, args["l1"])
+	w("\t%s\tl3+%d(FP), R3", movPtr, args["l3"])
+	w("\t%s\tl5+%d(FP), R4", movPtr, args["l5"])
+	w("\tADD\t$4, R2, R27")
+	w("\tCMP\tR27, R21")
+	w("\tBLO\tvdoob")
+	w("\tADD\tR20, R2, R2")
+	for i := 0; i < 4; i++ {
+		e.movi0(i)
+	}
+	w("\tFMOVS\t$0.0, F24")
+	w("\tCMPW\t$1, R1")
+	w("\tBLT\tvdreduce")
+	w("\tLSL\t$1, R1, R26")
+	for _, r := range []int{3, 4} {
+		w("\tADD\tR%d, R26, R27", r)
+		w("\tCMP\tR27, R21")
+		w("\tBLO\tvdoob")
+	}
+	w("\tADD\tR20, R3, R3")
+	w("\tADD\tR20, R4, R4")
+	w("vdloop16:")
+	w("\tCMPW\t$16, R1")
+	w("\tBLT\tvdtail4")
+	e.ldurQ(4, 3, 0)
+	e.ldurQ(5, 3, 16)
+	e.ldurQ(6, 4, 0)
+	e.ldurQ(7, 4, 16)
+	e.fcvtl(16, 4)
+	e.fcvtl2(17, 4)
+	e.fcvtl(18, 5)
+	e.fcvtl2(19, 5)
+	e.fcvtl(20, 6)
+	e.fcvtl2(21, 6)
+	e.fcvtl(22, 7)
+	e.fcvtl2(23, 7)
+	for i := 0; i < 4; i++ {
+		e.fmlaV(i, 16+i, 20+i)
+	}
+	w("\tADD\t$32, R3, R3")
+	w("\tADD\t$32, R4, R4")
+	w("\tSUBW\t$16, R1, R1")
+	w("\tB\tvdloop16")
+	w("vdtail4:")
+	w("\tCMPW\t$4, R1")
+	w("\tBLT\tvdtail1")
+	e.ldurD(4, 3, 0)
+	e.ldurD(6, 4, 0)
+	e.fcvtl(16, 4)
+	e.fcvtl(20, 6)
+	e.fmlaV(0, 16, 20)
+	w("\tADD\t$8, R3, R3")
+	w("\tADD\t$8, R4, R4")
+	w("\tSUBW\t$4, R1, R1")
+	w("\tB\tvdtail4")
+	w("vdtail1:")
+	w("\tCBZW\tR1, vdreduce")
+	e.ldurH(4, 3, 0)
+	e.ldurH(6, 4, 0)
+	e.fcvtSH(4, 4)
+	e.fcvtSH(6, 6)
+	e.fmaddS(24, 4, 6, 24)
+	w("\tADD\t$2, R3, R3")
+	w("\tADD\t$2, R4, R4")
+	w("\tSUBW\t$1, R1, R1")
+	w("\tB\tvdtail1")
+	w("vdreduce:")
+	e.faddV(0, 0, 1)
+	e.faddV(2, 2, 3)
+	e.faddV(0, 0, 2)
+	e.faddpV(0, 0, 0)
+	e.faddpS(0, 0)
+	w("\tFADDS\tF24, F0, F0")
+	w("\tFMOVS\tF0, (R2)")
+	w("\tRET")
+	w("vdoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}
+
+// a64VecMadF16F32Kernel emits y[i] += v * x[i] (y f32, x f16) under
+// sym: 16 elements per step, a 4-wide tail and a scalar tail. Bounds:
+// y + 4n, x + 2n against memSize.
+func a64VecMadF16F32Kernel(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+	var sb strings.Builder
+	e := newA64VecF16(&sb)
+	w := e.w
+	args, argBytes := vecMadF16F32Args(wide)
+	movPtr := "MOVWU"
+	if wide {
+		movPtr = "MOVD"
+	}
+	w("// %s: y += v * x (x f16, y f32).", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVW\tl0+%d(FP), R1", args["l0"])
+	w("\tCMPW\t$1, R1")
+	w("\tBLT\tvmdone")
+	w("\tMOVD\tm+0(FP), R0")
+	w("\tMOVD\t%d(R0), R21", offs.MemSize)
+	w("\tMOVD\t(R21), R21")
+	w("\tMOVD\t%d(R0), R20", offs.M)
+	w("\t%s\tl1+%d(FP), R2", movPtr, args["l1"])
+	w("\t%s\tl2+%d(FP), R3", movPtr, args["l2"])
+	w("\tFMOVS\tl3+%d(FP), F8", args["l3"])
+	w("\tLSL\t$2, R1, R26")
+	w("\tADD\tR2, R26, R27")
+	w("\tCMP\tR27, R21")
+	w("\tBLO\tvmoob")
+	w("\tLSL\t$1, R1, R26")
+	w("\tADD\tR3, R26, R27")
+	w("\tCMP\tR27, R21")
+	w("\tBLO\tvmoob")
+	w("\tADD\tR20, R2, R2")
+	w("\tADD\tR20, R3, R3")
+	w("vmloop16:")
+	w("\tCMPW\t$16, R1")
+	w("\tBLT\tvmtail4")
+	e.ldurQ(4, 3, 0)
+	e.ldurQ(5, 3, 16)
+	e.fcvtl(16, 4)
+	e.fcvtl2(17, 4)
+	e.fcvtl(18, 5)
+	e.fcvtl2(19, 5)
+	for i := 0; i < 4; i++ {
+		e.ldurQ(20+i, 2, 16*i)
+	}
+	for i := 0; i < 4; i++ {
+		e.fmlaLane(20+i, 16+i, 8, 0)
+	}
+	for i := 0; i < 4; i++ {
+		e.sturQ(20+i, 2, 16*i)
+	}
+	w("\tADD\t$32, R3, R3")
+	w("\tADD\t$64, R2, R2")
+	w("\tSUBW\t$16, R1, R1")
+	w("\tB\tvmloop16")
+	w("vmtail4:")
+	w("\tCMPW\t$4, R1")
+	w("\tBLT\tvmtail1")
+	e.ldurD(4, 3, 0)
+	e.fcvtl(16, 4)
+	e.ldurQ(20, 2, 0)
+	e.fmlaLane(20, 16, 8, 0)
+	e.sturQ(20, 2, 0)
+	w("\tADD\t$8, R3, R3")
+	w("\tADD\t$16, R2, R2")
+	w("\tSUBW\t$4, R1, R1")
+	w("\tB\tvmtail4")
+	w("vmtail1:")
+	w("\tCBZW\tR1, vmdone")
+	e.ldurH(4, 3, 0)
+	e.fcvtSH(4, 4)
+	w("\tFMOVS\t(R2), F5")
+	e.fmaddS(5, 4, 8, 5)
+	w("\tFMOVS\tF5, (R2)")
+	w("\tADD\t$2, R3, R3")
+	w("\tADD\t$4, R2, R2")
+	w("\tSUBW\t$1, R1, R1")
+	w("\tB\tvmtail1")
+	w("vmdone:")
+	w("\tRET")
+	w("vmoob:")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}

--- a/internal/gcasm/vecf16_test.go
+++ b/internal/gcasm/vecf16_test.go
@@ -1,0 +1,218 @@
+package gcasm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestVecF16KernelShape(t *testing.T) {
+	offs := &ModuleOffsets{M: 8, MemSize: 0}
+	a := a64VecDotF16Kernel("Fn16dotprod", "trapstub", offs, nil, true)
+	for _, want := range []string{"fcvtl2 v17.4s, v4.8h", "fmla v3.4s, v19.4s, v23.4s", "fmadd s24, s4, s6, s24", "faddp s0, v0.2s", "l5+48(FP)", "$16-68"} {
+		if !strings.Contains(a, want) {
+			t.Errorf("a64 vec_dot_f16 missing %q", want)
+		}
+	}
+	if s := a64VecMadF16F32Kernel("Fn17dotprod", "trapstub", offs, nil, true); !strings.Contains(s, "fmla v23.4s, v19.4s, v8.s[0]") || !strings.Contains(s, "l3+32(FP), F8") || !strings.Contains(s, "$16-36") {
+		t.Error("a64 vec_mad_f16_f32 shape")
+	}
+	x := x64VecDotF16Kernel("Fn16avx2", "trapstub", offs, nil, true)
+	for _, want := range []string{"VCVTPH2PS\t48(DX), Y11", "VFMADD231PS\tY11, Y7, Y3", "VFMADD231SS\tX8, X4, X13", "VHADDPS", "l5+48(FP)", "$16-68"} {
+		if !strings.Contains(x, want) {
+			t.Errorf("x64 vec_dot_f16 missing %q", want)
+		}
+	}
+	if s := x64VecMadF16F32Kernel("Fn17avx2", "trapstub", offs, nil, true); !strings.Contains(s, "VBROADCASTSS\tl3+32(FP), Y8") || !strings.Contains(s, "$16-36") {
+		t.Error("x64 vec_mad_f16_f32 shape")
+	}
+	if _, n := vecDotF16Args(false); n != 40 {
+		t.Error("narrow vec_dot_f16 frame")
+	}
+}
+
+// vecF16RunSrc drives both kernels against float64 references over
+// f16 inputs; the f32 result must agree to a few ulps of the f32 sum.
+const vecF16RunSrc = `package f16run
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+type mockModule struct {
+	memSizePtr *uint64
+	mem        unsafe.Pointer
+}
+
+func f16bits(f float32) uint16 {
+	b := math.Float32bits(f)
+	sign := uint16(b>>16) & 0x8000
+	exp := int((b>>23)&0xff) - 127 + 15
+	mant := b & 0x7fffff
+	if exp <= 0 {
+		return sign
+	}
+	if exp >= 31 {
+		return sign | 0x7c00
+	}
+	return sign | uint16(exp)<<10 | uint16(mant>>13)
+}
+
+func f16val(h uint16) float64 {
+	sign := 1.0
+	if h&0x8000 != 0 {
+		sign = -1
+	}
+	exp := int(h>>10) & 0x1f
+	mant := float64(h & 0x3ff)
+	if exp == 0 {
+		return sign * mant * math.Pow(2, -24)
+	}
+	return sign * (1 + mant/1024) * math.Pow(2, float64(exp-15))
+}
+
+func put16(mem []byte, off int, h uint16) { mem[off] = byte(h); mem[off+1] = byte(h >> 8) }
+func put32(mem []byte, off int, f float32) {
+	b := math.Float32bits(f)
+	mem[off], mem[off+1], mem[off+2], mem[off+3] = byte(b), byte(b>>8), byte(b>>16), byte(b>>24)
+}
+func get32(mem []byte, off int) float32 {
+	return math.Float32frombits(uint32(mem[off]) | uint32(mem[off+1])<<8 | uint32(mem[off+2])<<16 | uint32(mem[off+3])<<24)
+}
+
+func halves(n int, seed uint32) []uint16 {
+	out := make([]uint16, n)
+	s := seed
+	for i := range out {
+		s = s*1664525 + 1013904223
+		out[i] = f16bits(float32(int32(s>>8)%2000)/97.0 - 3.5)
+	}
+	return out
+}
+
+func close32(got float32, want float64, tolRel float64) bool {
+	d := math.Abs(float64(got) - want)
+	return d <= tolRel*math.Max(1, math.Abs(want))
+}
+
+func runDot(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2, l3, l4, l5, l6 int64, l7 int32), n int) {
+	t.Helper()
+	x := halves(n, uint32(n)*7919+1)
+	y := halves(n, uint32(n)*131+7)
+	mem := make([]byte, 4096+4*n*2)
+	sOff, xOff, yOff := 256, 512, 512+2*n+64
+	for i := range x {
+		put16(mem, xOff+2*i, x[i])
+		put16(mem, yOff+2*i, y[i])
+	}
+	put32(mem, sOff, 12345)
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	kernel(m, int32(n), int64(sOff), 0, int64(xOff), 0, int64(yOff), 0, 1)
+	var want float64
+	for i := range x {
+		want += f16val(x[i]) * f16val(y[i])
+	}
+	if got := get32(mem, sOff); !close32(got, want, 2e-6) {
+		t.Fatalf("n=%d dot = %v, want %v", n, got, want)
+	}
+}
+
+func runMad(t *testing.T, kernel func(m *mockModule, l0 int32, l1, l2 int64, l3 float32), n int) {
+	t.Helper()
+	x := halves(n, uint32(n)*31+5)
+	y0 := halves(n, uint32(n)*17+3)
+	mem := make([]byte, 4096+8*n*4)
+	yOff, xOff := 256, 256+4*n+64
+	for i := range x {
+		put16(mem, xOff+2*i, x[i])
+		put32(mem, yOff+4*i, float32(f16val(y0[i])))
+	}
+	memSize := uint64(len(mem))
+	m := &mockModule{memSizePtr: &memSize, mem: unsafe.Pointer(&mem[0])}
+	const v = float32(-0.8125)
+	kernel(m, int32(n), int64(yOff), int64(xOff), v)
+	for i := range x {
+		want := f16val(y0[i]) + float64(v)*f16val(x[i])
+		if got := get32(mem, yOff+4*i); !close32(got, want, 1e-6) {
+			t.Fatalf("n=%d y[%d] = %v, want %v", n, i, got, want)
+		}
+	}
+	for off := yOff + 4*n; off < xOff; off++ {
+		if mem[off] != 0 {
+			t.Fatalf("n=%d byte %d past y written", n, off)
+		}
+	}
+}
+`
+
+const vecF16Decls = "\nfunc DotKernel(m *mockModule, l0 int32, l1, l2, l3, l4, l5, l6 int64, l7 int32)\nfunc MadKernel(m *mockModule, l0 int32, l1, l2 int64, l3 float32)\nfunc trapstub()\n\nvar _ = trapstub\n"
+
+const vecF16RunTest = `package f16run
+
+import "testing"
+
+func TestVecF16(t *testing.T) {
+	for _, n := range []int{64, 128, 0, 1, 3, 4, 7, 9, 15, 16, 31, 33, 100, 4864} {
+		runDot(t, DotKernel, n)
+		runMad(t, MadKernel, n)
+	}
+}
+`
+
+func writeVecF16RunTree(t *testing.T, dir, arch, kernelAsm string) {
+	t.Helper()
+	trapstub := "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVD $0, R0\n\tMOVD R0, (R0)\n\tRET\n"
+	if arch == "amd64" {
+		trapstub = "\nTEXT ·trapstub(SB), NOSPLIT, $0-0\n\tMOVQ $0, AX\n\tMOVQ AX, (AX)\n\tRET\n"
+	}
+	files := map[string]string{
+		"go.mod": "module f16run\n\ngo 1.25.0\n",
+		"kernel_" + arch + ".s": "//go:build " + arch + "\n\n#include \"textflag.h\"\n#include \"funcdata.h\"\n\n" +
+			kernelAsm + trapstub,
+		"run.go":      vecF16RunSrc + vecF16Decls,
+		"run_test.go": vecF16RunTest,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestA64VecF16KernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	asm := a64VecDotF16Kernel("DotKernel", "trapstub", offs, nil, true) + "\n" +
+		a64VecMadF16F32Kernel("MadKernel", "trapstub", offs, nil, true)
+	dir := t.TempDir()
+	writeVecF16RunTree(t, dir, "arm64", asm)
+	runArm64Gate(t, dir, ".", "TestVecF16", asm)
+}
+
+func TestX64VecF16KernelGate(t *testing.T) {
+	offs := &ModuleOffsets{MemSize: 0, M: 8}
+	asm := x64VecDotF16Kernel("DotKernel", "trapstub", offs, nil, true) + "\n" +
+		x64VecMadF16F32Kernel("MadKernel", "trapstub", offs, nil, true)
+	dir := t.TempDir()
+	writeVecF16RunTree(t, dir, "amd64", asm)
+	bin := filepath.Join(dir, "f16run.test")
+	build := exec.Command("go", "test", "-c", "-o", bin, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOARCH=amd64")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 assemble/link failed: %v\n%s\n--- asm ---\n%s", err, out, asm)
+	}
+	if runtime.GOARCH != "amd64" || !hostHasAVX2(t) {
+		t.Skipf("assembled+linked OK; skipping execution (GOARCH=%s)", runtime.GOARCH)
+	}
+	cmd := exec.Command(bin, "-test.run", "TestVecF16", "-test.v")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("amd64 execution failed: %v\n%s", err, out)
+	}
+}

--- a/internal/gcasm/vecf16_x64.go
+++ b/internal/gcasm/vecf16_x64.go
@@ -1,0 +1,191 @@
+package gcasm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// x64VecDotF16Kernel emits *s = sum(x[i] * y[i]) over n f16 pairs under
+// sym for amd64 (see a64VecDotF16Kernel): VCVTPH2PS widens eight halves
+// at a time into four ymm accumulators (32 elements per step), then
+// 16-, 8- and 4-wide tails and a scalar tail, then a tree reduce.
+// Bounds: s + 4, x + 2n, y + 2n against memSize.
+func x64VecDotF16Kernel(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+	var sb strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&sb, format+"\n", args...) }
+	args, argBytes := vecDotF16Args(wide)
+	movPtr := "MOVL"
+	if wide {
+		movPtr = "MOVQ"
+	}
+	w("// %s: f16 dot product, f32 accumulate.", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R11", offs.MemSize)
+	w("\tMOVQ\t(R11), R11")
+	w("\tMOVQ\t%d(AX), R10", offs.M)
+	w("\tMOVLQSX\tl0+%d(FP), CX", args["l0"])
+	w("\t%s\tl1+%d(FP), DI", movPtr, args["l1"])
+	w("\t%s\tl3+%d(FP), SI", movPtr, args["l3"])
+	w("\t%s\tl5+%d(FP), DX", movPtr, args["l5"])
+	w("\tLEAQ\t4(DI), R8")
+	w("\tCMPQ\tR11, R8")
+	w("\tJCS\tvdoob")
+	w("\tADDQ\tR10, DI")
+	for _, r := range []string{"Y0", "Y1", "Y2", "Y3", "Y12", "Y13"} {
+		w("\tVXORPS\t%s, %s, %s", r, r, r)
+	}
+	w("\tTESTQ\tCX, CX")
+	w("\tJLE\tvdreduce")
+	for _, reg := range []string{"SI", "DX"} {
+		w("\tLEAQ\t(%s)(CX*2), R8", reg)
+		w("\tCMPQ\tR11, R8")
+		w("\tJCS\tvdoob")
+	}
+	w("\tADDQ\tR10, SI")
+	w("\tADDQ\tR10, DX")
+	// step: `cnt` ymm (8 elements each) per iteration into Y0..Y(cnt-1).
+	step := func(lbl, next string, cnt int) {
+		w("%s:", lbl)
+		w("\tCMPQ\tCX, $%d", 8*cnt)
+		w("\tJLT\t%s", next)
+		for i := 0; i < cnt; i++ {
+			w("\tVCVTPH2PS\t%d(SI), Y%d", 16*i, 4+i)
+			w("\tVCVTPH2PS\t%d(DX), Y%d", 16*i, 8+i)
+			w("\tVFMADD231PS\tY%d, Y%d, Y%d", 8+i, 4+i, i)
+		}
+		w("\tADDQ\t$%d, SI", 16*cnt)
+		w("\tADDQ\t$%d, DX", 16*cnt)
+		w("\tSUBQ\t$%d, CX", 8*cnt)
+		w("\tJMP\t%s", lbl)
+	}
+	step("vdloop32", "vdloop16", 4)
+	step("vdloop16", "vdloop8", 2)
+	step("vdloop8", "vdtail4", 1)
+	w("vdtail4:")
+	w("\tCMPQ\tCX, $4")
+	w("\tJLT\tvdtail1")
+	w("\tVCVTPH2PS\t(SI), X4")
+	w("\tVCVTPH2PS\t(DX), X8")
+	w("\tVFMADD231PS\tX8, X4, X12")
+	w("\tADDQ\t$8, SI")
+	w("\tADDQ\t$8, DX")
+	w("\tSUBQ\t$4, CX")
+	w("\tJMP\tvdtail4")
+	w("vdtail1:")
+	w("\tTESTQ\tCX, CX")
+	w("\tJZ\tvdreduce")
+	w("\tMOVWLZX\t(SI), R8")
+	w("\tVMOVD\tR8, X4")
+	w("\tVCVTPH2PS\tX4, X4")
+	w("\tMOVWLZX\t(DX), R8")
+	w("\tVMOVD\tR8, X8")
+	w("\tVCVTPH2PS\tX8, X8")
+	w("\tVFMADD231SS\tX8, X4, X13")
+	w("\tADDQ\t$2, SI")
+	w("\tADDQ\t$2, DX")
+	w("\tDECQ\tCX")
+	w("\tJMP\tvdtail1")
+	w("vdreduce:")
+	w("\tVADDPS\tY1, Y0, Y0")
+	w("\tVADDPS\tY3, Y2, Y2")
+	w("\tVADDPS\tY2, Y0, Y0")
+	w("\tVEXTRACTF128\t$1, Y0, X1")
+	w("\tVADDPS\tX1, X0, X0")
+	w("\tVADDPS\tX12, X0, X0")
+	w("\tVHADDPS\tX0, X0, X0")
+	w("\tVHADDPS\tX0, X0, X0")
+	w("\tVADDSS\tX13, X0, X0")
+	w("\tVMOVSS\tX0, (DI)")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("vdoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}
+
+// x64VecMadF16F32Kernel emits y[i] += v * x[i] (y f32, x f16) under sym
+// for amd64: 32 elements per step, then 8-, 4-wide and scalar tails.
+// Bounds: y + 4n, x + 2n against memSize.
+func x64VecMadF16F32Kernel(sym, trapSym string, offs *ModuleOffsets, _ *ConstPool, wide bool) string {
+	var sb strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&sb, format+"\n", args...) }
+	args, argBytes := vecMadF16F32Args(wide)
+	movPtr := "MOVL"
+	if wide {
+		movPtr = "MOVQ"
+	}
+	w("// %s: y += v * x (x f16, y f32).", sym)
+	w("TEXT ·%s(SB), $16-%d", sym, argBytes)
+	w("\tNO_LOCAL_POINTERS")
+	w("\tMOVLQSX\tl0+%d(FP), CX", args["l0"])
+	w("\tTESTQ\tCX, CX")
+	w("\tJLE\tvmdone")
+	w("\tMOVQ\tm+0(FP), AX")
+	w("\tMOVQ\t%d(AX), R11", offs.MemSize)
+	w("\tMOVQ\t(R11), R11")
+	w("\tMOVQ\t%d(AX), R10", offs.M)
+	w("\t%s\tl1+%d(FP), DI", movPtr, args["l1"])
+	w("\t%s\tl2+%d(FP), SI", movPtr, args["l2"])
+	w("\tVBROADCASTSS\tl3+%d(FP), Y8", args["l3"])
+	w("\tLEAQ\t(DI)(CX*4), R8")
+	w("\tCMPQ\tR11, R8")
+	w("\tJCS\tvmoob")
+	w("\tLEAQ\t(SI)(CX*2), R8")
+	w("\tCMPQ\tR11, R8")
+	w("\tJCS\tvmoob")
+	w("\tADDQ\tR10, DI")
+	w("\tADDQ\tR10, SI")
+	step := func(lbl, next string, cnt int) {
+		w("%s:", lbl)
+		w("\tCMPQ\tCX, $%d", 8*cnt)
+		w("\tJLT\t%s", next)
+		for i := 0; i < cnt; i++ {
+			w("\tVCVTPH2PS\t%d(SI), Y%d", 16*i, 4+i)
+			w("\tVMOVUPS\t%d(DI), Y%d", 32*i, 12+i)
+			w("\tVFMADD231PS\tY8, Y%d, Y%d", 4+i, 12+i)
+			w("\tVMOVUPS\tY%d, %d(DI)", 12+i, 32*i)
+		}
+		w("\tADDQ\t$%d, SI", 16*cnt)
+		w("\tADDQ\t$%d, DI", 32*cnt)
+		w("\tSUBQ\t$%d, CX", 8*cnt)
+		w("\tJMP\t%s", lbl)
+	}
+	step("vmloop32", "vmloop8", 4)
+	step("vmloop8", "vmtail4", 1)
+	w("vmtail4:")
+	w("\tCMPQ\tCX, $4")
+	w("\tJLT\tvmtail1")
+	w("\tVCVTPH2PS\t(SI), X4")
+	w("\tVMOVUPS\t(DI), X12")
+	w("\tVFMADD231PS\tX8, X4, X12")
+	w("\tVMOVUPS\tX12, (DI)")
+	w("\tADDQ\t$8, SI")
+	w("\tADDQ\t$16, DI")
+	w("\tSUBQ\t$4, CX")
+	w("\tJMP\tvmtail4")
+	w("vmtail1:")
+	w("\tTESTQ\tCX, CX")
+	w("\tJZ\tvmdone")
+	w("\tMOVWLZX\t(SI), R8")
+	w("\tVMOVD\tR8, X4")
+	w("\tVCVTPH2PS\tX4, X4")
+	w("\tVMOVSS\t(DI), X12")
+	w("\tVFMADD231SS\tX8, X4, X12")
+	w("\tVMOVSS\tX12, (DI)")
+	w("\tADDQ\t$2, SI")
+	w("\tADDQ\t$4, DI")
+	w("\tDECQ\tCX")
+	w("\tJMP\tvmtail1")
+	w("vmdone:")
+	w("\tVZEROUPPER")
+	w("\tRET")
+	w("vmoob:")
+	w("\tVZEROUPPER")
+	w("\tCALL\t·%s(SB)", trapSym)
+	w("\tRET")
+	return sb.String()
+}

--- a/internal/lower/inline.go
+++ b/internal/lower/inline.go
@@ -105,13 +105,12 @@ func analyzeModuleForInline(mod *wasm.Module) *inlineAnalysis {
 	// Exported retarget anchors: pin them out-of-line so the gcasm
 	// backend's by-name kernel retarget lands on a live body. The
 	// engine names these dbg_* by convention.
-	// Only the batched GEMMs are pinned (the q8_0 repack tile and the
-	// f32 flash-attention micro-GEMM): the GEMV runs at nrows=1 in
-	// the decode hot path, where its per-call overhead outweighs the
-	// tile benefit, so it stays inlinable. The GEMM tiles earn their
-	// keep only when a caller batches four or more rows.
+	// Every dbg_ export is a retarget anchor (repack GEMM and GEMV, the
+	// f32 micro-GEMM, the vector exp kernels): each is replaced by a
+	// native kernel whose whole-loop efficiency dwarfs the call, so
+	// they all stay out of line.
 	for _, e := range mod.Exports {
-		if e.Kind == wasm.ExportFunc && (strings.HasPrefix(e.Name, "dbg_gemm_") || strings.HasPrefix(e.Name, "dbg_simd_gemm_") || strings.HasPrefix(e.Name, "dbg_vec_")) {
+		if e.Kind == wasm.ExportFunc && strings.HasPrefix(e.Name, "dbg_") {
 			if info, ok := a.fns[e.Index]; ok {
 				info.noInline = true
 			}

--- a/internal/lower/inline.go
+++ b/internal/lower/inline.go
@@ -111,7 +111,7 @@ func analyzeModuleForInline(mod *wasm.Module) *inlineAnalysis {
 	// tile benefit, so it stays inlinable. The GEMM tiles earn their
 	// keep only when a caller batches four or more rows.
 	for _, e := range mod.Exports {
-		if e.Kind == wasm.ExportFunc && (strings.HasPrefix(e.Name, "dbg_gemm_") || strings.HasPrefix(e.Name, "dbg_simd_gemm_")) {
+		if e.Kind == wasm.ExportFunc && (strings.HasPrefix(e.Name, "dbg_gemm_") || strings.HasPrefix(e.Name, "dbg_simd_gemm_") || strings.HasPrefix(e.Name, "dbg_vec_")) {
 			if info, ok := a.fns[e.Index]; ok {
 				info.noInline = true
 			}

--- a/internal/lower/inline.go
+++ b/internal/lower/inline.go
@@ -105,12 +105,13 @@ func analyzeModuleForInline(mod *wasm.Module) *inlineAnalysis {
 	// Exported retarget anchors: pin them out-of-line so the gcasm
 	// backend's by-name kernel retarget lands on a live body. The
 	// engine names these dbg_* by convention.
-	// Only the batched GEMM is pinned: the GEMV runs at nrows=1 in
+	// Only the batched GEMMs are pinned (the q8_0 repack tile and the
+	// f32 flash-attention micro-GEMM): the GEMV runs at nrows=1 in
 	// the decode hot path, where its per-call overhead outweighs the
-	// tile benefit, so it stays inlinable. The GEMM tile earns its
+	// tile benefit, so it stays inlinable. The GEMM tiles earn their
 	// keep only when a caller batches four or more rows.
 	for _, e := range mod.Exports {
-		if e.Kind == wasm.ExportFunc && strings.HasPrefix(e.Name, "dbg_gemm_") {
+		if e.Kind == wasm.ExportFunc && (strings.HasPrefix(e.Name, "dbg_gemm_") || strings.HasPrefix(e.Name, "dbg_simd_gemm_")) {
 			if info, ok := a.fns[e.Index]; ok {
 				info.noInline = true
 			}

--- a/internal/lower/inline_noinline_test.go
+++ b/internal/lower/inline_noinline_test.go
@@ -22,7 +22,7 @@ func TestExportedRetargetAnchorNotInlined(t *testing.T) {
 	if !a.fns[0].noInline {
 		t.Error("dbg_-exported function must be pinned noInline")
 	}
-	if a.fns[1].noInline {
-		t.Error("gemv (nrows=1 decode kernel) must stay inlinable")
+	if !a.fns[1].noInline {
+		t.Error("gemv is a retarget anchor too and must be pinned noInline")
 	}
 }


### PR DESCRIPTION
## Summary

The q8_0x4 repack GEMM is the prompt-processing hot loop (45% of pp on the amd64 CI runner, 31% on arm64 with the current tiles). Both tile kernels spent most of their issue slots on per-(group,row) glue rather than multiplies.

- **amd64 AVX2 nest**: the activation row group is widened ONCE per chunk into a 64 KiB stack scratch (16 bytes of four row quads → 32 bytes of i16), so the block loop is `VPBROADCASTQ` (a pure load) + `VPMADDWD` + `VPADDD` per (group,row) with one shared `VPMOVSXBW` per weight group; the per-block collapse becomes two `VPHADDD` + two `VPERM2I128` + two unpacks into `[row0|row2]` / `[row1|row3]` ymm halves that convert and scale as pairs. K beyond the scratch (8192 columns) runs as chunks that accumulate into the output rows in the same block order (identical f32 sums). The VNNI nest keeps its exact +128 bias identity and takes each row quad by `VPBROADCASTD`.
- **arm64**: an 8-rows × 4-columns SMMLA tile over two activation row groups halves the weight bytes streamed per MAC and replaces 64 by-element SDOTs per 1024 MACs with 32 SMMLAs. Weights stay in their 4x4 interleave (two consecutive groups `zip1`/`zip2 .4s` into the two B operands shared by all eight rows); activations are zipped once per chunk into the scratch. Row groups past the last pair, and CPUs without I8MM, run the existing 4x4 SDOT nest.
- **FEAT_I8MM gate**: `CPUI8MM` (HWCAP2_I8MM / `hw.optional.arm.FEAT_I8MM`) is detected apart from dotprod and mirrored as `gcasmCPUI8MM`. The existing 2x2 SMMLA vec_dot tile kernel was selected by the dotprod gate alone, which does not imply I8MM (Neoverse N1, Cortex-A76..X1, Apple M1): its retarget symbol is now a frameless stub that sends such CPUs back to the bit-exact Go companion.

Both nests keep the wasm gemm's per-element arithmetic (exact i32 sum → f32 → × (dcol·drow) → + running sum, in block order), so the batched and single-row paths stay as close as before.
- **Later commits on this branch**: fused-multiply-add f32 GEMM; native NEON/AVX2 exp kernels for the exported `ggml_vec_soft_max_f32` / `ggml_vec_swiglu_f32` (`dbg_vec_*`); a by-export retarget table; a 256-bit VNNI repack nest with the bias on the activation side; native q8_0x4 repack GEMV kernels (single sequential weight stream on arm64 — decode is DRAM-bound and one stream feeds the prefetchers best); a trimmed SMMLA block tail (the tail was 36% of the kernel measured with it removed). Every `dbg_` export is pinned out of line.
- **Also fixed**: the f16 gather rewrite left a forward reference in fused trees (`undefined: n6` in the pure twin) once the idiom appeared everywhere.

### Later commits on this branch

- **One fused scale sequence across the arm64 kernels** (416610e): the trimmed SMMLA tail had fused the row scale while the SDOT nest and the GEMV still did mul-mul-add, so a row rounded differently depending on the kernel it landed in; go-llama's ScoreChoices tests (same tokens scored in different batch shapes) caught it. All three arm64 kernels now use the same sequence, and the full go-llama suite passes on the rebuilt bundle.
- **256-bit VNNI repack GEMV** (bb09eea): two k-quads per VPDPBUSD with the prepared activation pair as the memory operand, two accumulator chains per column group. Verified on an Intel Xeon 6973P-C runner (real AVX-512 VNNI): decode 27.4 tok/s vs native 28.2 (0.97); the 256-bit VNNI GEMM nest lifts prompt processing there from ~97 (AVX2 arm) to 134 tok/s, but native llama.cpp uses AMX on that CPU (495 tok/s), which is a separate follow-up. Most "EPYC 9V74" GitHub runners mask AVX-512 from user-mode CPUID/XCR0 and run the AVX2 arm (native is AVX2-only there too).
- **Native f16 dot / f16 multiply-add for the decode attention path** (d0eb518): `dbg_vec_dot_f16` / `dbg_vec_mad_f16_f32` retargets (FCVTL / VCVTPH2PS + FMA). At 1200 tokens of context, decode on an Apple M5 goes from 47 to 90 tok/s; the zero-context number is unchanged.

### Accuracy

wikitext-2 perplexity with llama-perplexity's protocol (512-token chunks, second half scored, 40 chunks; and 2048-token chunks, 8 chunks), qwen2.5-0.5b q8_0, replicated in go-llama. Native is llama.cpp built from the same commit llama-wasm pins (b10223), arm64 NEON:

| engine | c512 batched | c512 token-by-token | c2048 batched | c2048 token-by-token |
|---|---:|---:|---:|---:|
| native llama.cpp, same commit | 14.2517 | 14.2573 | 11.9125 | 11.9013 |
| v0.3.2 engine | 14.2605 | 14.4324 | 11.9271 | 12.1126 |
| this branch | 14.2553 | 14.2543 | 11.9295 | 11.9247 |

The branch sits within 0.03% (c512) / 0.2% (c2048) of same-commit native on both decode paths (token-by-token at c512 it is marginally below native). The v0.3.2 token-by-token path was 1.2% (c512) / 1.8% (c2048) worse than native (its truncating activation quantizer and table-based f16 attention); this branch closes that. (A newer Homebrew llama.cpp, b10520, scores 14.2095 / 11.8945 — a llama.cpp version difference, not an engine one.)

## Measurements

go-llama same-runner benchmark against native llama.cpp (qwen2.5-0.5b q8_0, 1 thread), bundle built from goccy/llama-wasm#19 with this branch (go-llama run 33736659559):

| runner | metric | native | go-llama | ratio | before (v0.3.2 engine) |
|---|---|---:|---:|---:|---:|
| amd64 EPYC 7763 | pp | 91.1 | **96.9** | **1.06** | 34.4 (0.38) |
| amd64 EPYC 7763 | tg | 27.7 | **30.9** | **1.12** | 21.1 (0.72) |
| arm64 Neoverse-N2 | pp | 86.1 | **115.2** | **1.34** | 54.4 (0.63) |
| arm64 Neoverse-N2 | tg | 36.3 | 32.6 | 0.90 | 26.7 (0.72) |

Greedy text identical on both runners; teacher-forced NLL of the new engine matches the old within ±0.005 nat and is identical across physical batch sizes 4 and 1. Local Apple M5 (arm64 native): pp 130 → 292 tok/s, tg 105 → 117.

What each commit bought (M5 pp unless noted): repack GEMM tiles + SIMD quantizer 130 → 163; flash-attention widening + f32 GEMM retarget → 219; fused f32 GEMM + native soft_max/swiglu → 260; native GEMV → 272 (CI tg amd64 22.5 → 30.9, N2 28.3 → 32.6); fused SMMLA tail → 292.

## Tests

- `TestRepackGemmKernelShape`, `TestA64RepackGemmKernelGate` (SDOT-only and SMMLA arms, nr=12 = pair + tail group, n=64 and n=32·300 across the chunk boundary), `TestX64RepackGemmKernelGate` (AVX2 and VNNI arms; executes on the amd64 runner).
- `make lint`, `go test ./internal/gcasm/ ./internal/codegen/` green locally (arm64 execution native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)








