### PR TITLE
spin guard: yield on every cold call when agents outnumber processors

### DIFF
--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -1594,11 +1594,40 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 // aggregate spin time — rare on an uncontended box, automatically
 // more frequent when oversubscription makes the spins long.
 //
+// When the instance runs more agents than the scheduler has processors
+// (spinAgents, maintained by threadLaunch, against GOMAXPROCS), a spinner
+// holds a processor that a runnable agent needs: every cold call yields
+// then. A barrier the guest spins on is only released once every agent
+// has arrived, and the arriving agents are exactly the ones waiting for
+// a processor, so the 1/64 rate turns each barrier into milliseconds of
+// scheduling latency (measured: n_threads twice the core count, decode
+// fell to 1/100 of the single-thread rate). Native ggml with an OpenMP
+// barrier degrades gracefully in the same setting; this is its
+// equivalent. The check is one atomic load: spinOversubscribed is
+// recomputed by threadLaunch (and agent exit) from the gauge and
+// GOMAXPROCS, because runtime.GOMAXPROCS takes sched.lock and eight
+// spinners asking it at cold-call rate measured a 3% decode loss on an
+// uncontended box.
+//
 //go:noinline
 func spinRelax() {
-	if atomic.AddUint32(&spinRelaxColdCalls, 1)&63 == 0 {
+	n := atomic.AddUint32(&spinRelaxColdCalls, 1)
+	if n&63 == 0 || atomic.LoadUint32(&spinOversubscribed) != 0 {
 		runtime.Gosched()
 	}
+}
+
+// spinAgentsAdd moves the live spawned-agent gauge by delta and
+// refreshes spinOversubscribed: the spawner itself is the extra
+// goroutine, so the instance is oversubscribed once the spawned agents
+// alone reach GOMAXPROCS.
+func spinAgentsAdd(delta int32) {
+	agents := atomic.AddInt32(&spinAgents, delta)
+	var over uint32
+	if int(agents) >= runtime.GOMAXPROCS(0) {
+		over = 1
+	}
+	atomic.StoreUint32(&spinOversubscribed, over)
 }
 
 // ----- wasm32 atomic helpers (named by the lowering) -----------------------
@@ -2456,8 +2485,10 @@ func threadLaunch(m *Module, body func(child *Module, tid int32)) int32 {
 	// malloc'ed inside the shared memory.
 	child := new(Module)
 	*child = *m
+	spinAgentsAdd(1)
 	go func() {
 		defer m.threads.wg.Done()
+		defer spinAgentsAdd(-1)
 		// A trap on any wasm thread traps the whole instance (wasi-threads
 		// semantics): surface WHERE it happened, then let it take the
 		// process down instead of silently unwinding the goroutine.

--- a/internal/codegen/helpers/helpers.go
+++ b/internal/codegen/helpers/helpers.go
@@ -1590,9 +1590,16 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 // every cold call still measured double-digit scheduler churn
 // (pthread_cond_signal — wakep — at 30% of the profile) on
 // barrier-heavy workloads, where waiting IS most of a worker's time.
-// One yield per 64 cold calls keeps donation proportional to
-// aggregate spin time — rare on an uncontended box, automatically
-// more frequent when oversubscription makes the spins long.
+// One yield per 64 cold calls kept donation proportional to aggregate
+// spin time, but on an uncontended box every yield still wakes an
+// idle scheduler thread (wakep -> pthread_cond_signal) that spins in
+// findRunnable and parks again: at n_threads = 4 on a 10-core host that
+// churn was 60% of the CPU samples of a decode step, and on a 4-core
+// host it takes cores from the workers themselves. With every agent on
+// its own processor there is nobody to donate the core to, so the
+// uncontended rate is now one yield per 1024 cold calls (tens of
+// milliseconds of spinning, sysmon's own preemption granularity, kept
+// for host goroutines); oversubscription yields on every cold call.
 //
 // When the instance runs more agents than the scheduler has processors
 // (spinAgents, maintained by threadLaunch, against GOMAXPROCS), a spinner
@@ -1612,7 +1619,7 @@ func atomicRmwCmpxchg64_32uAt(m *Module, ea uint64, expected, replacement int64)
 //go:noinline
 func spinRelax() {
 	n := atomic.AddUint32(&spinRelaxColdCalls, 1)
-	if n&63 == 0 || atomic.LoadUint32(&spinOversubscribed) != 0 {
+	if atomic.LoadUint32(&spinOversubscribed) != 0 || n&1023 == 0 {
 		runtime.Gosched()
 	}
 }

--- a/internal/codegen/helpers/helpers_spinrelax_test.go
+++ b/internal/codegen/helpers/helpers_spinrelax_test.go
@@ -1,6 +1,10 @@
 package helpers
 
-import "testing"
+import (
+	"runtime"
+	"sync/atomic"
+	"testing"
+)
 
 // TestSpinRelax exercises the cold half of the spin-loop preemption
 // guard: reaching runtime.Gosched must never block the caller, only
@@ -8,5 +12,30 @@ import "testing"
 func TestSpinRelax(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		spinRelax()
+	}
+}
+
+// TestSpinRelaxOversubscribed: with more live agents than processors
+// every cold call yields (the barrier-latency fix); the call still
+// returns promptly and leaves the gauge untouched.
+func TestSpinRelaxOversubscribed(t *testing.T) {
+	procs := int32(runtime.GOMAXPROCS(0))
+	spinAgentsAdd(procs - 1)
+	if atomic.LoadUint32(&spinOversubscribed) != 0 {
+		t.Fatalf("%d agents on %d procs flagged as oversubscribed", procs-1, procs)
+	}
+	spinAgentsAdd(1)
+	if atomic.LoadUint32(&spinOversubscribed) == 0 {
+		t.Fatalf("%d agents on %d procs not flagged", procs, procs)
+	}
+	for i := 0; i < 64; i++ {
+		spinRelax()
+	}
+	spinAgentsAdd(-procs)
+	if got := atomic.LoadInt32(&spinAgents); got != 0 {
+		t.Errorf("spinAgents = %d after every agent left", got)
+	}
+	if atomic.LoadUint32(&spinOversubscribed) != 0 {
+		t.Error("still flagged with no agents")
 	}
 }

--- a/internal/codegen/helpers/spinrelax_state.go
+++ b/internal/codegen/helpers/spinrelax_state.go
@@ -6,3 +6,10 @@ package helpers
 // output; there the generated base package supplies the counter from
 // the template, so the two declarations never meet.
 var spinRelaxColdCalls uint32
+
+// spinAgents mirrors the runtime template's live spawned-agent gauge
+// (threadLaunch maintains it, spinRelax reads it), for the same reason.
+var spinAgents int32
+
+// spinOversubscribed mirrors the template's flag derived from spinAgents.
+var spinOversubscribed uint32

--- a/internal/codegen/spinguard_test.go
+++ b/internal/codegen/spinguard_test.go
@@ -57,6 +57,11 @@ func TestSpinGuardInjection(t *testing.T) {
 	if !strings.Contains(all, "func spinRelax(") {
 		t.Error("spinRelax helper source not included")
 	}
+	// The guard's oversubscription gauge is package state the helper
+	// extraction cannot carry: the runtime template must declare it.
+	if !strings.Contains(all, "var spinAgents int32") || !strings.Contains(all, "var spinOversubscribed uint32") {
+		t.Error("spinAgents gauge / spinOversubscribed flag not declared alongside spinRelax")
+	}
 }
 
 // TestSpinGuardRuns compiles and runs the guarded output: the wait

--- a/internal/codegen/translate.go
+++ b/internal/codegen/translate.go
@@ -3668,6 +3668,24 @@ func (t *translator) emitHelpers() ([]ast.Decl, error) {
 			}},
 		})
 	}
+	// spinAgents is shared between threadLaunch (any memory-bearing module
+	// carries the threads helpers) and spinRelax: the live spawned-agent
+	// gauge the guard compares with GOMAXPROCS.
+	if t.helpers["spinRelax"] || len(t.mod.Memories) > 0 {
+		out = append(out, &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{&ast.ValueSpec{
+				Names: []*ast.Ident{newID("spinAgents")},
+				Type:  newID("int32"),
+			}},
+		}, &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{&ast.ValueSpec{
+				Names: []*ast.Ident{newID("spinOversubscribed")},
+				Type:  newID("uint32"),
+			}},
+		})
+	}
 	// The wasmExc type is not a FuncDecl, so pull it in explicitly whenever the
 	// module throws or catches. In multi-package mode the type lives in base and
 	// must be exported (WasmExc) so chunk packages can name it; single-package


### PR DESCRIPTION
## Summary

A wasm thread is a goroutine, and the spin guard's cold call (`spinRelax`) yielded its processor once per 64 calls. That rate keeps stop-the-world pauses bounded and is cheap when every agent has a processor of its own, but it is the wrong rate once an instance runs more agents than `GOMAXPROCS`: a barrier the guest spins on releases only when every agent has arrived, the missing agents are exactly the ones waiting for a processor, and the spinners hold those processors for milliseconds between yields.

Measured with go-llama on a 4-core GitHub runner: 8 ggml threads decoded at 1/100 of the single-thread rate (0.2 tok/s), while native ggml with an OpenMP barrier keeps ~90% of its 4-thread throughput in the same setting.

## Change

- `threadLaunch` maintains a live spawned-agent gauge (`spinAgents`) and derives `spinOversubscribed` (agents >= `GOMAXPROCS`; the spawner itself is the extra goroutine) at agent launch and exit. The derivation happens there, not in the hot path: `runtime.GOMAXPROCS` takes `sched.lock`, and calling it per cold call measured a 3% decode loss at 8 threads on an uncontended box.
- `spinRelax` yields on every cold call while the flag is set. Below that it now yields only once per 1024 cold calls (tens of milliseconds of spinning): a decode profile at `n_threads = 4` on a 10-core host showed 60% of the CPU samples in scheduler churn caused by the old 1/64 yields (`wakep` -> `pthread_cond_signal`, the woken thread spinning in `findRunnable` and parking again), and on a 4-core host that churn takes cores from the workers. With every agent on its own processor there is nobody to donate the core to; the rare yield keeps host goroutines' fairness at sysmon's own granularity.
- The runtime template declares both variables alongside `spinRelaxColdCalls`; `spinrelax_state.go` mirrors them for the helpers package.

## Measurements

Qwen2.5-0.5B Q8_0 on a 10-core M-series host, tok/s (old -> new):

| threads | decode | prompt (pp512) |
|--:|--:|--:|
| 1 | 129 -> 130 | — |
| 8 | 187 -> 187 | 1389 -> 1373 |

The rare-yield rate measures neutral on the 10-core host at 2, 4, 8, 12 and 16 threads (within run-to-run noise); the 4-core CI runners, where the churn cost worker time (decode 0.76-0.88 of native at 4 threads), are its target.
| 12 | 8.3 -> 87 | 1064 -> 1475 |
| 16 | 3.4 -> 51 | 749 -> 1441 |
| 32 | 0.5 -> 26 | 220 -> 1312 |

## Tests

- `TestSpinGuardInjection` checks the gauge and flag are declared with the helper.
- `TestSpinRelaxOversubscribed` exercises the flag transitions through `spinAgentsAdd` and the yielding path.
- `go test ./...` and `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
