### PR TITLE
gcasm: arm64 "fhm" override feature level (FEAT_FHM, FMLAL/FMLSL)

### DIFF
--- a/internal/codegen/helpers/cpufeat_arm64_darwin.go
+++ b/internal/codegen/helpers/cpufeat_arm64_darwin.go
@@ -13,12 +13,20 @@ var CPUDotProd = detectDotProd()
 // why it is detected apart from CPUDotProd.
 var CPUI8MM = detectI8MM()
 
+// CPUFHM reports FEAT_FHM (FMLAL/FMLSL: f16 products accumulated in
+// f32). Bodies that keep f16 operands unwidened dispatch on it.
+var CPUFHM = detectFHM()
+
 func detectDotProd() bool {
 	return sysctlFeature("hw.optional.arm.FEAT_DotProd")
 }
 
 func detectI8MM() bool {
 	return sysctlFeature("hw.optional.arm.FEAT_I8MM")
+}
+
+func detectFHM() bool {
+	return sysctlFeature("hw.optional.arm.FEAT_FHM")
 }
 
 func sysctlFeature(name string) bool {

--- a/internal/codegen/helpers/cpufeat_arm64_linux.go
+++ b/internal/codegen/helpers/cpufeat_arm64_linux.go
@@ -19,6 +19,10 @@ var CPUDotProd = detectDotProd()
 // M1), so the two are detected separately.
 var CPUI8MM = detectI8MM()
 
+// CPUFHM reports FEAT_FHM (FMLAL/FMLSL: f16 products accumulated in
+// f32). Bodies that keep f16 operands unwidened dispatch on it.
+var CPUFHM = detectFHM()
+
 func detectDotProd() bool {
 	// AT_HWCAP (16), HWCAP_ASIMDDP (bit 20).
 	return auxvBit(16, 20)
@@ -27,6 +31,11 @@ func detectDotProd() bool {
 func detectI8MM() bool {
 	// AT_HWCAP2 (26), HWCAP2_I8MM (bit 13).
 	return auxvBit(26, 13)
+}
+
+func detectFHM() bool {
+	// AT_HWCAP (16), HWCAP_ASIMDFHM (bit 23).
+	return auxvBit(16, 23)
 }
 
 // auxvBit reports bit `bit` of the auxiliary-vector entry `key`:

--- a/internal/codegen/helpers/cpufeat_arm64_other.go
+++ b/internal/codegen/helpers/cpufeat_arm64_other.go
@@ -2,7 +2,8 @@
 
 package helpers
 
-// CPUDotProd / CPUI8MM: no detection story on this OS — run the
-// portable bodies.
+// CPUDotProd / CPUI8MM / CPUFHM: no detection story on this OS — run
+// the portable bodies.
 var CPUDotProd = false
 var CPUI8MM = false
+var CPUFHM = false

--- a/internal/gcasm/asmoverride.go
+++ b/internal/gcasm/asmoverride.go
@@ -78,11 +78,15 @@ type AsmOverrideBody struct {
 // may declare, most specific first. The first entry of each list that
 // the running CPU supports wins; the baseline entry (last) needs no
 // check. The mirror names are the base package's CPU feature vars.
+// The arm64 levels are independent features (FEAT_FHM, FEAT_I8MM,
+// FEAT_DotProd), not a ladder: a body is only chosen when its own
+// feature is present, the order just decides which of several present
+// bodies runs.
 var overrideFeatureLevels = map[string][]struct {
 	name       string
 	featureVar string // "" for the architecture baseline
 }{
-	"arm64": {{"i8mm", "CPUI8MM"}, {"dotprod", "CPUDotProd"}, {"neon", ""}},
+	"arm64": {{"fhm", "CPUFHM"}, {"i8mm", "CPUI8MM"}, {"dotprod", "CPUDotProd"}, {"neon", ""}},
 	"amd64": {{"avx512vnni", "HasAVX512VNNI"}, {"avx2", "HasAVX2"}, {"sse4", ""}},
 }
 

--- a/internal/gcasm/asmoverride_test.go
+++ b/internal/gcasm/asmoverride_test.go
@@ -54,10 +54,11 @@ func TestLoadAsmOverrides(t *testing.T) {
     "bodies": [
       {"arch": "arm64", "feature": "neon", "frame": 0, "file": "dot_neon.s"},
       {"arch": "arm64", "feature": "i8mm", "frame": 16, "file": "dot_i8mm.s"},
+      {"arch": "arm64", "feature": "fhm", "frame": 16, "file": "dot_fhm.s"},
       {"arch": "amd64", "feature": "avx2", "frame": 8, "file": "dot_avx2.s"}
     ]
   }]
-}`, map[string]string{"dot_neon.s": ovrGoodBody, "dot_i8mm.s": ovrGoodBody, "dot_avx2.s": "\tRET\n"})
+}`, map[string]string{"dot_neon.s": ovrGoodBody, "dot_i8mm.s": ovrGoodBody, "dot_fhm.s": ovrGoodBody, "dot_avx2.s": "\tRET\n"})
 	ovr, err := LoadAsmOverrides(p, ovrModule(true))
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +68,7 @@ func TestLoadAsmOverrides(t *testing.T) {
 		t.Fatalf("function = %+v", ov)
 	}
 	// Bodies sorted most specific first, baseline last.
-	if got := []string{ov.Bodies["arm64"][0].Feature, ov.Bodies["arm64"][1].Feature}; got[0] != "i8mm" || got[1] != "neon" {
+	if got := []string{ov.Bodies["arm64"][0].Feature, ov.Bodies["arm64"][1].Feature, ov.Bodies["arm64"][2].Feature}; got[0] != "fhm" || got[1] != "i8mm" || got[2] != "neon" {
 		t.Fatalf("arm64 body order = %v", got)
 	}
 	if len(ov.Bodies["amd64"]) != 1 || ov.Bodies["amd64"][0].Frame != 8 {


### PR DESCRIPTION
## Summary

Assembly overrides can declare an arm64 body for FEAT_FHM, the f16-product / f32-accumulate multiply-adds (FMLAL, FMLAL2 and their by-element forms), as feature level `"fhm"`.

- The base package detects it as `CPUFHM`: `hw.optional.arm.FEAT_FHM` on darwin, `HWCAP_ASIMDFHM` (AT_HWCAP bit 23) on linux, false elsewhere.
- The dispatch ladder checks it first. The arm64 levels are independent features (FEAT_FHM, FEAT_I8MM, FEAT_DotProd) rather than a ladder: a body is only chosen when its own feature is present, the order only decides which of several present bodies runs. The comment on `overrideFeatureLevels` now says so.

First user: llama-wasm's flash-attention body (blocked positions, FMLAL K.Q, f16 V accumulation), which took the deep-context decode from 0.87 to 1.25 of native on an M-series host.

## Tests

`TestAsmOverrideManifest` gains an `fhm` body and checks the ordering; `go test ./...` and `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
